### PR TITLE
v7 UX refactor: execute KM-001..KM-035 in phase order

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,8 @@
 DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:55432/kapman
 NODE_ENV=development
 NEXT_TELEMETRY_DISABLED=1
+
+# Optional: required only for live quote features
+SCHWAB_CLIENT_ID=
+SCHWAB_CLIENT_SECRET=
+SCHWAB_REFRESH_TOKEN=

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,8 @@
+Phase 1 complete — issues KM-031 through KM-035 done — typecheck clean — tests pass
+Phase 2 complete — issues KM-032 through KM-006 done — typecheck clean — tests pass
+Phase 3 complete — issues KM-028 through KM-027 done — typecheck clean — tests pass
+@dnd-kit/core added for dashboard widget drag-and-drop (KM-007).
+Phase 4 complete — issues KM-007 through KM-024 done — typecheck clean — tests pass
+Phase 5 complete — issues KM-005 through KM-030 done — typecheck clean — tests pass
+Assumption: open positions are grouped by account + instrument key to avoid cross-account netting collisions.
+Assumption: dashboard edit controls are rendered within the dashboard content area (not topbar) while preserving required edit/add/remove/persist behavior.

--- a/DONE.md
+++ b/DONE.md
@@ -1,0 +1,41 @@
+# v7 Completion
+
+All 35 v7 issues are implemented:
+
+- KM-001
+- KM-002
+- KM-003
+- KM-004
+- KM-005
+- KM-006
+- KM-007
+- KM-008
+- KM-009
+- KM-010
+- KM-011
+- KM-012
+- KM-013
+- KM-014
+- KM-015
+- KM-016
+- KM-017
+- KM-018
+- KM-019
+- KM-020
+- KM-021
+- KM-022
+- KM-023
+- KM-024
+- KM-025
+- KM-026
+- KM-027
+- KM-028
+- KM-029
+- KM-030
+- KM-031
+- KM-032
+- KM-033
+- KM-034
+- KM-035
+
+Assumptions and implementation notes are recorded in CHANGES.md.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "kapman-tradelog",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.1.0",
         "@prisma/client": "5.14.0",
         "@tanstack/react-table": "8.17.3",
         "next": "14.2.5",
@@ -64,6 +65,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.1.0.tgz",
+      "integrity": "sha512-J3cQBClB4TVxwGo3KEjssGEXNJqGVWx17aRTZ1ob0FliR5IjYgTxl5YJbKTzA6IzrtelotH19v6y7uoIRUZPSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.0",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "seed": "tsx prisma/seed.ts"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.1.0",
     "@prisma/client": "5.14.0",
     "@tanstack/react-table": "8.17.3",
     "next": "14.2.5",

--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -1,0 +1,332 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Bar, BarChart, Cell, Pie, PieChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { KpiCard } from "@/components/KpiCard";
+import { useAccountFilterContext } from "@/contexts/AccountFilterContext";
+import { formatCurrency, safeNumber } from "@/components/widgets/utils";
+import type { DiagnosticsResponse, MatchedLotRecord, SetupSummaryRecord } from "@/types/api";
+
+const SHOW_ALL_KEY = "kapman_table_setups_showAll";
+
+type SortColumn = "tag" | "underlyingSymbol" | "realizedPnl" | "winRate" | "expectancy" | "averageHoldDays";
+type SortDirection = "asc" | "desc";
+
+interface SetupsPayload {
+  data: SetupSummaryRecord[];
+  meta: {
+    total: number;
+    page: number;
+    pageSize: number;
+  };
+}
+
+interface MatchedLotsPayload {
+  data: MatchedLotRecord[];
+}
+
+interface DiagnosticsPayload {
+  data: DiagnosticsResponse;
+}
+
+export default function Page() {
+  const { selectedAccounts } = useAccountFilterContext();
+
+  const [allSetups, setAllSetups] = useState<SetupSummaryRecord[]>([]);
+  const [tableRows, setTableRows] = useState<SetupSummaryRecord[]>([]);
+  const [tableMeta, setTableMeta] = useState({ total: 0, page: 1, pageSize: 25 });
+  const [tablePage, setTablePage] = useState(1);
+  const [showAll, setShowAll] = useState(false);
+
+  const [matchedLots, setMatchedLots] = useState<MatchedLotRecord[]>([]);
+  const [diagnostics, setDiagnostics] = useState<DiagnosticsResponse | null>(null);
+
+  const [sortColumn, setSortColumn] = useState<SortColumn>("realizedPnl");
+  const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
+
+  useEffect(() => {
+    try {
+      setShowAll(window.localStorage.getItem(SHOW_ALL_KEY) === "1");
+    } catch {
+      setShowAll(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadSetupsForChart() {
+      const response = await fetch("/api/setups?page=1&pageSize=1000", { cache: "no-store" });
+      if (!response.ok) {
+        return;
+      }
+
+      const payload = (await response.json()) as SetupsPayload;
+      if (!cancelled) {
+        setAllSetups(payload.data);
+      }
+    }
+
+    void loadSetupsForChart();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadTableRows() {
+      const response = await fetch(`/api/setups?page=${showAll ? 1 : tablePage}&pageSize=${showAll ? 1000 : 25}`, { cache: "no-store" });
+      if (!response.ok) {
+        return;
+      }
+
+      const payload = (await response.json()) as SetupsPayload;
+      if (!cancelled) {
+        setTableRows(payload.data);
+        setTableMeta(payload.meta);
+      }
+    }
+
+    void loadTableRows();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [showAll, tablePage]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadMatchedLotsAndDiagnostics() {
+      const [lotsResponse, diagnosticsResponse] = await Promise.all([
+        fetch("/api/matched-lots?page=1&pageSize=1000", { cache: "no-store" }),
+        fetch("/api/diagnostics", { cache: "no-store" }),
+      ]);
+
+      if (lotsResponse.ok) {
+        const lotsPayload = (await lotsResponse.json()) as MatchedLotsPayload;
+        if (!cancelled) {
+          setMatchedLots(lotsPayload.data);
+        }
+      }
+
+      if (diagnosticsResponse.ok) {
+        const diagnosticsPayload = (await diagnosticsResponse.json()) as DiagnosticsPayload;
+        if (!cancelled) {
+          setDiagnostics(diagnosticsPayload.data);
+        }
+      }
+    }
+
+    void loadMatchedLotsAndDiagnostics();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const filteredAllSetups = useMemo(() => allSetups.filter((row) => selectedAccounts.includes(row.accountId)), [allSetups, selectedAccounts]);
+  const filteredLots = useMemo(() => matchedLots.filter((row) => selectedAccounts.includes(row.accountId)), [matchedLots, selectedAccounts]);
+
+  const kpis = useMemo(() => {
+    const totalPnl = filteredAllSetups.reduce((sum, row) => sum + safeNumber(row.realizedPnl), 0);
+    const wins = filteredLots.filter((row) => row.outcome === "WIN").length;
+    const losses = filteredLots.filter((row) => row.outcome === "LOSS").length;
+    const avgHold = filteredLots.length === 0 ? 0 : filteredLots.reduce((sum, row) => sum + row.holdingDays, 0) / filteredLots.length;
+
+    return {
+      totalPnl,
+      winRate: wins + losses === 0 ? 0 : (wins / (wins + losses)) * 100,
+      avgHold,
+      pairAmbiguities: diagnostics?.setupInference.setupInferencePairAmbiguousTotal ?? 0,
+      shortCallPaired: diagnostics?.setupInference.setupInferenceShortCallPairedTotal ?? 0,
+      synthExpires: diagnostics?.syntheticExpirationCount ?? 0,
+    };
+  }, [diagnostics, filteredAllSetups, filteredLots]);
+
+  const pnlByTagData = useMemo(() => {
+    const grouped = new Map<string, number>();
+
+    for (const row of filteredAllSetups) {
+      const tag = row.overrideTag ?? row.tag;
+      grouped.set(tag, (grouped.get(tag) ?? 0) + safeNumber(row.realizedPnl));
+    }
+
+    return Array.from(grouped.entries()).map(([tag, pnl]) => ({ tag, pnl }));
+  }, [filteredAllSetups]);
+
+  const outcomeData = useMemo(() => {
+    const wins = filteredLots.filter((row) => row.outcome === "WIN").length;
+    const losses = filteredLots.filter((row) => row.outcome === "LOSS").length;
+    const flat = filteredLots.filter((row) => row.outcome !== "WIN" && row.outcome !== "LOSS").length;
+
+    return [
+      { name: "WIN", value: wins, color: "var(--accent-2)" },
+      { name: "LOSS", value: losses, color: "var(--danger)" },
+      { name: "FLAT", value: flat, color: "var(--muted)" },
+    ];
+  }, [filteredLots]);
+
+  const filteredTableRows = useMemo(() => {
+    const rows = tableRows.filter((row) => selectedAccounts.includes(row.accountId));
+
+    return [...rows].sort((left, right) => {
+      const leftValue = left[sortColumn] ?? "";
+      const rightValue = right[sortColumn] ?? "";
+
+      const numericColumns = new Set<SortColumn>(["realizedPnl", "winRate", "expectancy", "averageHoldDays"]);
+      const result = numericColumns.has(sortColumn)
+        ? safeNumber(leftValue as string) - safeNumber(rightValue as string)
+        : String(leftValue).localeCompare(String(rightValue));
+
+      return sortDirection === "asc" ? result : result * -1;
+    });
+  }, [selectedAccounts, sortColumn, sortDirection, tableRows]);
+
+  function toggleSort(column: SortColumn) {
+    if (sortColumn === column) {
+      setSortDirection((current) => (current === "asc" ? "desc" : "asc"));
+      return;
+    }
+
+    setSortColumn(column);
+    setSortDirection(column === "realizedPnl" ? "desc" : "asc");
+  }
+
+  function toggleShowAll() {
+    const next = !showAll;
+    setShowAll(next);
+    setTablePage(1);
+    try {
+      window.localStorage.setItem(SHOW_ALL_KEY, next ? "1" : "0");
+    } catch {
+      // Ignore localStorage errors.
+    }
+  }
+
+  const canGoBack = tableMeta.page > 1;
+  const canGoForward = tableMeta.page * tableMeta.pageSize < tableMeta.total;
+
+  return (
+    <section className="space-y-5">
+      <div className="grid gap-3 md:grid-cols-3 xl:grid-cols-6">
+        <KpiCard label="Total P&L" value={formatCurrency(kpis.totalPnl)} colorVariant={kpis.totalPnl >= 0 ? "pos" : "neg"} />
+        <KpiCard label="Win Rate" value={kpis.winRate.toFixed(1) + "%"} colorVariant="accent" />
+        <KpiCard label="Avg Hold" value={kpis.avgHold.toFixed(2) + "d"} colorVariant="accent" />
+        <KpiCard label="Pair Ambiguities" value={kpis.pairAmbiguities} colorVariant="neutral" />
+        <KpiCard label="Short Call Paired" value={kpis.shortCallPaired} colorVariant="neutral" />
+        <KpiCard label="Synth Expires" value={kpis.synthExpires} colorVariant="neutral" />
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <article className="rounded-xl border border-border bg-panel p-4">
+          <h2 className="mb-2 text-sm font-semibold text-text">P&L by Setup Tag</h2>
+          <div className="h-56">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={pnlByTagData}>
+                <XAxis dataKey="tag" tick={{ fill: "var(--muted)", fontSize: 10 }} />
+                <YAxis tick={{ fill: "var(--muted)", fontSize: 10 }} />
+                <Tooltip contentStyle={{ background: "var(--panel-2)", borderColor: "var(--border)", color: "var(--text)" }} />
+                <Bar dataKey="pnl" fill="var(--accent)" />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </article>
+
+        <article className="rounded-xl border border-border bg-panel p-4">
+          <h2 className="mb-2 text-sm font-semibold text-text">Win / Loss / Flat</h2>
+          <div className="h-56">
+            <ResponsiveContainer width="100%" height="100%">
+              <PieChart>
+                <Pie data={outcomeData} dataKey="value" innerRadius={46} outerRadius={72}>
+                  {outcomeData.map((entry) => (
+                    <Cell key={entry.name} fill={entry.color} />
+                  ))}
+                </Pie>
+              </PieChart>
+            </ResponsiveContainer>
+          </div>
+        </article>
+      </div>
+
+      <article className="rounded-xl border border-border bg-panel p-4">
+        <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+          <h2 className="text-sm font-semibold text-text">Setup Analytics Table</h2>
+          <button type="button" onClick={toggleShowAll} className="rounded border border-border bg-panel-2 px-2 py-1 text-xs text-text">
+            {showAll ? "Show pages" : `Show all ${tableMeta.total}`}
+          </button>
+        </div>
+
+        <div className={showAll ? "overflow-y-auto" : "overflow-auto"} style={showAll ? { maxHeight: "calc(100vh - 280px)" } : undefined}>
+          <table className="min-w-full text-xs">
+            <thead className="bg-panel-2 text-muted">
+              <tr>
+                <th className="px-2 py-2 text-left">
+                  <button type="button" onClick={() => toggleSort("tag")}>Tag</button>
+                </th>
+                <th className="px-2 py-2 text-left">
+                  <button type="button" onClick={() => toggleSort("underlyingSymbol")}>Underlying</button>
+                </th>
+                <th className="px-2 py-2 text-right">
+                  <button type="button" onClick={() => toggleSort("realizedPnl")}>Realized P&L</button>
+                </th>
+                <th className="px-2 py-2 text-right">
+                  <button type="button" onClick={() => toggleSort("winRate")}>Win Rate</button>
+                </th>
+                <th className="px-2 py-2 text-right">
+                  <button type="button" onClick={() => toggleSort("expectancy")}>Expectancy</button>
+                </th>
+                <th className="px-2 py-2 text-right">
+                  <button type="button" onClick={() => toggleSort("averageHoldDays")}>Avg Hold</button>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredTableRows.map((row) => (
+                <tr key={row.id} className="border-t border-border text-text">
+                  <td className="px-2 py-2">{row.overrideTag ?? row.tag}</td>
+                  <td className="px-2 py-2">{row.underlyingSymbol}</td>
+                  <td className="px-2 py-2 text-right">{formatCurrency(safeNumber(row.realizedPnl))}</td>
+                  <td className="px-2 py-2 text-right">{safeNumber(row.winRate).toFixed(2)}</td>
+                  <td className="px-2 py-2 text-right">{safeNumber(row.expectancy).toFixed(2)}</td>
+                  <td className="px-2 py-2 text-right">{safeNumber(row.averageHoldDays).toFixed(2)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {showAll ? (
+          <p className="mt-2 text-xs text-muted">Showing all {tableMeta.total} records</p>
+        ) : (
+          <div className="mt-2 flex items-center justify-between text-xs text-muted">
+            <p>
+              Showing page {tableMeta.page} of {Math.max(1, Math.ceil(tableMeta.total / tableMeta.pageSize))} ({tableMeta.total} rows)
+            </p>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => setTablePage((current) => Math.max(1, current - 1))}
+                disabled={!canGoBack}
+                className="rounded border border-border px-2 py-1 disabled:opacity-50"
+              >
+                Prev
+              </button>
+              <button
+                type="button"
+                onClick={() => setTablePage((current) => current + 1)}
+                disabled={!canGoForward}
+                className="rounded border border-border px-2 py-1 disabled:opacity-50"
+              >
+                Next
+              </button>
+            </div>
+          </div>
+        )}
+      </article>
+    </section>
+  );
+}

--- a/src/app/api/option-quote/route.ts
+++ b/src/app/api/option-quote/route.ts
@@ -1,0 +1,109 @@
+import { NextResponse } from "next/server";
+import type { OptionQuoteRecord, QuoteUnavailableResponse } from "@/types/api";
+import { SchwabCredentialsUnavailableError, getAccessToken } from "@/lib/schwab-auth";
+
+function unavailable(): QuoteUnavailableResponse {
+  return { error: "unavailable" };
+}
+
+function numberOrNull(value: unknown): number | null {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function getOptionContract(
+  map: Record<string, Record<string, Array<Record<string, unknown>>>>,
+  expDate: string,
+  strike: number,
+): Record<string, unknown> | null {
+  for (const [expKey, strikeMap] of Object.entries(map)) {
+    if (!expKey.startsWith(expDate + ":")) {
+      continue;
+    }
+
+    for (const [strikeKey, contracts] of Object.entries(strikeMap)) {
+      const strikeNumber = Number(strikeKey);
+      if (Number.isFinite(strikeNumber) && Math.abs(strikeNumber - strike) < 0.0001 && contracts.length > 0) {
+        return contracts[0];
+      }
+    }
+  }
+
+  return null;
+}
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const symbol = (url.searchParams.get("symbol") ?? "").trim().toUpperCase();
+  const strikeRaw = (url.searchParams.get("strike") ?? "").trim();
+  const expDate = (url.searchParams.get("expDate") ?? "").trim();
+  const contractType = (url.searchParams.get("contractType") ?? "").trim().toUpperCase();
+  const strike = Number(strikeRaw);
+
+  if (!symbol || !expDate || !Number.isFinite(strike) || (contractType !== "CALL" && contractType !== "PUT")) {
+    return NextResponse.json(unavailable());
+  }
+
+  try {
+    const token = await getAccessToken();
+    const upstream = await fetch(
+      `https://api.schwabapi.com/marketdata/v1/chains?symbol=${encodeURIComponent(symbol)}&strikeCount=50&fromDate=${encodeURIComponent(
+        expDate,
+      )}&toDate=${encodeURIComponent(expDate)}&contractType=${contractType}`,
+      {
+        headers: { Authorization: `Bearer ${token}` },
+        cache: "no-store",
+      },
+    );
+
+    if (!upstream.ok) {
+      return NextResponse.json(unavailable());
+    }
+
+    const payload = (await upstream.json()) as {
+      callExpDateMap?: Record<string, Record<string, Array<Record<string, unknown>>>>;
+      putExpDateMap?: Record<string, Record<string, Array<Record<string, unknown>>>>;
+    };
+
+    const expMap = contractType === "CALL" ? payload.callExpDateMap : payload.putExpDateMap;
+    if (!expMap) {
+      return NextResponse.json(unavailable());
+    }
+
+    const contract = getOptionContract(expMap, expDate, strike);
+    if (!contract) {
+      return NextResponse.json(unavailable());
+    }
+
+    const mark = numberOrNull(contract.mark) ?? numberOrNull(contract.markChange) ?? numberOrNull(contract.last);
+    const bid = numberOrNull(contract.bid);
+    const ask = numberOrNull(contract.ask);
+    const delta = numberOrNull(contract.delta);
+    const theta = numberOrNull(contract.theta);
+    const iv = numberOrNull(contract.volatility);
+    const dte = numberOrNull(contract.daysToExpiration);
+
+    if (mark === null || bid === null || ask === null || delta === null || theta === null || iv === null || dte === null) {
+      return NextResponse.json(unavailable());
+    }
+
+    const responsePayload: OptionQuoteRecord = {
+      mark,
+      bid,
+      ask,
+      delta,
+      theta,
+      iv,
+      dte,
+      inTheMoney: Boolean(contract.inTheMoney),
+    };
+
+    return NextResponse.json(responsePayload);
+  } catch (error) {
+    if (error instanceof SchwabCredentialsUnavailableError) {
+      return NextResponse.json(unavailable());
+    }
+
+    return NextResponse.json(unavailable());
+  }
+}

--- a/src/app/api/overview/streaks/route.ts
+++ b/src/app/api/overview/streaks/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db/prisma";
+import type { StreakSummaryResponse } from "@/types/api";
+
+export async function GET() {
+  const lots = await prisma.matchedLot.findMany({
+    include: {
+      closeExecution: {
+        select: {
+          tradeDate: true,
+        },
+      },
+      openExecution: {
+        select: {
+          tradeDate: true,
+        },
+      },
+    },
+    orderBy: [{ closeExecution: { tradeDate: "asc" } }, { id: "asc" }],
+  });
+
+  let currentType: "WIN" | "LOSS" | null = null;
+  let currentCount = 0;
+  let longestWin = 0;
+  let longestLoss = 0;
+
+  const sorted = [...lots].sort((left, right) => {
+    const leftDate = left.closeExecution?.tradeDate ?? left.openExecution.tradeDate;
+    const rightDate = right.closeExecution?.tradeDate ?? right.openExecution.tradeDate;
+    return leftDate.getTime() - rightDate.getTime();
+  });
+
+  for (const lot of sorted) {
+    if (lot.outcome !== "WIN" && lot.outcome !== "LOSS") {
+      currentType = null;
+      currentCount = 0;
+      continue;
+    }
+
+    if (lot.outcome === currentType) {
+      currentCount += 1;
+    } else {
+      currentType = lot.outcome;
+      currentCount = 1;
+    }
+
+    if (currentType === "WIN") {
+      longestWin = Math.max(longestWin, currentCount);
+    }
+
+    if (currentType === "LOSS") {
+      longestLoss = Math.max(longestLoss, currentCount);
+    }
+  }
+
+  const payload: StreakSummaryResponse = {
+    currentStreak: currentCount,
+    currentStreakType: currentType,
+    longestWinStreak: longestWin,
+    longestLossStreak: longestLoss,
+  };
+
+  return NextResponse.json(payload);
+}

--- a/src/app/api/quotes/route.ts
+++ b/src/app/api/quotes/route.ts
@@ -1,0 +1,93 @@
+import { NextResponse } from "next/server";
+import type { EquityQuoteRecord, QuoteUnavailableResponse, QuotesResponse } from "@/types/api";
+import { SchwabCredentialsUnavailableError, getAccessToken } from "@/lib/schwab-auth";
+
+interface QuoteCacheEntry {
+  expiresAtMs: number;
+  value: QuotesResponse;
+}
+
+const quoteCache = new Map<string, QuoteCacheEntry>();
+
+function numberOrZero(value: unknown): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function parseEquityQuote(payload: unknown): EquityQuoteRecord {
+  const quoteSource = typeof payload === "object" && payload !== null && "quote" in payload ? (payload as { quote?: unknown }).quote : payload;
+  const quote = (quoteSource ?? {}) as Record<string, unknown>;
+
+  return {
+    mark: numberOrZero(quote.mark ?? quote.markPrice ?? quote.lastPrice ?? quote.closePrice),
+    bid: numberOrZero(quote.bidPrice ?? quote.bid),
+    ask: numberOrZero(quote.askPrice ?? quote.ask),
+    last: numberOrZero(quote.lastPrice ?? quote.last),
+    netChange: numberOrZero(quote.netChange ?? quote.netChangePct),
+    netPctChange: numberOrZero(quote.netPercentChangeInDouble ?? quote.netPctChange),
+  };
+}
+
+function unavailable(): QuoteUnavailableResponse {
+  return { error: "unavailable" };
+}
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const symbolsRaw = url.searchParams.get("symbols") ?? "";
+  const symbols = Array.from(
+    new Set(
+      symbolsRaw
+        .split(",")
+        .map((value) => value.trim().toUpperCase())
+        .filter(Boolean),
+    ),
+  ).sort((left, right) => left.localeCompare(right));
+
+  if (symbols.length === 0) {
+    return NextResponse.json({} satisfies Record<string, EquityQuoteRecord>);
+  }
+
+  const cacheKey = symbols.join(",");
+  const now = Date.now();
+  const cached = quoteCache.get(cacheKey);
+  if (cached && cached.expiresAtMs > now) {
+    return NextResponse.json(cached.value);
+  }
+
+  try {
+    const token = await getAccessToken();
+    const upstream = await fetch(`https://api.schwabapi.com/marketdata/v1/quotes?symbols=${encodeURIComponent(cacheKey)}`, {
+      headers: { Authorization: `Bearer ${token}` },
+      cache: "no-store",
+    });
+
+    if (!upstream.ok) {
+      const payload = unavailable();
+      return NextResponse.json(payload);
+    }
+
+    const upstreamPayload = (await upstream.json()) as Record<string, unknown>;
+    const responsePayload: Record<string, EquityQuoteRecord> = {};
+
+    for (const symbol of symbols) {
+      const quotePayload = upstreamPayload[symbol] ?? upstreamPayload[symbol.toLowerCase()];
+      if (quotePayload) {
+        responsePayload[symbol] = parseEquityQuote(quotePayload);
+      }
+    }
+
+    quoteCache.set(cacheKey, {
+      value: responsePayload,
+      expiresAtMs: now + 30_000,
+    });
+
+    return NextResponse.json(responsePayload);
+  } catch (error) {
+    if (error instanceof SchwabCredentialsUnavailableError) {
+      return NextResponse.json(unavailable());
+    }
+
+    return NextResponse.json(unavailable());
+  }
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import { DndContext, type DragEndEvent, useDraggable, useDroppable } from "@dnd-kit/core";
+import { useEffect, useMemo, useState } from "react";
+import { WidgetPicker } from "@/components/WidgetPicker";
+import { KpiCard } from "@/components/KpiCard";
+import { LoadingSkeleton } from "@/components/loading-skeleton";
+import { DEFAULT_DASHBOARD_LAYOUT, WIDGET_REGISTRY } from "@/lib/widget-registry";
+import type { OverviewSummaryResponse } from "@/types/api";
+
+const LAYOUT_STORAGE_KEY = "kapman_dashboard_layout";
+
+interface OverviewPayload {
+  data: OverviewSummaryResponse;
+}
+
+function reorder<T>(items: T[], from: number, to: number): T[] {
+  const next = [...items];
+  const [moved] = next.splice(from, 1);
+  next.splice(to, 0, moved);
+  return next;
+}
+
+function DashboardTile({
+  slotId,
+  colSpan,
+  editMode,
+  remove,
+  children,
+}: {
+  slotId: string;
+  colSpan: 1 | 2;
+  editMode: boolean;
+  remove: () => void;
+  children: React.ReactNode;
+}) {
+  const { attributes, listeners, setNodeRef: setDragRef, transform, isDragging } = useDraggable({ id: slotId, disabled: !editMode });
+  const { setNodeRef: setDropRef } = useDroppable({ id: slotId });
+
+  const style = transform ? { transform: `translate3d(${transform.x}px, ${transform.y}px, 0)`, zIndex: isDragging ? 20 : 1 } : undefined;
+
+  function setNodeRef(node: HTMLElement | null) {
+    setDragRef(node);
+    setDropRef(node);
+  }
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={[
+        "relative",
+        colSpan === 2 ? "md:col-span-2" : "md:col-span-1",
+        editMode ? "cursor-move" : "",
+      ].join(" ")}
+      {...attributes}
+      {...listeners}
+    >
+      {editMode ? (
+        <button type="button" onClick={remove} className="absolute right-2 top-2 z-30 rounded border border-border bg-panel px-2 py-0.5 text-xs text-muted">
+          ×
+        </button>
+      ) : null}
+      {children}
+    </div>
+  );
+}
+
+export default function Page() {
+  const widgetMap = useMemo(() => new Map(WIDGET_REGISTRY.map((widget) => [widget.id, widget])), []);
+  const [layout, setLayout] = useState<string[]>(DEFAULT_DASHBOARD_LAYOUT);
+  const [editMode, setEditMode] = useState(false);
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  const [summary, setSummary] = useState<OverviewSummaryResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    try {
+      const stored = window.localStorage.getItem(LAYOUT_STORAGE_KEY);
+      if (!stored) {
+        return;
+      }
+
+      const parsed = JSON.parse(stored) as string[];
+      if (Array.isArray(parsed) && parsed.every((value) => typeof value === "string") && parsed.length > 0) {
+        setLayout(parsed);
+      }
+    } catch {
+      setLayout(DEFAULT_DASHBOARD_LAYOUT);
+    }
+  }, []);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(LAYOUT_STORAGE_KEY, JSON.stringify(layout));
+    } catch {
+      // Ignore localStorage errors.
+    }
+  }, [layout]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadSummary() {
+      try {
+        const response = await fetch("/api/overview/summary", { cache: "no-store" });
+        if (!response.ok) {
+          throw new Error("Unable to load dashboard summary.");
+        }
+
+        const payload = (await response.json()) as OverviewPayload;
+        if (!cancelled) {
+          setSummary(payload.data);
+        }
+      } catch (loadError) {
+        if (!cancelled) {
+          setError(loadError instanceof Error ? loadError.message : "Dashboard load failed.");
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void loadSummary();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  function onDragEnd(event: DragEndEvent) {
+    const activeIndex = Number(String(event.active.id).replace("slot-", ""));
+    const overIndex = Number(String(event.over?.id ?? "").replace("slot-", ""));
+
+    if (!Number.isFinite(activeIndex) || !Number.isFinite(overIndex) || activeIndex === overIndex) {
+      return;
+    }
+
+    setLayout((current) => reorder(current, activeIndex, overIndex));
+  }
+
+  return (
+    <section className="space-y-5">
+      <div className="flex items-center justify-end gap-2">
+        {editMode ? (
+          <button type="button" onClick={() => setEditMode(false)} className="rounded border border-border bg-panel-2 px-3 py-1 text-xs text-text">
+            Done
+          </button>
+        ) : (
+          <button type="button" onClick={() => setEditMode(true)} className="rounded border border-border bg-panel-2 px-3 py-1 text-xs text-text">
+            Customize
+          </button>
+        )}
+      </div>
+
+      {loading ? <LoadingSkeleton lines={4} /> : null}
+      {!loading && error ? <p className="text-sm text-red-200">{error}</p> : null}
+
+      {!loading && !error && summary ? (
+        <div className="grid gap-3 md:grid-cols-3 xl:grid-cols-6">
+          <KpiCard label="Net P&L" value={summary.netPnl} colorVariant={Number(summary.netPnl) < 0 ? "neg" : "pos"} />
+          <KpiCard label="Executions" value={summary.executionCount} colorVariant="accent" />
+          <KpiCard label="Matched Lots" value={summary.matchedLotCount} colorVariant="accent" />
+          <KpiCard label="Setups" value={summary.setupCount} colorVariant="accent" />
+          <KpiCard label="Average Hold Days" value={summary.averageHoldDays} colorVariant="accent" />
+          <KpiCard label="Snapshots" value={summary.snapshotCount} colorVariant="neutral" />
+        </div>
+      ) : null}
+
+      <DndContext onDragEnd={onDragEnd}>
+        <div className="grid gap-3 md:grid-cols-3">
+          {layout.map((widgetId, index) => {
+            const definition = widgetMap.get(widgetId);
+            if (!definition) {
+              return null;
+            }
+
+            const Component = definition.component;
+
+            return (
+              <DashboardTile
+                key={widgetId + "-" + String(index)}
+                slotId={"slot-" + String(index)}
+                colSpan={definition.defaultColSpan}
+                editMode={editMode}
+                remove={() => setLayout((current) => current.filter((_value, valueIndex) => valueIndex !== index))}
+              >
+                <Component />
+              </DashboardTile>
+            );
+          })}
+
+          {editMode ? (
+            <button
+              type="button"
+              onClick={() => setPickerOpen(true)}
+              className="rounded-xl border border-dashed border-border bg-panel-2 p-6 text-left text-sm text-muted"
+            >
+              + Add widget
+            </button>
+          ) : null}
+        </div>
+      </DndContext>
+
+      <WidgetPicker
+        open={pickerOpen}
+        widgets={WIDGET_REGISTRY}
+        onClose={() => setPickerOpen(false)}
+        onSelect={(widgetId) => setLayout((current) => [...current, widgetId])}
+      />
+    </section>
+  );
+}

--- a/src/app/diagnostics/page.tsx
+++ b/src/app/diagnostics/page.tsx
@@ -2,16 +2,13 @@ import { DataPageLayout } from "@/components/data-page-layout";
 import { DiagnosticsPanel } from "@/components/diagnostics-panel";
 import { dataPageCopy } from "@/lib/ui/page-copy";
 
-function DiagnosticsPage() {
+export default function Page() {
   const page = dataPageCopy.diagnostics;
+
   return (
     <div className="space-y-6">
       <DataPageLayout title={page.title} subtitle={page.subtitle} nextAction={page.nextAction} />
       <DiagnosticsPanel />
     </div>
   );
-}
-
-export default function Page() {
-  return <DiagnosticsPage />;
 }

--- a/src/app/executions/page.tsx
+++ b/src/app/executions/page.tsx
@@ -1,17 +1,5 @@
-import { DataPageLayout } from "@/components/data-page-layout";
-import { ExecutionsTablePanel } from "@/components/executions-table-panel";
-import { dataPageCopy } from "@/lib/ui/page-copy";
-
-function ExecutionsPage() {
-  const page = dataPageCopy.executions;
-  return (
-    <div className="space-y-6">
-      <DataPageLayout title={page.title} subtitle={page.subtitle} nextAction={page.nextAction} />
-      <ExecutionsTablePanel />
-    </div>
-  );
-}
+import { redirect } from "next/navigation";
 
 export default function Page() {
-  return <ExecutionsPage />;
+  redirect("/trade-records?tab=executions");
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11,6 +11,10 @@
   --accent: #67a3ff;
   --accent-2: #7ef0c6;
   --border: rgba(255, 255, 255, 0.1);
+  --sidebar-bg: #0a1020;
+  --danger: #fca5a5;
+  --warning: #fbbf24;
+  --violet: #a78bfa;
 }
 
 * {
@@ -19,6 +23,6 @@
 
 body {
   margin: 0;
-  background: radial-gradient(circle at top left, #152245 0%, #090f1e 42%, #050913 100%);
   color: var(--text);
+  background: radial-gradient(circle at 0% 0%, #152245 0%, #090f1e 42%, #050913 100%);
 }

--- a/src/app/imports/page.tsx
+++ b/src/app/imports/page.tsx
@@ -1,19 +1,48 @@
-import { DataPageLayout } from "@/components/data-page-layout";
+import Link from "next/link";
 import { AdapterRegistryPanel } from "@/components/adapter-registry-panel";
 import { ImportsWorkflowPanel } from "@/components/imports-workflow-panel";
-import { dataPageCopy } from "@/lib/ui/page-copy";
 
-function ImportsConnectionsPage() {
-  const page = dataPageCopy.imports;
+type ImportTab = "upload" | "history" | "adapters";
+
+function normalizeTab(value: string | undefined): ImportTab {
+  if (value === "history" || value === "adapters") {
+    return value;
+  }
+
+  return "upload";
+}
+
+function TabLink({ tab, activeTab, label }: { tab: ImportTab; activeTab: ImportTab; label: string }) {
+  const active = tab === activeTab;
+
   return (
-    <div className="space-y-6">
-      <DataPageLayout title={page.title} subtitle={page.subtitle} nextAction={page.nextAction} />
-      <ImportsWorkflowPanel />
-      <AdapterRegistryPanel />
-    </div>
+    <Link
+      href={"/imports?tab=" + tab}
+      className={[
+        "rounded-lg border px-3 py-1 text-xs font-medium",
+        active ? "border-accent bg-accent/10 text-text" : "border-border bg-panel text-muted hover:text-text",
+      ].join(" ")}
+    >
+      {label}
+    </Link>
   );
 }
 
-export default function Page() {
-  return <ImportsConnectionsPage />;
+export default function Page({ searchParams }: { searchParams?: Record<string, string | string[] | undefined> }) {
+  const tabQuery = searchParams?.tab;
+  const activeTab = normalizeTab(Array.isArray(tabQuery) ? tabQuery[0] : tabQuery);
+
+  return (
+    <section className="space-y-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <TabLink tab="upload" activeTab={activeTab} label="Upload Statement" />
+        <TabLink tab="history" activeTab={activeTab} label="Import History" />
+        <TabLink tab="adapters" activeTab={activeTab} label="Adapter Registry" />
+      </div>
+
+      {activeTab === "upload" ? <ImportsWorkflowPanel mode="upload" /> : null}
+      {activeTab === "history" ? <ImportsWorkflowPanel mode="history" /> : null}
+      {activeTab === "adapters" ? <AdapterRegistryPanel /> : null}
+    </section>
+  );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,28 +1,17 @@
 import type { Metadata } from "next";
-import { SidebarNav } from "@/components/sidebar-nav";
+import { RootShell } from "@/components/root-shell";
 import "./globals.css";
 
 export const metadata: Metadata = {
   title: "KapMan Trading Journal",
-  description: "Containerized trading journal MVP for imports, FIFO lots, and setup analytics.",
+  description: "Containerized trading journal for imports, FIFO lots, and setup analytics.",
 };
 
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="en">
       <body>
-        <div className="grid min-h-screen grid-cols-1 lg:grid-cols-[280px_1fr]">
-          <aside className="border-b border-slate-700 bg-slate-950/80 p-6 lg:border-b-0 lg:border-r">
-            <div className="rounded-2xl border border-slate-700/70 bg-slate-900/60 p-4">
-              <h1 className="text-base font-semibold text-slate-100">KapMan Trading Journal</h1>
-              <p className="mt-1 text-xs text-slate-300">MVP routing shell</p>
-            </div>
-            <div className="mt-6">
-              <SidebarNav />
-            </div>
-          </aside>
-          <main className="p-6 lg:p-10">{children}</main>
-        </div>
+        <RootShell>{children}</RootShell>
       </body>
     </html>
   );

--- a/src/app/matched-lots/page.tsx
+++ b/src/app/matched-lots/page.tsx
@@ -1,17 +1,5 @@
-import { DataPageLayout } from "@/components/data-page-layout";
-import { MatchedLotsTablePanel } from "@/components/matched-lots-table-panel";
-import { dataPageCopy } from "@/lib/ui/page-copy";
-
-function MatchedLotsPage() {
-  const page = dataPageCopy.matchedLots;
-  return (
-    <div className="space-y-6">
-      <DataPageLayout title={page.title} subtitle={page.subtitle} nextAction={page.nextAction} />
-      <MatchedLotsTablePanel />
-    </div>
-  );
-}
+import { redirect } from "next/navigation";
 
 export default function Page() {
-  return <MatchedLotsPage />;
+  redirect("/trade-records?tab=matched-lots");
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,17 +1,5 @@
-import { DataPageLayout } from "@/components/data-page-layout";
-import { OverviewDashboardPanel } from "@/components/overview-dashboard-panel";
-import { dataPageCopy } from "@/lib/ui/page-copy";
-
-function OverviewPage() {
-  const page = dataPageCopy.overview;
-  return (
-    <div className="space-y-6">
-      <DataPageLayout title={page.title} subtitle={page.subtitle} nextAction={page.nextAction} />
-      <OverviewDashboardPanel />
-    </div>
-  );
-}
+import { redirect } from "next/navigation";
 
 export default function Page() {
-  return <OverviewPage />;
+  redirect("/dashboard");
 }

--- a/src/app/positions/page.tsx
+++ b/src/app/positions/page.tsx
@@ -1,0 +1,332 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Badge } from "@/components/Badge";
+import { LoadingSkeleton } from "@/components/loading-skeleton";
+import { useAccountFilterContext } from "@/contexts/AccountFilterContext";
+import { useOpenPositions } from "@/hooks/useOpenPositions";
+import type { EquityQuoteRecord, OpenPosition, OptionQuoteResponse, QuotesResponse } from "@/types/api";
+
+const SHOW_ALL_KEY = "kapman_table_positions_showAll";
+
+function positionKey(position: OpenPosition): string {
+  return position.accountId + "::" + position.instrumentKey;
+}
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 2 }).format(value);
+}
+
+function formatPercent(value: number): string {
+  return value.toFixed(2) + "%";
+}
+
+function getDte(expirationDate: string | null): number | null {
+  if (!expirationDate) {
+    return null;
+  }
+
+  const expiration = new Date(expirationDate);
+  const diffMs = expiration.getTime() - Date.now();
+  return Math.ceil(diffMs / (24 * 60 * 60 * 1000));
+}
+
+function isQuoteUnavailable(payload: QuotesResponse): payload is { error: "unavailable" } {
+  return typeof payload === "object" && payload !== null && "error" in payload && payload.error === "unavailable";
+}
+
+function isOptionQuoteUnavailable(payload: OptionQuoteResponse): payload is { error: "unavailable" } {
+  return typeof payload === "object" && payload !== null && "error" in payload && payload.error === "unavailable";
+}
+
+export default function Page() {
+  const { positions, loading, error } = useOpenPositions();
+  const { selectedAccounts } = useAccountFilterContext();
+
+  const [showAll, setShowAll] = useState(false);
+  const [page, setPage] = useState(1);
+  const [markLoading, setMarkLoading] = useState(false);
+  const [lastQuoted, setLastQuoted] = useState<Date | null>(null);
+  const [markMap, setMarkMap] = useState<Record<string, number | null>>({});
+  const [quoteUnavailable, setQuoteUnavailable] = useState(false);
+  const [refreshCounter, setRefreshCounter] = useState(0);
+
+  useEffect(() => {
+    try {
+      const stored = window.localStorage.getItem(SHOW_ALL_KEY);
+      setShowAll(stored === "1");
+    } catch {
+      setShowAll(false);
+    }
+  }, []);
+
+  const filteredPositions = useMemo(() => {
+    return positions.filter((position) => selectedAccounts.includes(position.accountId));
+  }, [positions, selectedAccounts]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchMarks() {
+      if (filteredPositions.length === 0) {
+        if (!cancelled) {
+          setMarkMap({});
+          setLastQuoted(null);
+          setQuoteUnavailable(false);
+        }
+        return;
+      }
+
+      setMarkLoading(true);
+
+      try {
+        const nextMap: Record<string, number | null> = {};
+        let unavailable = false;
+
+        const equityPositions = filteredPositions.filter((position) => position.assetClass === "EQUITY");
+        const optionPositions = filteredPositions.filter((position) => position.assetClass === "OPTION");
+
+        if (equityPositions.length > 0) {
+          const symbols = Array.from(new Set(equityPositions.map((position) => position.symbol))).join(",");
+          const equityResponse = await fetch(`/api/quotes?symbols=${encodeURIComponent(symbols)}`, { cache: "no-store" });
+          const equityPayload = (await equityResponse.json()) as QuotesResponse;
+
+          if (isQuoteUnavailable(equityPayload)) {
+            unavailable = true;
+          } else {
+            const quoteMap = equityPayload as Record<string, EquityQuoteRecord>;
+            for (const position of equityPositions) {
+              const quote = quoteMap[position.symbol];
+              nextMap[positionKey(position)] = quote ? quote.mark : null;
+            }
+          }
+        }
+
+        if (!unavailable && optionPositions.length > 0) {
+          const optionResults = await Promise.all(
+            optionPositions.map(async (position) => {
+              const expDate = position.expirationDate?.slice(0, 10);
+              if (!position.optionType || !position.strike || !expDate) {
+                return {
+                  key: positionKey(position),
+                  mark: null,
+                  unavailable: true,
+                };
+              }
+
+              const response = await fetch(
+                `/api/option-quote?symbol=${encodeURIComponent(position.underlyingSymbol)}&strike=${encodeURIComponent(
+                  position.strike,
+                )}&expDate=${encodeURIComponent(expDate)}&contractType=${position.optionType}`,
+                { cache: "no-store" },
+              );
+
+              const payload = (await response.json()) as OptionQuoteResponse;
+              if (isOptionQuoteUnavailable(payload)) {
+                return {
+                  key: positionKey(position),
+                  mark: null,
+                  unavailable: true,
+                };
+              }
+
+              return {
+                key: positionKey(position),
+                mark: payload.mark,
+                unavailable: false,
+              };
+            }),
+          );
+
+          for (const result of optionResults) {
+            nextMap[result.key] = result.mark;
+            if (result.unavailable) {
+              unavailable = true;
+            }
+          }
+        }
+
+        if (!cancelled) {
+          setMarkMap(nextMap);
+          setQuoteUnavailable(unavailable);
+          setLastQuoted(unavailable ? null : new Date());
+        }
+      } catch {
+        if (!cancelled) {
+          setMarkMap({});
+          setQuoteUnavailable(true);
+          setLastQuoted(null);
+        }
+      } finally {
+        if (!cancelled) {
+          setMarkLoading(false);
+        }
+      }
+    }
+
+    void fetchMarks();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [filteredPositions, refreshCounter]);
+
+  const rows = useMemo(() => {
+    return filteredPositions.map((position) => {
+      const key = positionKey(position);
+      const mark = markMap[key] ?? null;
+      const multiplier = position.assetClass === "OPTION" ? 100 : 1;
+      const marketValue = mark === null ? null : mark * position.netQty * multiplier;
+      const unrealizedPnl = marketValue === null ? null : marketValue - position.costBasis;
+      const pnlPct = unrealizedPnl === null || position.costBasis === 0 ? null : (unrealizedPnl / Math.abs(position.costBasis)) * 100;
+
+      return {
+        ...position,
+        key,
+        dte: getDte(position.expirationDate),
+        mark,
+        marketValue,
+        unrealizedPnl,
+        pnlPct,
+      };
+    });
+  }, [filteredPositions, markMap]);
+
+  const pageSize = 25;
+  const total = rows.length;
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  const currentPage = Math.min(page, totalPages);
+  const pagedRows = showAll ? rows : rows.slice((currentPage - 1) * pageSize, currentPage * pageSize);
+
+  function toggleShowAll() {
+    const next = !showAll;
+    setShowAll(next);
+    setPage(1);
+    try {
+      window.localStorage.setItem(SHOW_ALL_KEY, next ? "1" : "0");
+    } catch {
+      // Ignore localStorage errors.
+    }
+  }
+
+  return (
+    <section className="space-y-4 rounded-xl border border-border bg-panel p-4">
+      <header className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <p className="text-sm font-semibold text-text">Open Positions</p>
+          <span className="rounded-full bg-panel-2 px-2 py-0.5 text-[11px] text-muted">{total} positions</span>
+          <span className="text-xs text-muted">Last quoted: {lastQuoted ? lastQuoted.toLocaleTimeString() : "—"}</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setRefreshCounter((current) => current + 1)}
+            className="rounded border border-border bg-panel-2 px-2 py-1 text-xs text-text"
+          >
+            Refresh Quotes
+          </button>
+          <button type="button" onClick={toggleShowAll} className="rounded border border-border bg-panel-2 px-2 py-1 text-xs text-text">
+            {showAll ? "Show pages" : `Show all ${total}`}
+          </button>
+        </div>
+      </header>
+
+      {loading ? <LoadingSkeleton lines={6} /> : null}
+      {!loading && error ? <p className="text-sm text-red-200">{error}</p> : null}
+      {!loading && !error && total === 0 ? (
+        <div className="rounded-lg border border-border bg-panel-2 p-4 text-sm text-muted">No open positions for the selected accounts.</div>
+      ) : null}
+
+      {!loading && !error && total > 0 ? (
+        <div className="space-y-2">
+          {quoteUnavailable ? <p className="text-xs text-amber-200">Live quotes unavailable. Showing cost basis only.</p> : null}
+          <div className={showAll ? "overflow-y-auto" : "overflow-auto"} style={showAll ? { maxHeight: "calc(100vh - 280px)" } : undefined}>
+            <table className="min-w-full text-xs">
+              <thead className="bg-panel-2 text-muted">
+                <tr>
+                  <th className="px-2 py-2 text-left">Symbol</th>
+                  <th className="px-2 py-2 text-left">Type</th>
+                  <th className="px-2 py-2 text-right">Strike</th>
+                  <th className="px-2 py-2 text-left">Expiry</th>
+                  <th className="px-2 py-2 text-right">DTE</th>
+                  <th className="px-2 py-2 text-right">Qty</th>
+                  <th className="px-2 py-2 text-right">Cost Basis</th>
+                  <th className="px-2 py-2 text-right">Mark</th>
+                  <th className="px-2 py-2 text-right">Mkt Value</th>
+                  <th className="px-2 py-2 text-right">Unrealized P&L</th>
+                  <th className="px-2 py-2 text-right">P&L %</th>
+                  <th className="px-2 py-2 text-left">Account</th>
+                </tr>
+              </thead>
+              <tbody>
+                {pagedRows.map((row) => (
+                  <tr key={row.key} className="border-t border-border text-text">
+                    <td className="px-2 py-2 font-semibold">{row.underlyingSymbol}</td>
+                    <td className="px-2 py-2">
+                      {row.assetClass === "OPTION" ? (
+                        <Badge variant={row.optionType === "PUT" ? "put" : "call"}>{row.optionType ?? "OPTION"}</Badge>
+                      ) : (
+                        <Badge variant="stub">EQUITY</Badge>
+                      )}
+                    </td>
+                    <td className="px-2 py-2 text-right font-mono">{row.strike ?? "—"}</td>
+                    <td className="px-2 py-2">{row.expirationDate ? new Date(row.expirationDate).toLocaleDateString() : "—"}</td>
+                    <td
+                      className={[
+                        "px-2 py-2 text-right",
+                        row.dte === null ? "text-muted" : row.dte < 7 ? "text-red-300" : row.dte < 30 ? "text-amber-300" : "text-text",
+                      ].join(" ")}
+                    >
+                      {row.dte ?? "—"}
+                    </td>
+                    <td className={row.netQty >= 0 ? "px-2 py-2 text-right text-green-300" : "px-2 py-2 text-right text-red-300"}>{row.netQty}</td>
+                    <td className="px-2 py-2 text-right font-mono">{formatCurrency(row.costBasis)}</td>
+                    <td className="px-2 py-2 text-right font-mono">
+                      {markLoading ? <span className="text-muted">...</span> : row.mark === null ? "—" : formatCurrency(row.mark)}
+                    </td>
+                    <td className="px-2 py-2 text-right font-mono">{row.marketValue === null ? "—" : formatCurrency(row.marketValue)}</td>
+                    <td className={row.unrealizedPnl !== null && row.unrealizedPnl >= 0 ? "px-2 py-2 text-right text-green-300" : "px-2 py-2 text-right text-red-300"}>
+                      {row.unrealizedPnl === null ? "—" : formatCurrency(row.unrealizedPnl)}
+                    </td>
+                    <td className={row.pnlPct !== null && row.pnlPct >= 0 ? "px-2 py-2 text-right text-green-300" : "px-2 py-2 text-right text-red-300"}>
+                      {row.pnlPct === null ? "—" : formatPercent(row.pnlPct)}
+                    </td>
+                    <td className="px-2 py-2 text-muted">{row.accountId.slice(-4)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {!showAll ? (
+            <div className="flex items-center justify-between text-xs text-muted">
+              <p>
+                Page {currentPage} of {totalPages}
+              </p>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => setPage((current) => Math.max(1, current - 1))}
+                  disabled={currentPage <= 1}
+                  className="rounded border border-border px-2 py-1 disabled:opacity-50"
+                >
+                  Prev
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setPage((current) => Math.min(totalPages, current + 1))}
+                  disabled={currentPage >= totalPages}
+                  className="rounded border border-border px-2 py-1 disabled:opacity-50"
+                >
+                  Next
+                </button>
+              </div>
+            </div>
+          ) : (
+            <p className="text-xs text-muted">Showing all {total} records</p>
+          )}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/src/app/setups/page.tsx
+++ b/src/app/setups/page.tsx
@@ -1,17 +1,5 @@
-import { DataPageLayout } from "@/components/data-page-layout";
-import { SetupsAnalyticsPanel } from "@/components/setups-analytics-panel";
-import { dataPageCopy } from "@/lib/ui/page-copy";
-
-function SetupsPage() {
-  const page = dataPageCopy.setups;
-  return (
-    <div className="space-y-6">
-      <DataPageLayout title={page.title} subtitle={page.subtitle} nextAction={page.nextAction} />
-      <SetupsAnalyticsPanel />
-    </div>
-  );
-}
+import { redirect } from "next/navigation";
 
 export default function Page() {
-  return <SetupsPage />;
+  redirect("/trade-records?tab=setups");
 }

--- a/src/app/trade-records/page.tsx
+++ b/src/app/trade-records/page.tsx
@@ -1,0 +1,49 @@
+import Link from "next/link";
+import { ExecutionsTablePanel } from "@/components/executions-table-panel";
+import { MatchedLotsTablePanel } from "@/components/matched-lots-table-panel";
+import { SetupsAnalyticsPanel } from "@/components/setups-analytics-panel";
+
+type TradeRecordTab = "executions" | "matched-lots" | "setups";
+
+function normalizeTab(value: string | undefined): TradeRecordTab {
+  if (value === "matched-lots" || value === "setups") {
+    return value;
+  }
+
+  return "executions";
+}
+
+function TabLink({ tab, activeTab, label }: { tab: TradeRecordTab; activeTab: TradeRecordTab; label: string }) {
+  const active = tab === activeTab;
+
+  return (
+    <Link
+      href={"/trade-records?tab=" + tab}
+      className={[
+        "rounded-lg border px-3 py-1 text-xs font-medium",
+        active ? "border-accent bg-accent/10 text-text" : "border-border bg-panel text-muted hover:text-text",
+      ].join(" ")}
+    >
+      {label}
+    </Link>
+  );
+}
+
+export default function Page({ searchParams }: { searchParams?: Record<string, string | string[] | undefined> }) {
+  const tabQuery = searchParams?.tab;
+  const activeTab = normalizeTab(Array.isArray(tabQuery) ? tabQuery[0] : tabQuery);
+
+  return (
+    <section className="space-y-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <TabLink tab="executions" activeTab={activeTab} label="Executions (T1)" />
+        <TabLink tab="matched-lots" activeTab={activeTab} label="Matched Lots (T2)" />
+        <TabLink tab="setups" activeTab={activeTab} label="Setups (T3)" />
+      </div>
+
+      {activeTab === "executions" ? <ExecutionsTablePanel /> : null}
+      {activeTab === "matched-lots" ? <MatchedLotsTablePanel /> : null}
+      {activeTab === "setups" ? <SetupsAnalyticsPanel /> : null}
+    </section>
+  );
+}

--- a/src/app/tts-evidence/page.tsx
+++ b/src/app/tts-evidence/page.tsx
@@ -2,16 +2,13 @@ import { DataPageLayout } from "@/components/data-page-layout";
 import { TtsEvidencePanel } from "@/components/tts-evidence-panel";
 import { dataPageCopy } from "@/lib/ui/page-copy";
 
-function TtsEvidencePage() {
+export default function Page() {
   const page = dataPageCopy.ttsEvidence;
+
   return (
     <div className="space-y-6">
       <DataPageLayout title={page.title} subtitle={page.subtitle} nextAction={page.nextAction} />
       <TtsEvidencePanel />
     </div>
   );
-}
-
-export default function Page() {
-  return <TtsEvidencePage />;
 }

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from "react";
+
+interface BadgeProps {
+  variant: "buy" | "sell" | "call" | "put" | "win" | "loss" | "flat" | "to-open" | "to-close" | "committed" | "stub";
+  children?: ReactNode;
+}
+
+const variantClasses: Record<BadgeProps["variant"], string> = {
+  buy: "bg-green-500/20 text-green-200",
+  sell: "bg-red-500/20 text-red-200",
+  call: "bg-blue-500/20 text-blue-200",
+  put: "bg-violet-500/20 text-violet-200",
+  win: "bg-green-500/20 text-green-200",
+  loss: "bg-red-500/20 text-red-200",
+  flat: "bg-slate-500/20 text-slate-200",
+  "to-open": "bg-blue-500/20 text-blue-200",
+  "to-close": "bg-amber-500/20 text-amber-200",
+  committed: "bg-green-500/20 text-green-200",
+  stub: "bg-slate-500/20 text-slate-200",
+};
+
+export function Badge({ variant, children }: BadgeProps) {
+  return (
+    <span className={`inline-flex rounded-full px-1.5 py-0.5 text-[9px] font-bold uppercase leading-none ${variantClasses[variant]}`}>
+      {children ?? variant.replace("-", " ")}
+    </span>
+  );
+}

--- a/src/components/KpiCard.tsx
+++ b/src/components/KpiCard.tsx
@@ -1,0 +1,23 @@
+interface KpiCardProps {
+  label: string;
+  value: string | number;
+  sub?: string;
+  colorVariant?: "pos" | "neg" | "neutral" | "accent";
+}
+
+const valueColorByVariant: Record<NonNullable<KpiCardProps["colorVariant"]>, string> = {
+  pos: "text-accent-2",
+  neg: "text-red-300",
+  neutral: "text-text",
+  accent: "text-accent",
+};
+
+export function KpiCard({ label, value, sub, colorVariant = "neutral" }: KpiCardProps) {
+  return (
+    <article className="rounded-xl border border-border bg-panel p-3">
+      <p className="text-[10px] uppercase tracking-[0.08em] text-muted">{label}</p>
+      <p className={`mt-1 font-mono text-2xl font-semibold ${valueColorByVariant[colorVariant]}`}>{value}</p>
+      {sub ? <p className="mt-1 text-xs text-muted">{sub}</p> : null}
+    </article>
+  );
+}

--- a/src/components/WidgetPicker.tsx
+++ b/src/components/WidgetPicker.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect } from "react";
+import type { WidgetDefinition } from "@/lib/widget-registry";
+
+interface WidgetPickerProps {
+  open: boolean;
+  widgets: WidgetDefinition[];
+  onClose: () => void;
+  onSelect: (widgetId: string) => void;
+}
+
+export function WidgetPicker({ open, widgets, onClose, onSelect }: WidgetPickerProps) {
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    function handleKeydown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    }
+
+    window.addEventListener("keydown", handleKeydown);
+    return () => {
+      window.removeEventListener("keydown", handleKeydown);
+    };
+  }, [open, onClose]);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-bg/80 p-4" onClick={onClose}>
+      <div className="max-h-[80vh] w-full max-w-4xl overflow-y-auto rounded-xl border border-border bg-panel p-4" onClick={(event) => event.stopPropagation()}>
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-text">Add Widget</h2>
+          <button type="button" onClick={onClose} className="rounded border border-border px-2 py-1 text-xs text-muted">
+            Close
+          </button>
+        </div>
+
+        <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+          {widgets.map((widget) => (
+            <button
+              key={widget.id}
+              type="button"
+              onClick={() => {
+                onSelect(widget.id);
+                onClose();
+              }}
+              className="rounded-lg border border-border bg-panel-2 p-3 text-left"
+            >
+              <p className="text-sm font-semibold text-text">{widget.name}</p>
+              <p className="mt-1 text-xs text-muted">{widget.description}</p>
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/account-selector.tsx
+++ b/src/components/account-selector.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useAccountFilterContext } from "@/contexts/AccountFilterContext";
+
+export function AccountSelector() {
+  const [open, setOpen] = useState(false);
+  const { availableAccounts, selectedAccounts, setSelectedAccounts } = useAccountFilterContext();
+
+  const allSelected = availableAccounts.length > 0 && selectedAccounts.length === availableAccounts.length;
+  const label = useMemo(() => {
+    if (availableAccounts.length === 0) {
+      return "Accounts: none";
+    }
+
+    if (allSelected) {
+      return `Accounts: all (${availableAccounts.length})`;
+    }
+
+    return `Accounts: ${selectedAccounts.length}/${availableAccounts.length}`;
+  }, [allSelected, availableAccounts.length, selectedAccounts.length]);
+
+  function toggleAccount(accountId: string) {
+    if (selectedAccounts.includes(accountId)) {
+      setSelectedAccounts(selectedAccounts.filter((value) => value !== accountId));
+      return;
+    }
+
+    setSelectedAccounts([...selectedAccounts, accountId]);
+  }
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((current) => !current)}
+        className="rounded-lg border border-border bg-panel px-3 py-2 text-xs font-medium text-text"
+      >
+        {label}
+      </button>
+
+      {open ? (
+        <div className="absolute right-0 z-30 mt-2 w-64 rounded-xl border border-border bg-panel-2 p-3 shadow-2xl">
+          <div className="mb-2 flex items-center justify-between">
+            <p className="text-[11px] uppercase tracking-wide text-muted">Account Filter</p>
+            <button
+              type="button"
+              onClick={() => setSelectedAccounts(availableAccounts)}
+              className="text-[11px] text-accent"
+              disabled={availableAccounts.length === 0}
+            >
+              Select all
+            </button>
+          </div>
+
+          <div className="max-h-56 space-y-2 overflow-auto pr-1">
+            {availableAccounts.length === 0 ? <p className="text-xs text-muted">No accounts available</p> : null}
+            {availableAccounts.map((accountId) => (
+              <label key={accountId} className="flex cursor-pointer items-center gap-2 text-xs text-text">
+                <input
+                  type="checkbox"
+                  checked={selectedAccounts.includes(accountId)}
+                  onChange={() => toggleAccount(accountId)}
+                  className="h-3 w-3 rounded border-border bg-panel"
+                />
+                <span className="truncate font-mono">{accountId}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/executions-table-panel.tsx
+++ b/src/components/executions-table-panel.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
+import { Badge } from "@/components/Badge";
 import { LoadingSkeleton } from "@/components/loading-skeleton";
 import type { ExecutionRecord, ImportRecord } from "@/types/api";
 
@@ -45,6 +46,8 @@ const defaultFilters: ExecutionFilters = {
   dateTo: "",
 };
 
+const SHOW_ALL_STORAGE_KEY = "kapman_table_executions_showAll";
+
 function sortExecutionRows(rows: ExecutionRecord[], column: SortColumn, direction: SortDirection): ExecutionRecord[] {
   const sorted = [...rows].sort((left, right) => {
     if (column === "eventTimestamp") {
@@ -78,11 +81,20 @@ export function ExecutionsTablePanel() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [page, setPage] = useState(1);
-  const [meta, setMeta] = useState({ total: 0, page: 1, pageSize: 50 });
+  const [meta, setMeta] = useState({ total: 0, page: 1, pageSize: 25 });
+  const [showAll, setShowAll] = useState(false);
   const [draftFilters, setDraftFilters] = useState<ExecutionFilters>(defaultFilters);
   const [appliedFilters, setAppliedFilters] = useState<ExecutionFilters>(defaultFilters);
   const [sortColumn, setSortColumn] = useState<SortColumn>("eventTimestamp");
   const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
+
+  useEffect(() => {
+    try {
+      setShowAll(window.localStorage.getItem(SHOW_ALL_STORAGE_KEY) === "1");
+    } catch {
+      setShowAll(false);
+    }
+  }, []);
 
   useEffect(() => {
     if (initializedFromSearch.current) {
@@ -123,8 +135,8 @@ export function ExecutionsTablePanel() {
       setError(null);
 
       const query = new URLSearchParams({
-        page: String(page),
-        pageSize: String(meta.pageSize),
+        page: String(showAll ? 1 : page),
+        pageSize: String(showAll ? 1000 : 25),
       });
 
       if (appliedFilters.symbol.trim()) {
@@ -161,7 +173,7 @@ export function ExecutionsTablePanel() {
     }
 
     void loadExecutions();
-  }, [appliedFilters, page, meta.pageSize]);
+  }, [appliedFilters, page, showAll]);
 
   const accountOptions = useMemo(() => {
     return Array.from(new Set(imports.map((entry) => entry.accountId))).sort();
@@ -200,6 +212,17 @@ export function ExecutionsTablePanel() {
   const hasRows = sortedRows.length > 0;
   const canGoBack = meta.page > 1;
   const canGoForward = meta.page * meta.pageSize < meta.total;
+
+  function toggleShowAll() {
+    const next = !showAll;
+    setShowAll(next);
+    setPage(1);
+    try {
+      window.localStorage.setItem(SHOW_ALL_STORAGE_KEY, next ? "1" : "0");
+    } catch {
+      // Ignore localStorage errors.
+    }
+  }
 
   return (
     <section className="space-y-4 rounded-2xl border border-slate-700 bg-slate-900/40 p-6">
@@ -276,6 +299,9 @@ export function ExecutionsTablePanel() {
         >
           Reset
         </button>
+        <button type="button" onClick={toggleShowAll} className="rounded-lg border border-slate-600 bg-slate-900 px-4 py-2 text-sm text-slate-200">
+          {showAll ? "Show pages" : `Show all ${meta.total}`}
+        </button>
       </div>
 
       {loading ? <LoadingSkeleton lines={6} /> : null}
@@ -293,7 +319,10 @@ export function ExecutionsTablePanel() {
 
       {!loading && !error && hasRows ? (
         <div className="space-y-3">
-          <div className="overflow-auto rounded border border-slate-700">
+          <div
+            className={showAll ? "overflow-y-auto rounded border border-slate-700" : "overflow-auto rounded border border-slate-700"}
+            style={showAll ? { maxHeight: "calc(100vh - 280px)" } : undefined}
+          >
             <table className="min-w-full text-xs">
               <thead className="bg-slate-900 text-slate-300">
                 <tr>
@@ -332,13 +361,32 @@ export function ExecutionsTablePanel() {
                     <td className="px-2 py-2">{new Date(row.eventTimestamp).toLocaleString()}</td>
                     <td className="px-2 py-2">{row.tradeDate.slice(0, 10)}</td>
                     <td className="px-2 py-2">{row.symbol}</td>
-                    <td className="px-2 py-2">{row.side ?? "-"}</td>
+                    <td className="px-2 py-2">
+                      {row.side === "BUY" ? <Badge variant="buy">BUY</Badge> : row.side === "SELL" ? <Badge variant="sell">SELL</Badge> : "-"}
+                    </td>
                     <td className="px-2 py-2 text-right">{row.quantity}</td>
                     <td className="px-2 py-2 text-right">{row.price ?? "~"}</td>
                     <td className="px-2 py-2">{row.eventType}</td>
-                    <td className="px-2 py-2">{row.openingClosingEffect ?? "UNKNOWN"}</td>
                     <td className="px-2 py-2">
-                      {row.optionType ? `${row.optionType} ${row.strike ?? "-"} ${row.expirationDate?.slice(0, 10) ?? "-"}` : "-"}
+                      {row.openingClosingEffect === "TO_OPEN" ? (
+                        <Badge variant="to-open">TO_OPEN</Badge>
+                      ) : row.openingClosingEffect === "TO_CLOSE" ? (
+                        <Badge variant="to-close">TO_CLOSE</Badge>
+                      ) : (
+                        "UNKNOWN"
+                      )}
+                    </td>
+                    <td className="px-2 py-2">
+                      {row.optionType ? (
+                        <span className="inline-flex items-center gap-1">
+                          <Badge variant={row.optionType === "PUT" ? "put" : "call"}>{row.optionType}</Badge>
+                          <span className="font-mono">
+                            {row.strike ?? "-"} {row.expirationDate?.slice(0, 10) ?? "-"}
+                          </span>
+                        </span>
+                      ) : (
+                        "-"
+                      )}
                     </td>
                     <td className="px-2 py-2">{row.accountId}</td>
                     <td className="px-2 py-2">
@@ -352,29 +400,33 @@ export function ExecutionsTablePanel() {
             </table>
           </div>
 
-          <div className="flex items-center justify-between text-xs text-slate-300">
-            <p>
-              Showing page {meta.page} of {Math.max(1, Math.ceil(meta.total / meta.pageSize))} ({meta.total} rows)
-            </p>
-            <div className="flex items-center gap-2">
-              <button
-                type="button"
-                disabled={!canGoBack}
-                onClick={() => setPage((current) => Math.max(1, current - 1))}
-                className="rounded border border-slate-600 px-2 py-1 disabled:opacity-50"
-              >
-                Prev
-              </button>
-              <button
-                type="button"
-                disabled={!canGoForward}
-                onClick={() => setPage((current) => current + 1)}
-                className="rounded border border-slate-600 px-2 py-1 disabled:opacity-50"
-              >
-                Next
-              </button>
+          {showAll ? (
+            <p className="text-xs text-slate-300">Showing all {meta.total} records</p>
+          ) : (
+            <div className="flex items-center justify-between text-xs text-slate-300">
+              <p>
+                Showing page {meta.page} of {Math.max(1, Math.ceil(meta.total / meta.pageSize))} ({meta.total} rows)
+              </p>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  disabled={!canGoBack}
+                  onClick={() => setPage((current) => Math.max(1, current - 1))}
+                  className="rounded border border-slate-600 px-2 py-1 disabled:opacity-50"
+                >
+                  Prev
+                </button>
+                <button
+                  type="button"
+                  disabled={!canGoForward}
+                  onClick={() => setPage((current) => current + 1)}
+                  className="rounded border border-slate-600 px-2 py-1 disabled:opacity-50"
+                >
+                  Next
+                </button>
+              </div>
             </div>
-          </div>
+          )}
         </div>
       ) : null}
     </section>

--- a/src/components/imports-workflow-panel.tsx
+++ b/src/components/imports-workflow-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { LoadingSkeleton } from "@/components/loading-skeleton";
 import type { CommitImportResponse, ImportRecord, UploadImportResponse } from "@/types/api";
 
@@ -21,37 +21,59 @@ interface UploadPayload {
   data: UploadImportResponse;
 }
 
-export function ImportsWorkflowPanel() {
+interface ImportsWorkflowPanelProps {
+  mode?: "all" | "upload" | "history";
+}
+
+const SHOW_ALL_STORAGE_KEY = "kapman_table_imports_showAll";
+
+export function ImportsWorkflowPanel({ mode = "all" }: ImportsWorkflowPanelProps) {
+  const showUpload = mode !== "history";
+  const showHistory = mode !== "upload";
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [uploading, setUploading] = useState(false);
   const [uploadProgress, setUploadProgress] = useState(0);
   const [uploadResult, setUploadResult] = useState<UploadImportResponse | null>(null);
   const [commitResult, setCommitResult] = useState<CommitImportResponse | null>(null);
   const [history, setHistory] = useState<ImportRecord[]>([]);
+  const [historyMeta, setHistoryMeta] = useState({ total: 0, page: 1, pageSize: 25 });
+  const [historyPage, setHistoryPage] = useState(1);
+  const [showAllHistory, setShowAllHistory] = useState(false);
   const [historyLoading, setHistoryLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [accountFilter, setAccountFilter] = useState("");
 
   const canCommit = Boolean(uploadResult && !uploading);
 
-  async function loadHistory(accountId = "") {
+  const loadHistory = useCallback(async (accountId = "", page = historyPage) => {
     setHistoryLoading(true);
 
     const searchParams = new URLSearchParams();
     if (accountId.trim()) {
       searchParams.set("account", accountId.trim());
     }
+    searchParams.set("page", String(showAllHistory ? 1 : page));
+    searchParams.set("pageSize", String(showAllHistory ? 1000 : 25));
 
     const query = searchParams.toString();
     const response = await fetch(`/api/imports${query ? `?${query}` : ""}`, { cache: "no-store" });
     const payload = (await response.json()) as ImportsListPayload;
     setHistory(payload.data);
+    setHistoryMeta(payload.meta);
     setHistoryLoading(false);
-  }
+  }, [historyPage, showAllHistory]);
 
   useEffect(() => {
-    void loadHistory();
+    try {
+      setShowAllHistory(window.localStorage.getItem(SHOW_ALL_STORAGE_KEY) === "1");
+    } catch {
+      setShowAllHistory(false);
+    }
   }, []);
+
+  useEffect(() => {
+    void loadHistory(accountFilter, historyPage);
+  }, [accountFilter, historyPage, loadHistory]);
 
   async function handleUpload() {
     if (!selectedFile) {
@@ -134,6 +156,25 @@ export function ImportsWorkflowPanel() {
     return `${commitResult.parsedRows} parsed · ${commitResult.inserted} inserted · ${commitResult.skipped_duplicate} skipped duplicate · ${commitResult.failed} failed`;
   }, [commitResult]);
 
+  const canGoBack = historyMeta.page > 1;
+  const canGoForward = historyMeta.page * historyMeta.pageSize < historyMeta.total;
+
+  function applyHistoryFilter() {
+    setHistoryPage(1);
+    void loadHistory(accountFilter, 1);
+  }
+
+  function toggleShowAllHistory() {
+    const next = !showAllHistory;
+    setShowAllHistory(next);
+    setHistoryPage(1);
+    try {
+      window.localStorage.setItem(SHOW_ALL_STORAGE_KEY, next ? "1" : "0");
+    } catch {
+      // Ignore localStorage errors.
+    }
+  }
+
   return (
     <section className="space-y-6 rounded-2xl border border-slate-700 bg-slate-900/40 p-6">
       <header className="space-y-1">
@@ -141,159 +182,202 @@ export function ImportsWorkflowPanel() {
         <p className="text-sm text-slate-300">Upload, detect, preview, and commit a broker statement into canonical T1 executions.</p>
       </header>
 
-      <div className="grid gap-3 lg:grid-cols-[1fr_auto]">
-        <input
-          type="file"
-          accept=".csv,text/csv"
-          onChange={(event) => setSelectedFile(event.target.files?.[0] ?? null)}
-          className="w-full rounded-lg border border-slate-600 bg-slate-950/60 px-3 py-2 text-sm text-slate-100"
-        />
-        <button
-          type="button"
-          onClick={handleUpload}
-          disabled={!selectedFile || uploading}
-          className="rounded-lg border border-blue-400/40 bg-blue-500/20 px-4 py-2 text-sm text-blue-100 disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          {uploading ? "Uploading..." : "Upload Statement"}
-        </button>
-      </div>
-
-      {(uploading || uploadProgress > 0) && (
-        <div>
-          <p className="mb-1 text-xs text-slate-300">Upload progress: {uploadProgress}%</p>
-          <div className="h-2 rounded-full bg-slate-800">
-            <div className="h-2 rounded-full bg-blue-400" style={{ width: `${uploadProgress}%` }} />
-          </div>
-        </div>
-      )}
-
-      {uploadResult && (
-        <div className="space-y-4 rounded-xl border border-slate-700/80 bg-slate-950/60 p-4">
-          <div>
-            <p className="text-sm font-medium text-slate-100">Detection Result</p>
-            <p className="mt-1 text-xs text-slate-300">
-              Adapter: {uploadResult.detection.adapterId} · Confidence: {uploadResult.detection.confidence} · Format: {uploadResult.detection.formatVersion}
-            </p>
+      {showUpload ? (
+        <>
+          <div className="grid gap-3 lg:grid-cols-[1fr_auto]">
+            <input
+              type="file"
+              accept=".csv,text/csv"
+              onChange={(event) => setSelectedFile(event.target.files?.[0] ?? null)}
+              className="w-full rounded-lg border border-slate-600 bg-slate-950/60 px-3 py-2 text-sm text-slate-100"
+            />
+            <button
+              type="button"
+              onClick={handleUpload}
+              disabled={!selectedFile || uploading}
+              className="rounded-lg border border-blue-400/40 bg-blue-500/20 px-4 py-2 text-sm text-blue-100 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {uploading ? "Uploading..." : "Upload Statement"}
+            </button>
           </div>
 
-          <div>
-            <p className="text-sm font-medium text-slate-100">Parse Preview (first 10 rows)</p>
-            <div className="mt-2 overflow-auto rounded border border-slate-700">
+          {(uploading || uploadProgress > 0) && (
+            <div>
+              <p className="mb-1 text-xs text-slate-300">Upload progress: {uploadProgress}%</p>
+              <div className="h-2 rounded-full bg-slate-800">
+                <div className="h-2 rounded-full bg-blue-400" style={{ width: `${uploadProgress}%` }} />
+              </div>
+            </div>
+          )}
+
+          {uploadResult && (
+            <div className="space-y-4 rounded-xl border border-slate-700/80 bg-slate-950/60 p-4">
+              <div>
+                <p className="text-sm font-medium text-slate-100">Detection Result</p>
+                <p className="mt-1 text-xs text-slate-300">
+                  Adapter: {uploadResult.detection.adapterId} · Confidence: {uploadResult.detection.confidence} · Format:{" "}
+                  {uploadResult.detection.formatVersion}
+                </p>
+              </div>
+
+              <div>
+                <p className="text-sm font-medium text-slate-100">Parse Preview (first 10 rows)</p>
+                <div className="mt-2 overflow-auto rounded border border-slate-700">
+                  <table className="min-w-full text-xs">
+                    <thead className="bg-slate-900 text-slate-300">
+                      <tr>
+                        <th className="px-2 py-2 text-left">Timestamp</th>
+                        <th className="px-2 py-2 text-left">Symbol</th>
+                        <th className="px-2 py-2 text-left">Side</th>
+                        <th className="px-2 py-2 text-right">Qty</th>
+                        <th className="px-2 py-2 text-right">Price</th>
+                        <th className="px-2 py-2 text-left">Spread</th>
+                        <th className="px-2 py-2 text-left">Effect</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {uploadResult.previewRows.map((row, index) => (
+                        <tr key={`${row.eventTimestamp}-${index}`} className="border-t border-slate-800 text-slate-200">
+                          <td className="px-2 py-2">{row.eventTimestamp}</td>
+                          <td className="px-2 py-2">{row.symbol}</td>
+                          <td className="px-2 py-2">{row.side}</td>
+                          <td className="px-2 py-2 text-right">{row.quantity}</td>
+                          <td className="px-2 py-2 text-right">{row.price ?? "~"}</td>
+                          <td className="px-2 py-2">{row.spread}</td>
+                          <td className="px-2 py-2">{row.openingClosingEffect}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+
+              <div className="flex items-center gap-3">
+                <button
+                  type="button"
+                  onClick={handleCommit}
+                  disabled={!canCommit}
+                  className="rounded-lg border border-emerald-400/40 bg-emerald-500/20 px-4 py-2 text-sm text-emerald-100 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  Commit Import
+                </button>
+                {commitSummary && <p className="text-xs text-slate-200">{commitSummary}</p>}
+              </div>
+
+              {commitResult?.warnings.length ? (
+                <ul className="list-disc space-y-1 pl-4 text-xs text-amber-200">
+                  {commitResult.warnings.map((warning) => (
+                    <li key={warning}>{warning}</li>
+                  ))}
+                </ul>
+              ) : null}
+            </div>
+          )}
+        </>
+      ) : null}
+
+      {error && <p className="text-sm text-red-200">{error}</p>}
+
+      {showHistory ? (
+        <div className="space-y-3">
+          <div className="flex flex-wrap items-center gap-3">
+            <h3 className="text-lg font-semibold text-slate-100">Import History</h3>
+            <input
+              type="text"
+              value={accountFilter}
+              onChange={(event) => setAccountFilter(event.target.value)}
+              placeholder="Filter by account id"
+              className="w-56 rounded-lg border border-slate-700 bg-slate-950/60 px-3 py-2 text-xs text-slate-100"
+            />
+            <button
+              type="button"
+              onClick={applyHistoryFilter}
+              className="rounded-lg border border-slate-600 bg-slate-900 px-3 py-2 text-xs text-slate-200"
+            >
+              Apply
+            </button>
+            <button type="button" onClick={toggleShowAllHistory} className="rounded-lg border border-slate-600 bg-slate-900 px-3 py-2 text-xs text-slate-200">
+              {showAllHistory ? "Show pages" : `Show all ${historyMeta.total}`}
+            </button>
+          </div>
+
+        {historyLoading ? (
+          <LoadingSkeleton lines={4} />
+        ) : (
+          <div className="space-y-2">
+            <div
+              className={showAllHistory ? "overflow-y-auto rounded border border-slate-700" : "overflow-auto rounded border border-slate-700"}
+              style={showAllHistory ? { maxHeight: "calc(100vh - 280px)" } : undefined}
+            >
               <table className="min-w-full text-xs">
                 <thead className="bg-slate-900 text-slate-300">
                   <tr>
-                    <th className="px-2 py-2 text-left">Timestamp</th>
-                    <th className="px-2 py-2 text-left">Symbol</th>
-                    <th className="px-2 py-2 text-left">Side</th>
-                    <th className="px-2 py-2 text-right">Qty</th>
-                    <th className="px-2 py-2 text-right">Price</th>
-                    <th className="px-2 py-2 text-left">Spread</th>
-                    <th className="px-2 py-2 text-left">Effect</th>
+                    <th className="px-2 py-2 text-left">Imported At</th>
+                    <th className="px-2 py-2 text-left">Filename</th>
+                    <th className="px-2 py-2 text-left">Broker</th>
+                    <th className="px-2 py-2 text-left">Account</th>
+                    <th className="px-2 py-2 text-left">Status</th>
+                    <th className="px-2 py-2 text-right">Parsed</th>
+                    <th className="px-2 py-2 text-right">Inserted</th>
+                    <th className="px-2 py-2 text-right">Skipped Duplicate</th>
+                    <th className="px-2 py-2 text-right">Failed</th>
+                    <th className="px-2 py-2 text-left">Link</th>
                   </tr>
                 </thead>
                 <tbody>
-                  {uploadResult.previewRows.map((row, index) => (
-                    <tr key={`${row.eventTimestamp}-${index}`} className="border-t border-slate-800 text-slate-200">
-                      <td className="px-2 py-2">{row.eventTimestamp}</td>
-                      <td className="px-2 py-2">{row.symbol}</td>
-                      <td className="px-2 py-2">{row.side}</td>
-                      <td className="px-2 py-2 text-right">{row.quantity}</td>
-                      <td className="px-2 py-2 text-right">{row.price ?? "~"}</td>
-                      <td className="px-2 py-2">{row.spread}</td>
-                      <td className="px-2 py-2">{row.openingClosingEffect}</td>
+                  {history.map((row) => (
+                    <tr key={row.id} className="border-t border-slate-800 text-slate-200">
+                      <td className="px-2 py-2">{new Date(row.createdAt).toLocaleString()}</td>
+                      <td className="px-2 py-2">{row.filename}</td>
+                      <td className="px-2 py-2">{row.broker}</td>
+                      <td className="px-2 py-2">{row.accountId}</td>
+                      <td className="px-2 py-2">{row.status}</td>
+                      <td className="px-2 py-2 text-right">{row.parsedRows}</td>
+                      <td className="px-2 py-2 text-right">{row.inserted}</td>
+                      <td className="px-2 py-2 text-right">{row.skipped_duplicate}</td>
+                      <td className="px-2 py-2 text-right">{row.failed}</td>
+                      <td className="px-2 py-2">
+                        <a href={`/trade-records?tab=executions&import=${row.id}&account=${row.accountId}`} className="text-blue-300 underline">
+                          View executions
+                        </a>
+                      </td>
                     </tr>
                   ))}
                 </tbody>
               </table>
             </div>
-          </div>
 
-          <div className="flex items-center gap-3">
-            <button
-              type="button"
-              onClick={handleCommit}
-              disabled={!canCommit}
-              className="rounded-lg border border-emerald-400/40 bg-emerald-500/20 px-4 py-2 text-sm text-emerald-100 disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              Commit Import
-            </button>
-            {commitSummary && <p className="text-xs text-slate-200">{commitSummary}</p>}
-          </div>
-
-          {commitResult?.warnings.length ? (
-            <ul className="list-disc space-y-1 pl-4 text-xs text-amber-200">
-              {commitResult.warnings.map((warning) => (
-                <li key={warning}>{warning}</li>
-              ))}
-            </ul>
-          ) : null}
-        </div>
-      )}
-
-      {error && <p className="text-sm text-red-200">{error}</p>}
-
-      <div className="space-y-3">
-        <div className="flex items-center gap-3">
-          <h3 className="text-lg font-semibold text-slate-100">Import History</h3>
-          <input
-            type="text"
-            value={accountFilter}
-            onChange={(event) => setAccountFilter(event.target.value)}
-            placeholder="Filter by account id"
-            className="w-56 rounded-lg border border-slate-700 bg-slate-950/60 px-3 py-2 text-xs text-slate-100"
-          />
-          <button
-            type="button"
-            onClick={() => void loadHistory(accountFilter)}
-            className="rounded-lg border border-slate-600 bg-slate-900 px-3 py-2 text-xs text-slate-200"
-          >
-            Apply
-          </button>
-        </div>
-
-        {historyLoading ? (
-          <LoadingSkeleton lines={4} />
-        ) : (
-          <div className="overflow-auto rounded border border-slate-700">
-            <table className="min-w-full text-xs">
-              <thead className="bg-slate-900 text-slate-300">
-                <tr>
-                  <th className="px-2 py-2 text-left">Imported At</th>
-                  <th className="px-2 py-2 text-left">Filename</th>
-                  <th className="px-2 py-2 text-left">Broker</th>
-                  <th className="px-2 py-2 text-left">Account</th>
-                  <th className="px-2 py-2 text-left">Status</th>
-                  <th className="px-2 py-2 text-right">Parsed</th>
-                  <th className="px-2 py-2 text-right">Inserted</th>
-                  <th className="px-2 py-2 text-right">Skipped Duplicate</th>
-                  <th className="px-2 py-2 text-right">Failed</th>
-                  <th className="px-2 py-2 text-left">Link</th>
-                </tr>
-              </thead>
-              <tbody>
-                {history.map((row) => (
-                  <tr key={row.id} className="border-t border-slate-800 text-slate-200">
-                    <td className="px-2 py-2">{new Date(row.createdAt).toLocaleString()}</td>
-                    <td className="px-2 py-2">{row.filename}</td>
-                    <td className="px-2 py-2">{row.broker}</td>
-                    <td className="px-2 py-2">{row.accountId}</td>
-                    <td className="px-2 py-2">{row.status}</td>
-                    <td className="px-2 py-2 text-right">{row.parsedRows}</td>
-                    <td className="px-2 py-2 text-right">{row.inserted}</td>
-                    <td className="px-2 py-2 text-right">{row.skipped_duplicate}</td>
-                    <td className="px-2 py-2 text-right">{row.failed}</td>
-                    <td className="px-2 py-2">
-                      <a href={`/executions?import=${row.id}&account=${row.accountId}`} className="text-blue-300 underline">
-                        View executions
-                      </a>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+            {showAllHistory ? (
+              <p className="text-xs text-slate-300">Showing all {historyMeta.total} records</p>
+            ) : (
+              <div className="flex items-center justify-between text-xs text-slate-300">
+                <p>
+                  Showing page {historyMeta.page} of {Math.max(1, Math.ceil(historyMeta.total / historyMeta.pageSize))} ({historyMeta.total} rows)
+                </p>
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    disabled={!canGoBack}
+                    onClick={() => setHistoryPage((current) => Math.max(1, current - 1))}
+                    className="rounded border border-slate-600 px-2 py-1 disabled:opacity-50"
+                  >
+                    Prev
+                  </button>
+                  <button
+                    type="button"
+                    disabled={!canGoForward}
+                    onClick={() => setHistoryPage((current) => current + 1)}
+                    className="rounded border border-slate-600 px-2 py-1 disabled:opacity-50"
+                  >
+                    Next
+                  </button>
+                </div>
+              </div>
+            )}
           </div>
         )}
       </div>
+      ) : null}
     </section>
   );
 }

--- a/src/components/matched-lots-table-panel.tsx
+++ b/src/components/matched-lots-table-panel.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
+import { Badge } from "@/components/Badge";
 import { LoadingSkeleton } from "@/components/loading-skeleton";
 import type { ImportRecord, MatchedLotRecord } from "@/types/api";
 
@@ -44,6 +45,8 @@ const defaultFilters: MatchedLotFilters = {
   dateTo: "",
 };
 
+const SHOW_ALL_STORAGE_KEY = "kapman_table_matched-lots_showAll";
+
 function sortMatchedLots(rows: MatchedLotRecord[], column: SortColumn, direction: SortDirection): MatchedLotRecord[] {
   const sorted = [...rows].sort((left, right) => {
     if (column === "closeTradeDate") {
@@ -74,11 +77,20 @@ export function MatchedLotsTablePanel() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [page, setPage] = useState(1);
-  const [meta, setMeta] = useState({ total: 0, page: 1, pageSize: 50 });
+  const [meta, setMeta] = useState({ total: 0, page: 1, pageSize: 25 });
+  const [showAll, setShowAll] = useState(false);
   const [draftFilters, setDraftFilters] = useState<MatchedLotFilters>(defaultFilters);
   const [appliedFilters, setAppliedFilters] = useState<MatchedLotFilters>(defaultFilters);
   const [sortColumn, setSortColumn] = useState<SortColumn>("closeTradeDate");
   const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
+
+  useEffect(() => {
+    try {
+      setShowAll(window.localStorage.getItem(SHOW_ALL_STORAGE_KEY) === "1");
+    } catch {
+      setShowAll(false);
+    }
+  }, []);
 
   useEffect(() => {
     async function loadImports() {
@@ -100,8 +112,8 @@ export function MatchedLotsTablePanel() {
       setError(null);
 
       const query = new URLSearchParams({
-        page: String(page),
-        pageSize: String(meta.pageSize),
+        page: String(showAll ? 1 : page),
+        pageSize: String(showAll ? 1000 : 25),
       });
 
       if (appliedFilters.symbol.trim()) {
@@ -138,7 +150,7 @@ export function MatchedLotsTablePanel() {
     }
 
     void loadMatchedLots();
-  }, [appliedFilters, page, meta.pageSize]);
+  }, [appliedFilters, page, showAll]);
 
   const accountOptions = useMemo(() => {
     return Array.from(new Set(imports.map((entry) => entry.accountId))).sort();
@@ -177,6 +189,17 @@ export function MatchedLotsTablePanel() {
   const hasRows = sortedRows.length > 0;
   const canGoBack = meta.page > 1;
   const canGoForward = meta.page * meta.pageSize < meta.total;
+
+  function toggleShowAll() {
+    const next = !showAll;
+    setShowAll(next);
+    setPage(1);
+    try {
+      window.localStorage.setItem(SHOW_ALL_STORAGE_KEY, next ? "1" : "0");
+    } catch {
+      // Ignore localStorage errors.
+    }
+  }
 
   return (
     <section className="space-y-4 rounded-2xl border border-slate-700 bg-slate-900/40 p-6">
@@ -256,6 +279,9 @@ export function MatchedLotsTablePanel() {
         >
           Reset
         </button>
+        <button type="button" onClick={toggleShowAll} className="rounded-lg border border-slate-600 bg-slate-900 px-4 py-2 text-sm text-slate-200">
+          {showAll ? "Show pages" : `Show all ${meta.total}`}
+        </button>
       </div>
 
       {loading ? <LoadingSkeleton lines={6} /> : null}
@@ -273,7 +299,10 @@ export function MatchedLotsTablePanel() {
 
       {!loading && !error && hasRows ? (
         <div className="space-y-3">
-          <div className="overflow-auto rounded border border-slate-700">
+          <div
+            className={showAll ? "overflow-y-auto rounded border border-slate-700" : "overflow-auto rounded border border-slate-700"}
+            style={showAll ? { maxHeight: "calc(100vh - 280px)" } : undefined}
+          >
             <table className="min-w-full text-xs">
               <thead className="bg-slate-900 text-slate-300">
                 <tr>
@@ -313,7 +342,15 @@ export function MatchedLotsTablePanel() {
                       {row.realizedPnl}
                     </td>
                     <td className="px-2 py-2 text-right">{row.holdingDays}</td>
-                    <td className="px-2 py-2">{row.outcome}</td>
+                    <td className="px-2 py-2">
+                      {row.outcome === "WIN" ? (
+                        <Badge variant="win">WIN</Badge>
+                      ) : row.outcome === "LOSS" ? (
+                        <Badge variant="loss">LOSS</Badge>
+                      ) : (
+                        <Badge variant="flat">FLAT</Badge>
+                      )}
+                    </td>
                     <td className="px-2 py-2">
                       <Link href={`/executions?execution=${row.openExecutionId}&account=${row.accountId}`} className="text-blue-300 underline">
                         {row.openExecutionId.slice(0, 8)}...
@@ -334,29 +371,33 @@ export function MatchedLotsTablePanel() {
             </table>
           </div>
 
-          <div className="flex items-center justify-between text-xs text-slate-300">
-            <p>
-              Showing page {meta.page} of {Math.max(1, Math.ceil(meta.total / meta.pageSize))} ({meta.total} rows)
-            </p>
-            <div className="flex items-center gap-2">
-              <button
-                type="button"
-                disabled={!canGoBack}
-                onClick={() => setPage((current) => Math.max(1, current - 1))}
-                className="rounded border border-slate-600 px-2 py-1 disabled:opacity-50"
-              >
-                Prev
-              </button>
-              <button
-                type="button"
-                disabled={!canGoForward}
-                onClick={() => setPage((current) => current + 1)}
-                className="rounded border border-slate-600 px-2 py-1 disabled:opacity-50"
-              >
-                Next
-              </button>
+          {showAll ? (
+            <p className="text-xs text-slate-300">Showing all {meta.total} records</p>
+          ) : (
+            <div className="flex items-center justify-between text-xs text-slate-300">
+              <p>
+                Showing page {meta.page} of {Math.max(1, Math.ceil(meta.total / meta.pageSize))} ({meta.total} rows)
+              </p>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  disabled={!canGoBack}
+                  onClick={() => setPage((current) => Math.max(1, current - 1))}
+                  className="rounded border border-slate-600 px-2 py-1 disabled:opacity-50"
+                >
+                  Prev
+                </button>
+                <button
+                  type="button"
+                  disabled={!canGoForward}
+                  onClick={() => setPage((current) => current + 1)}
+                  className="rounded border border-slate-600 px-2 py-1 disabled:opacity-50"
+                >
+                  Next
+                </button>
+              </div>
             </div>
-          </div>
+          )}
         </div>
       ) : null}
     </section>

--- a/src/components/overview-dashboard-panel.tsx
+++ b/src/components/overview-dashboard-panel.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
+import { KpiCard } from "@/components/KpiCard";
 import { LoadingSkeleton } from "@/components/loading-skeleton";
 import type { OverviewSummaryResponse } from "@/types/api";
 
@@ -66,26 +67,11 @@ export function OverviewDashboardPanel() {
       {!loading && !error && data && hasData ? (
         <div className="space-y-4">
           <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
-            <div className="rounded-lg border border-slate-700 bg-slate-950/50 p-3">
-              <p className="text-xs text-slate-400">Net P&L</p>
-              <p className={`text-lg font-semibold ${Number(data.netPnl) >= 0 ? "text-emerald-300" : "text-red-300"}`}>{data.netPnl}</p>
-            </div>
-            <div className="rounded-lg border border-slate-700 bg-slate-950/50 p-3">
-              <p className="text-xs text-slate-400">Executions</p>
-              <p className="text-lg font-semibold text-slate-100">{data.executionCount}</p>
-            </div>
-            <div className="rounded-lg border border-slate-700 bg-slate-950/50 p-3">
-              <p className="text-xs text-slate-400">Matched Lots</p>
-              <p className="text-lg font-semibold text-slate-100">{data.matchedLotCount}</p>
-            </div>
-            <div className="rounded-lg border border-slate-700 bg-slate-950/50 p-3">
-              <p className="text-xs text-slate-400">Setup Groups</p>
-              <p className="text-lg font-semibold text-slate-100">{data.setupCount}</p>
-            </div>
-            <div className="rounded-lg border border-slate-700 bg-slate-950/50 p-3">
-              <p className="text-xs text-slate-400">Average Hold Days</p>
-              <p className="text-lg font-semibold text-slate-100">{data.averageHoldDays}</p>
-            </div>
+            <KpiCard label="Net P&L" value={data.netPnl} colorVariant={Number(data.netPnl) >= 0 ? "pos" : "neg"} />
+            <KpiCard label="Executions" value={data.executionCount} colorVariant="accent" />
+            <KpiCard label="Matched Lots" value={data.matchedLotCount} colorVariant="accent" />
+            <KpiCard label="Setup Groups" value={data.setupCount} colorVariant="accent" />
+            <KpiCard label="Average Hold Days" value={data.averageHoldDays} colorVariant="neutral" />
           </div>
 
           <div className="grid gap-4 lg:grid-cols-2">

--- a/src/components/root-shell.tsx
+++ b/src/components/root-shell.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useMemo } from "react";
+import { usePathname } from "next/navigation";
+import { AccountSelector } from "@/components/account-selector";
+import { SidebarNav } from "@/components/sidebar-nav";
+import { AccountFilterContextProvider } from "@/contexts/AccountFilterContext";
+import { getRouteTitle, getTopbarContextTags } from "@/lib/navigation";
+
+export function RootShell({ children }: { children: React.ReactNode }) {
+  return (
+    <AccountFilterContextProvider>
+      <ShellContent>{children}</ShellContent>
+    </AccountFilterContextProvider>
+  );
+}
+
+function ShellContent({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const title = useMemo(() => getRouteTitle(pathname), [pathname]);
+  const tags = useMemo(() => getTopbarContextTags(pathname), [pathname]);
+
+  return (
+    <div className="grid min-h-screen grid-cols-1 lg:grid-cols-[220px_1fr]">
+      <aside className="border-b border-border px-4 py-5 lg:border-b-0 lg:border-r" style={{ backgroundColor: "var(--sidebar-bg)" }}>
+        <div className="mb-4 flex items-center gap-3">
+          <div className="inline-flex h-9 w-9 items-center justify-center rounded-lg bg-accent-2 text-xs font-bold text-bg">KM</div>
+          <div>
+            <p className="text-xs font-semibold text-text">KapMan Trading Journal</p>
+            <p className="text-[10px] text-muted">v7.0</p>
+          </div>
+        </div>
+        <SidebarNav />
+      </aside>
+
+      <div className="min-w-0">
+        <header
+          className="flex h-11 items-center justify-between border-b border-border px-4"
+          style={{ backgroundColor: "rgba(18, 25, 51, 0.9)" }}
+        >
+          <div className="flex items-center gap-2">
+            <p className="text-xs font-bold text-text">{title}</p>
+            <div className="flex items-center gap-1">
+              {tags.map((tag) => (
+                <span key={tag} className="rounded-full bg-panel-2 px-2 py-0.5 text-[10px] text-muted">
+                  {tag}
+                </span>
+              ))}
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <AccountSelector />
+            <button
+              type="button"
+              onClick={() => window.location.reload()}
+              className="rounded-md border border-border bg-panel px-2 py-1 text-[11px] text-muted"
+            >
+              Refresh
+            </button>
+          </div>
+        </header>
+
+        <main className="p-5 lg:p-7">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/src/components/setups-analytics-panel.tsx
+++ b/src/components/setups-analytics-panel.tsx
@@ -53,14 +53,17 @@ const tagOptions = [
   "uncategorized",
 ];
 
+const SHOW_ALL_STORAGE_KEY = "kapman_table_setups_showAll";
+
 export function SetupsAnalyticsPanel() {
   const pathname = usePathname();
   const router = useRouter();
   const searchParams = useSearchParams();
   const [imports, setImports] = useState<ImportRecord[]>([]);
   const [rows, setRows] = useState<SetupSummaryRecord[]>([]);
-  const [meta, setMeta] = useState({ total: 0, page: 1, pageSize: 50 });
+  const [meta, setMeta] = useState({ total: 0, page: 1, pageSize: 25 });
   const [page, setPage] = useState(1);
+  const [showAll, setShowAll] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [draftFilters, setDraftFilters] = useState<SetupFilters>(defaultFilters);
@@ -70,6 +73,14 @@ export function SetupsAnalyticsPanel() {
   const [detail, setDetail] = useState<SetupDetailResponse | null>(null);
   const [detailLoading, setDetailLoading] = useState(false);
   const [detailError, setDetailError] = useState<string | null>(null);
+
+  useEffect(() => {
+    try {
+      setShowAll(window.localStorage.getItem(SHOW_ALL_STORAGE_KEY) === "1");
+    } catch {
+      setShowAll(false);
+    }
+  }, []);
 
   useEffect(() => {
     const setupFromQuery = searchParams.get("setup");
@@ -96,8 +107,8 @@ export function SetupsAnalyticsPanel() {
       setError(null);
 
       const query = new URLSearchParams({
-        page: String(page),
-        pageSize: String(meta.pageSize),
+        page: String(showAll ? 1 : page),
+        pageSize: String(showAll ? 1000 : 25),
       });
 
       if (appliedFilters.account.trim()) {
@@ -122,7 +133,7 @@ export function SetupsAnalyticsPanel() {
     }
 
     void loadSetups();
-  }, [appliedFilters, page, meta.pageSize]);
+  }, [appliedFilters, page, showAll]);
 
   useEffect(() => {
     async function loadSetupDetail() {
@@ -187,6 +198,17 @@ export function SetupsAnalyticsPanel() {
   const hasRows = rows.length > 0;
   const canGoBack = meta.page > 1;
   const canGoForward = meta.page * meta.pageSize < meta.total;
+
+  function toggleShowAll() {
+    const next = !showAll;
+    setShowAll(next);
+    setPage(1);
+    try {
+      window.localStorage.setItem(SHOW_ALL_STORAGE_KEY, next ? "1" : "0");
+    } catch {
+      // Ignore localStorage errors.
+    }
+  }
 
   function applyFilters() {
     setAppliedFilters(draftFilters);
@@ -268,6 +290,9 @@ export function SetupsAnalyticsPanel() {
         >
           Reset
         </button>
+        <button type="button" onClick={toggleShowAll} className="rounded-lg border border-slate-600 bg-slate-900 px-4 py-2 text-sm text-slate-200">
+          {showAll ? "Show pages" : `Show all ${meta.total}`}
+        </button>
       </div>
 
       {loading ? <LoadingSkeleton lines={6} /> : null}
@@ -285,7 +310,10 @@ export function SetupsAnalyticsPanel() {
 
       {!loading && !error && hasRows ? (
         <div className="space-y-3">
-          <div className="overflow-auto rounded border border-slate-700">
+          <div
+            className={showAll ? "overflow-y-auto rounded border border-slate-700" : "overflow-auto rounded border border-slate-700"}
+            style={showAll ? { maxHeight: "calc(100vh - 280px)" } : undefined}
+          >
             <table className="min-w-full text-xs">
               <thead className="bg-slate-900 text-slate-300">
                 <tr>
@@ -320,29 +348,33 @@ export function SetupsAnalyticsPanel() {
             </table>
           </div>
 
-          <div className="flex items-center justify-between text-xs text-slate-300">
-            <p>
-              Showing page {meta.page} of {Math.max(1, Math.ceil(meta.total / meta.pageSize))} ({meta.total} rows)
-            </p>
-            <div className="flex items-center gap-2">
-              <button
-                type="button"
-                disabled={!canGoBack}
-                onClick={() => setPage((current) => Math.max(1, current - 1))}
-                className="rounded border border-slate-600 px-2 py-1 disabled:opacity-50"
-              >
-                Prev
-              </button>
-              <button
-                type="button"
-                disabled={!canGoForward}
-                onClick={() => setPage((current) => current + 1)}
-                className="rounded border border-slate-600 px-2 py-1 disabled:opacity-50"
-              >
-                Next
-              </button>
+          {showAll ? (
+            <p className="text-xs text-slate-300">Showing all {meta.total} records</p>
+          ) : (
+            <div className="flex items-center justify-between text-xs text-slate-300">
+              <p>
+                Showing page {meta.page} of {Math.max(1, Math.ceil(meta.total / meta.pageSize))} ({meta.total} rows)
+              </p>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  disabled={!canGoBack}
+                  onClick={() => setPage((current) => Math.max(1, current - 1))}
+                  className="rounded border border-slate-600 px-2 py-1 disabled:opacity-50"
+                >
+                  Prev
+                </button>
+                <button
+                  type="button"
+                  disabled={!canGoForward}
+                  onClick={() => setPage((current) => current + 1)}
+                  className="rounded border border-slate-600 px-2 py-1 disabled:opacity-50"
+                >
+                  Next
+                </button>
+              </div>
             </div>
-          </div>
+          )}
         </div>
       ) : null}
 

--- a/src/components/sidebar-nav.tsx
+++ b/src/components/sidebar-nav.tsx
@@ -2,30 +2,109 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { navItems } from "@/lib/navigation";
+import { useEffect, useMemo, useState } from "react";
+import { navGroups } from "@/lib/navigation";
+
+interface PageStatsPayload {
+  data: {
+    accountTotal: number;
+    importTotal: number;
+    snapshotTotal: number;
+  };
+}
+
+interface OverviewSummaryPayload {
+  data: {
+    executionCount: number;
+  };
+}
 
 export function SidebarNav() {
   const pathname = usePathname();
+  const [accountTotal, setAccountTotal] = useState(0);
+  const [importTotal, setImportTotal] = useState(0);
+  const [snapshotTotal, setSnapshotTotal] = useState(0);
+  const [executionCount, setExecutionCount] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadSidebarStats() {
+      try {
+        const [statsResponse, summaryResponse] = await Promise.all([
+          fetch("/api/page-stats", { cache: "no-store" }),
+          fetch("/api/overview/summary", { cache: "no-store" }),
+        ]);
+
+        if (!cancelled && statsResponse.ok) {
+          const statsPayload = (await statsResponse.json()) as PageStatsPayload;
+          setAccountTotal(statsPayload.data.accountTotal);
+          setImportTotal(statsPayload.data.importTotal);
+          setSnapshotTotal(statsPayload.data.snapshotTotal);
+        }
+
+        if (!cancelled && summaryResponse.ok) {
+          const summaryPayload = (await summaryResponse.json()) as OverviewSummaryPayload;
+          setExecutionCount(summaryPayload.data.executionCount);
+        }
+      } catch {
+        if (!cancelled) {
+          setAccountTotal(0);
+          setImportTotal(0);
+          setSnapshotTotal(0);
+          setExecutionCount(0);
+        }
+      }
+    }
+
+    void loadSidebarStats();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const badgeValues = useMemo(
+    () => ({
+      executionCount,
+      importCount: importTotal,
+    }),
+    [executionCount, importTotal],
+  );
 
   return (
-    <nav className="space-y-2">
-      {navItems.map((item) => {
-        const isActive = pathname === item.href;
-        return (
-          <Link
-            key={item.href}
-            href={item.href}
-            className={[
-              "block rounded-xl border px-3 py-2 text-sm transition-colors",
-              isActive
-                ? "border-blue-300/50 bg-blue-500/20 text-white"
-                : "border-transparent text-slate-300 hover:border-slate-700 hover:bg-slate-900/50",
-            ].join(" ")}
-          >
-            {item.label}
-          </Link>
-        );
-      })}
-    </nav>
+    <div className="flex min-h-[calc(100vh-180px)] flex-col justify-between">
+      <nav className="space-y-5">
+        {navGroups.map((group) => (
+          <div key={group.label}>
+            <p className="mb-2 text-[10px] uppercase tracking-[0.08em] text-muted">{group.label}</p>
+            <div className="space-y-1">
+              {group.items.map((item) => {
+                const isActive = pathname === item.href || pathname.startsWith(item.href + "/");
+                const badgeValue = item.badgeKey ? badgeValues[item.badgeKey] : null;
+
+                return (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    className={[
+                      "flex items-center justify-between border-l-2 px-2 py-2 text-[11px] font-medium transition-colors",
+                      isActive ? "border-accent bg-accent/10 text-text" : "border-transparent text-muted hover:bg-panel-2 hover:text-text",
+                    ].join(" ")}
+                  >
+                    <span>{item.label}</span>
+                    {typeof badgeValue === "number" ? (
+                      <span className="rounded-full bg-panel-2 px-2 py-0.5 text-[10px] text-muted">{badgeValue}</span>
+                    ) : null}
+                  </Link>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </nav>
+
+      <p className="mt-4 text-[10px] text-muted">v7.0 · {accountTotal} accounts · {snapshotTotal} snapshots</p>
+    </div>
   );
 }

--- a/src/components/widgets/AccountBalancesWidget.tsx
+++ b/src/components/widgets/AccountBalancesWidget.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useAccountFilterContext } from "@/contexts/AccountFilterContext";
+import { useNetLiquidationValue } from "@/hooks/useNetLiquidationValue";
+import { WidgetCard } from "@/components/widgets/WidgetCard";
+import { formatCurrency } from "@/components/widgets/utils";
+
+function AccountBalanceRow({ accountId, refreshSeed }: { accountId: string; refreshSeed: number }) {
+  void refreshSeed;
+  const { nlv, cash, lastUpdated, loading } = useNetLiquidationValue(accountId);
+
+  const value = nlv ?? cash;
+  const progress = Math.max(0, Math.min(100, (value / 100_000) * 100));
+
+  return (
+    <div className="rounded-lg border border-border bg-panel-2 p-3">
+      <div className="flex items-center justify-between">
+        <p className="font-mono text-xs text-text">{accountId}</p>
+        <p className="text-[11px] text-muted">{loading ? "Updating..." : lastUpdated ? lastUpdated.toLocaleTimeString() : "Quotes unavailable"}</p>
+      </div>
+      <p className="mt-1 text-xs text-muted">Cash: {formatCurrency(cash)}</p>
+      <p className="text-sm font-semibold text-text">{nlv === null ? "NLV unavailable" : "NLV: " + formatCurrency(nlv)}</p>
+      <div className="mt-2 h-2 rounded bg-panel">
+        <div className="h-2 rounded bg-accent" style={{ width: `${progress}%` }} />
+      </div>
+    </div>
+  );
+}
+
+export function AccountBalancesWidget() {
+  const { selectedAccounts } = useAccountFilterContext();
+  const [refreshSeed, setRefreshSeed] = useState(0);
+
+  const action = useMemo(
+    () => (
+      <button
+        type="button"
+        onClick={() => setRefreshSeed((current) => current + 1)}
+        className="rounded border border-border bg-panel-2 px-2 py-0.5 text-[10px] text-muted"
+      >
+        Refresh
+      </button>
+    ),
+    [],
+  );
+
+  return (
+    <WidgetCard title="Account Balances + NLV" action={action}>
+      <div className="space-y-2">
+        {selectedAccounts.length === 0 ? <p className="text-xs text-muted">No accounts selected.</p> : null}
+        {selectedAccounts.map((accountId) => (
+          <AccountBalanceRow key={`${accountId}-${refreshSeed}`} accountId={accountId} refreshSeed={refreshSeed} />
+        ))}
+      </div>
+    </WidgetCard>
+  );
+}

--- a/src/components/widgets/DiagnosticsWidget.tsx
+++ b/src/components/widgets/DiagnosticsWidget.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { WidgetCard } from "@/components/widgets/WidgetCard";
+import type { DiagnosticsResponse } from "@/types/api";
+
+interface DiagnosticsPayload {
+  data: DiagnosticsResponse;
+}
+
+export function DiagnosticsWidget() {
+  const [data, setData] = useState<DiagnosticsResponse | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadData() {
+      const response = await fetch("/api/diagnostics", { cache: "no-store" });
+      if (!response.ok) {
+        return;
+      }
+
+      const payload = (await response.json()) as DiagnosticsPayload;
+      if (!cancelled) {
+        setData(payload.data);
+      }
+    }
+
+    void loadData();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const clear = Boolean(data && data.warningsCount === 0 && data.parseCoverage === 1 && data.matchingCoverage === 1);
+
+  return (
+    <WidgetCard title="Diagnostics Badge">
+      {data ? (
+        <div className="space-y-1 text-xs text-muted">
+          <p>Parse coverage: {(data.parseCoverage * 100).toFixed(1)}%</p>
+          <p>Matching coverage: {(data.matchingCoverage * 100).toFixed(1)}%</p>
+          <p>Warnings: {data.warningsCount}</p>
+          <p>Pair ambiguity: {data.setupInference.setupInferencePairAmbiguousTotal}</p>
+          <p>Synthetic expiration: {data.syntheticExpirationCount}</p>
+          <p className={clear ? "text-accent-2" : "text-amber-300"}>{clear ? "All clear" : data.warningsCount + " warnings"}</p>
+          <Link href="/diagnostics" className="text-accent underline">
+            View diagnostics →
+          </Link>
+        </div>
+      ) : (
+        <p className="text-xs text-muted">Diagnostics unavailable.</p>
+      )}
+    </WidgetCard>
+  );
+}

--- a/src/components/widgets/EquityCurveWidget.tsx
+++ b/src/components/widgets/EquityCurveWidget.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { useAccountFilterContext } from "@/contexts/AccountFilterContext";
+import { WidgetCard } from "@/components/widgets/WidgetCard";
+import { safeNumber } from "@/components/widgets/utils";
+import type { OverviewSummaryResponse } from "@/types/api";
+
+interface OverviewPayload {
+  data: OverviewSummaryResponse;
+}
+
+export function EquityCurveWidget() {
+  const { selectedAccounts } = useAccountFilterContext();
+  const [viewMode, setViewMode] = useState<"combined" | "accounts">("combined");
+  const [data, setData] = useState<OverviewSummaryResponse["snapshotSeries"]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadData() {
+      const response = await fetch("/api/overview/summary", { cache: "no-store" });
+      if (!response.ok) {
+        return;
+      }
+
+      const payload = (await response.json()) as OverviewPayload;
+      if (!cancelled) {
+        setData(payload.data.snapshotSeries);
+      }
+    }
+
+    void loadData();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const accounts = useMemo(() => {
+    return Array.from(new Set(data.map((point) => point.accountId).filter((accountId) => selectedAccounts.includes(accountId)))).sort();
+  }, [data, selectedAccounts]);
+
+  const chartRows = useMemo(() => {
+    const rowsByDate = new Map<string, Record<string, number | string>>();
+
+    for (const point of data) {
+      if (!selectedAccounts.includes(point.accountId)) {
+        continue;
+      }
+
+      const dateKey = point.snapshotDate.slice(0, 10);
+      const row = rowsByDate.get(dateKey) ?? { date: dateKey, combined: 0 };
+      const balance = safeNumber(point.balance);
+      row[point.accountId] = balance;
+      row.combined = safeNumber(row.combined) + balance;
+      rowsByDate.set(dateKey, row);
+    }
+
+    return Array.from(rowsByDate.values()).sort((left, right) => String(left.date).localeCompare(String(right.date)));
+  }, [data, selectedAccounts]);
+
+  return (
+    <WidgetCard
+      title="Equity Curve"
+      action={
+        <button
+          type="button"
+          onClick={() => setViewMode((current) => (current === "combined" ? "accounts" : "combined"))}
+          className="rounded border border-border bg-panel-2 px-2 py-0.5 text-[10px] text-muted"
+        >
+          {viewMode === "combined" ? "Combined" : "Per Account"}
+        </button>
+      }
+    >
+      {chartRows.length === 0 ? (
+        <p className="text-xs text-muted">No snapshot data available.</p>
+      ) : (
+        <div className="h-56">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={chartRows}>
+              <XAxis dataKey="date" tick={{ fill: "var(--muted)", fontSize: 10 }} />
+              <YAxis tick={{ fill: "var(--muted)", fontSize: 10 }} tickFormatter={(value) => `$${Math.round(Number(value) / 1000)}K`} />
+              <Tooltip
+                contentStyle={{ background: "var(--panel-2)", borderColor: "var(--border)", color: "var(--text)" }}
+                formatter={(value: number) => [value.toFixed(2), "Balance"]}
+              />
+              {viewMode === "combined" ? (
+                <Line type="monotone" dataKey="combined" stroke="var(--accent)" strokeWidth={2} dot={false} />
+              ) : (
+                accounts.map((accountId, index) => (
+                  <Line
+                    key={accountId}
+                    type="monotone"
+                    dataKey={accountId}
+                    stroke={index % 2 === 0 ? "var(--accent)" : "var(--accent-2)"}
+                    strokeWidth={2}
+                    dot={false}
+                  />
+                ))
+              )}
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </WidgetCard>
+  );
+}

--- a/src/components/widgets/ExpectancyScatterWidget.tsx
+++ b/src/components/widgets/ExpectancyScatterWidget.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { ResponsiveContainer, Scatter, ScatterChart, Tooltip, XAxis, YAxis, ZAxis } from "recharts";
+import { WidgetCard } from "@/components/widgets/WidgetCard";
+import { useAccountFilterContext } from "@/contexts/AccountFilterContext";
+import { formatCurrency, safeNumber } from "@/components/widgets/utils";
+import type { SetupSummaryRecord } from "@/types/api";
+
+interface SetupsPayload {
+  data: SetupSummaryRecord[];
+}
+
+const tagColors: Record<string, string> = {
+  long_call: "var(--accent)",
+  stock: "var(--accent-2)",
+  bull_vertical: "var(--warning)",
+  diagonal: "var(--violet)",
+};
+
+export function ExpectancyScatterWidget() {
+  const { selectedAccounts } = useAccountFilterContext();
+  const [rows, setRows] = useState<SetupSummaryRecord[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadRows() {
+      const response = await fetch("/api/setups?page=1&pageSize=1000", { cache: "no-store" });
+      if (!response.ok) {
+        return;
+      }
+
+      const payload = (await response.json()) as SetupsPayload;
+      if (!cancelled) {
+        setRows(payload.data);
+      }
+    }
+
+    void loadRows();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const grouped = useMemo(() => {
+    const map = new Map<string, Array<{ x: number; y: number; z: number; row: SetupSummaryRecord }>>();
+
+    for (const row of rows) {
+      if (!selectedAccounts.includes(row.accountId)) {
+        continue;
+      }
+
+      const tag = row.overrideTag ?? row.tag;
+      const points = map.get(tag) ?? [];
+      points.push({
+        x: safeNumber(row.averageHoldDays),
+        y: safeNumber(row.expectancy),
+        z: Math.max(1, Math.abs(safeNumber(row.realizedPnl))),
+        row,
+      });
+      map.set(tag, points);
+    }
+
+    return map;
+  }, [rows, selectedAccounts]);
+
+  return (
+    <WidgetCard title="Expectancy vs Hold">
+      <div className="h-56">
+        <ResponsiveContainer width="100%" height="100%">
+          <ScatterChart>
+            <XAxis dataKey="x" name="Average Hold" tick={{ fill: "var(--muted)", fontSize: 10 }} />
+            <YAxis dataKey="y" name="Expectancy" tick={{ fill: "var(--muted)", fontSize: 10 }} />
+            <ZAxis dataKey="z" range={[40, 260]} />
+            <Tooltip
+              cursor={{ strokeDasharray: "3 3" }}
+              contentStyle={{ background: "var(--panel-2)", borderColor: "var(--border)", color: "var(--text)" }}
+              formatter={(_value, _name, item) => {
+                const row = item.payload.row as SetupSummaryRecord;
+                return [formatCurrency(safeNumber(row.realizedPnl)), row.overrideTag ?? row.tag];
+              }}
+            />
+            {Array.from(grouped.entries()).map(([tag, points]) => (
+              <Scatter key={tag} data={points} fill={tagColors[tag] ?? "var(--muted)"} />
+            ))}
+          </ScatterChart>
+        </ResponsiveContainer>
+      </div>
+    </WidgetCard>
+  );
+}

--- a/src/components/widgets/HoldingDistributionWidget.tsx
+++ b/src/components/widgets/HoldingDistributionWidget.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Bar, BarChart, ResponsiveContainer, XAxis, YAxis } from "recharts";
+import { WidgetCard } from "@/components/widgets/WidgetCard";
+import { useAccountFilterContext } from "@/contexts/AccountFilterContext";
+import type { MatchedLotRecord } from "@/types/api";
+
+interface MatchedLotsPayload {
+  data: MatchedLotRecord[];
+}
+
+export function HoldingDistributionWidget() {
+  const { selectedAccounts } = useAccountFilterContext();
+  const [rows, setRows] = useState<MatchedLotRecord[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadRows() {
+      const response = await fetch("/api/matched-lots?page=1&pageSize=1000", { cache: "no-store" });
+      if (!response.ok) {
+        return;
+      }
+
+      const payload = (await response.json()) as MatchedLotsPayload;
+      if (!cancelled) {
+        setRows(payload.data);
+      }
+    }
+
+    void loadRows();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const bucketData = useMemo(() => {
+    const buckets = {
+      "0-1d": 0,
+      "2-5d": 0,
+      "6-20d": 0,
+      "21d+": 0,
+    };
+
+    for (const row of rows) {
+      if (!selectedAccounts.includes(row.accountId)) {
+        continue;
+      }
+
+      if (row.holdingDays <= 1) {
+        buckets["0-1d"] += 1;
+      } else if (row.holdingDays <= 5) {
+        buckets["2-5d"] += 1;
+      } else if (row.holdingDays <= 20) {
+        buckets["6-20d"] += 1;
+      } else {
+        buckets["21d+"] += 1;
+      }
+    }
+
+    return Object.entries(buckets).map(([bucket, count]) => ({ bucket, count }));
+  }, [rows, selectedAccounts]);
+
+  return (
+    <WidgetCard title="Holding Distribution">
+      <div className="h-48">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={bucketData} layout="vertical">
+            <XAxis type="number" tick={{ fill: "var(--muted)", fontSize: 10 }} />
+            <YAxis type="category" dataKey="bucket" tick={{ fill: "var(--muted)", fontSize: 10 }} width={56} />
+            <Bar dataKey="count" fill="var(--accent)" radius={[0, 4, 4, 0]} />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </WidgetCard>
+  );
+}

--- a/src/components/widgets/ImportHealthWidget.tsx
+++ b/src/components/widgets/ImportHealthWidget.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import { WidgetCard } from "@/components/widgets/WidgetCard";
+import { useAccountFilterContext } from "@/contexts/AccountFilterContext";
+import type { ImportRecord } from "@/types/api";
+
+interface ImportsPayload {
+  data: ImportRecord[];
+}
+
+export function ImportHealthWidget() {
+  const { selectedAccounts } = useAccountFilterContext();
+  const [rows, setRows] = useState<ImportRecord[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadRows() {
+      const response = await fetch("/api/imports?page=1&pageSize=1000", { cache: "no-store" });
+      if (!response.ok) {
+        return;
+      }
+
+      const payload = (await response.json()) as ImportsPayload;
+      if (!cancelled) {
+        setRows(payload.data);
+      }
+    }
+
+    void loadRows();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const summary = useMemo(() => {
+    const filtered = rows.filter((row) => selectedAccounts.includes(row.accountId));
+    const committed = filtered.filter((row) => row.status === "COMMITTED").length;
+    const failed = filtered.filter((row) => row.status === "FAILED").length;
+    const parsedRows = filtered.reduce((sum, row) => sum + row.parsedRows, 0);
+    const skippedRows = filtered.reduce((sum, row) => sum + row.skipped_parse + row.skipped_duplicate, 0);
+
+    return {
+      totalImports: filtered.length,
+      committedImports: committed,
+      failedImports: failed,
+      parsedRows,
+      skippedRows,
+    };
+  }, [rows, selectedAccounts]);
+
+  const healthy = summary.failedImports === 0 && summary.skippedRows === 0;
+
+  return (
+    <WidgetCard title="Import Health">
+      <div className="space-y-1 text-xs text-muted">
+        <p>Total imports: {summary.totalImports}</p>
+        <p>Committed: {summary.committedImports}</p>
+        <p>Failed: {summary.failedImports}</p>
+        <p>Parsed rows: {summary.parsedRows}</p>
+        <p>Skipped rows: {summary.skippedRows}</p>
+      </div>
+      <p className={healthy ? "mt-2 text-xs text-accent-2" : "mt-2 text-xs text-amber-300"}>{healthy ? "Healthy" : "Needs review"}</p>
+      <Link href="/imports" className="mt-2 inline-block text-xs text-accent underline">
+        View imports →
+      </Link>
+    </WidgetCard>
+  );
+}

--- a/src/components/widgets/MonthlyPnlWidget.tsx
+++ b/src/components/widgets/MonthlyPnlWidget.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Bar, BarChart, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { WidgetCard } from "@/components/widgets/WidgetCard";
+import { useAccountFilterContext } from "@/contexts/AccountFilterContext";
+import { formatCurrency, safeNumber } from "@/components/widgets/utils";
+import type { MatchedLotRecord } from "@/types/api";
+
+interface MatchedLotsPayload {
+  data: MatchedLotRecord[];
+}
+
+export function MonthlyPnlWidget() {
+  const { selectedAccounts } = useAccountFilterContext();
+  const [rows, setRows] = useState<MatchedLotRecord[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadRows() {
+      const response = await fetch("/api/matched-lots?page=1&pageSize=1000", { cache: "no-store" });
+      if (!response.ok) {
+        return;
+      }
+
+      const payload = (await response.json()) as MatchedLotsPayload;
+      if (!cancelled) {
+        setRows(payload.data);
+      }
+    }
+
+    void loadRows();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const chartData = useMemo(() => {
+    const grouped = new Map<string, number>();
+
+    for (const row of rows) {
+      if (!selectedAccounts.includes(row.accountId)) {
+        continue;
+      }
+
+      const month = (row.closeTradeDate ?? row.openTradeDate).slice(0, 7);
+      grouped.set(month, (grouped.get(month) ?? 0) + safeNumber(row.realizedPnl));
+    }
+
+    return Array.from(grouped.entries())
+      .sort((left, right) => left[0].localeCompare(right[0]))
+      .map(([month, pnl]) => ({ month, label: month.slice(5), pnl }));
+  }, [rows, selectedAccounts]);
+
+  return (
+    <WidgetCard title="Monthly P&L Bars">
+      <div className="h-48">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={chartData}>
+            <XAxis dataKey="label" tick={{ fill: "var(--muted)", fontSize: 10 }} />
+            <YAxis tick={{ fill: "var(--muted)", fontSize: 10 }} />
+            <Tooltip
+              contentStyle={{ background: "var(--panel-2)", borderColor: "var(--border)", color: "var(--text)" }}
+              formatter={(value: number) => [formatCurrency(value), "P&L"]}
+            />
+            <Bar dataKey="pnl">
+              {chartData.map((entry) => (
+                <Cell key={entry.month} fill={entry.pnl >= 0 ? "var(--accent-2)" : "var(--danger)"} />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </WidgetCard>
+  );
+}

--- a/src/components/widgets/OpenPositionsSummaryWidget.tsx
+++ b/src/components/widgets/OpenPositionsSummaryWidget.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import { WidgetCard } from "@/components/widgets/WidgetCard";
+import { formatCurrency } from "@/components/widgets/utils";
+import { useAccountFilterContext } from "@/contexts/AccountFilterContext";
+import { useOpenPositions } from "@/hooks/useOpenPositions";
+import type { OptionQuoteResponse, QuotesResponse } from "@/types/api";
+
+export function OpenPositionsSummaryWidget() {
+  const { selectedAccounts } = useAccountFilterContext();
+  const { positions } = useOpenPositions();
+  const [markValue, setMarkValue] = useState<number | null>(null);
+  const [lastQuoted, setLastQuoted] = useState<Date | null>(null);
+
+  const filtered = useMemo(() => positions.filter((position) => selectedAccounts.includes(position.accountId)), [positions, selectedAccounts]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadMarks() {
+      if (filtered.length === 0) {
+        if (!cancelled) {
+          setMarkValue(0);
+          setLastQuoted(null);
+        }
+        return;
+      }
+
+      let total = 0;
+
+      const equities = filtered.filter((position) => position.assetClass === "EQUITY");
+      const options = filtered.filter((position) => position.assetClass === "OPTION");
+
+      if (equities.length > 0) {
+        const symbols = Array.from(new Set(equities.map((position) => position.symbol))).join(",");
+        const response = await fetch(`/api/quotes?symbols=${encodeURIComponent(symbols)}`, { cache: "no-store" });
+        const payload = (await response.json()) as QuotesResponse;
+        if ("error" in payload) {
+          if (!cancelled) {
+            setMarkValue(null);
+            setLastQuoted(null);
+          }
+          return;
+        }
+
+        for (const position of equities) {
+          const quote = payload[position.symbol];
+          if (!quote) {
+            continue;
+          }
+          total += quote.mark * position.netQty;
+        }
+      }
+
+      if (options.length > 0) {
+        for (const position of options) {
+          const expDate = position.expirationDate?.slice(0, 10);
+          if (!position.optionType || !position.strike || !expDate) {
+            continue;
+          }
+
+          const response = await fetch(
+            `/api/option-quote?symbol=${encodeURIComponent(position.underlyingSymbol)}&strike=${encodeURIComponent(
+              position.strike,
+            )}&expDate=${encodeURIComponent(expDate)}&contractType=${position.optionType}`,
+            { cache: "no-store" },
+          );
+          const payload = (await response.json()) as OptionQuoteResponse;
+
+          if ("error" in payload) {
+            if (!cancelled) {
+              setMarkValue(null);
+              setLastQuoted(null);
+            }
+            return;
+          }
+
+          total += payload.mark * 100 * position.netQty;
+        }
+      }
+
+      if (!cancelled) {
+        setMarkValue(total);
+        setLastQuoted(new Date());
+      }
+    }
+
+    void loadMarks();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [filtered]);
+
+  const totalCostBasis = useMemo(() => filtered.reduce((sum, row) => sum + row.costBasis, 0), [filtered]);
+  const unrealized = markValue === null ? null : markValue - totalCostBasis;
+
+  return (
+    <WidgetCard title="Open Positions Summary">
+      <div className="space-y-1 text-xs text-muted">
+        <p>Open positions: {filtered.length}</p>
+        <p>Cost basis: {formatCurrency(totalCostBasis)}</p>
+        <p>Mark value: {markValue === null ? "—" : formatCurrency(markValue)}</p>
+        <p className={unrealized !== null && unrealized >= 0 ? "text-accent-2" : "text-red-300"}>
+          Unrealized: {unrealized === null ? "—" : formatCurrency(unrealized)}
+        </p>
+        <p>Last quoted: {lastQuoted ? lastQuoted.toLocaleTimeString() : "—"}</p>
+      </div>
+      <Link href="/positions" className="mt-2 inline-block text-xs text-accent underline">
+        View positions →
+      </Link>
+    </WidgetCard>
+  );
+}

--- a/src/components/widgets/RecentExecutionsWidget.tsx
+++ b/src/components/widgets/RecentExecutionsWidget.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import { Badge } from "@/components/Badge";
+import { WidgetCard } from "@/components/widgets/WidgetCard";
+import { useAccountFilterContext } from "@/contexts/AccountFilterContext";
+import type { ExecutionRecord } from "@/types/api";
+
+interface ExecutionsPayload {
+  data: ExecutionRecord[];
+}
+
+export function RecentExecutionsWidget() {
+  const { selectedAccounts } = useAccountFilterContext();
+  const [rows, setRows] = useState<ExecutionRecord[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadRows() {
+      const response = await fetch("/api/executions?page=1&pageSize=1000", { cache: "no-store" });
+      if (!response.ok) {
+        return;
+      }
+
+      const payload = (await response.json()) as ExecutionsPayload;
+      if (!cancelled) {
+        setRows(payload.data);
+      }
+    }
+
+    void loadRows();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const recentRows = useMemo(() => {
+    return rows
+      .filter((row) => selectedAccounts.includes(row.accountId))
+      .sort((left, right) => new Date(right.eventTimestamp).getTime() - new Date(left.eventTimestamp).getTime())
+      .slice(0, 10);
+  }, [rows, selectedAccounts]);
+
+  return (
+    <WidgetCard title="Recent Executions">
+      <div className="space-y-2">
+        {recentRows.map((row) => (
+          <div key={row.id} className="flex items-center justify-between gap-2 text-xs">
+            <div>
+              <p className="font-semibold text-text">{row.symbol}</p>
+              <p className="text-muted">{new Date(row.tradeDate).toLocaleDateString()} · {row.price ?? "~"}</p>
+            </div>
+            <div className="flex items-center gap-1">
+              {row.side === "BUY" ? <Badge variant="buy">BUY</Badge> : row.side === "SELL" ? <Badge variant="sell">SELL</Badge> : null}
+              {row.optionType ? <Badge variant={row.optionType === "PUT" ? "put" : "call"}>{row.optionType}</Badge> : <Badge variant="stub">EQUITY</Badge>}
+            </div>
+          </div>
+        ))}
+      </div>
+      <Link href="/trade-records?tab=executions" className="mt-2 inline-block text-xs text-accent underline">
+        View all →
+      </Link>
+    </WidgetCard>
+  );
+}

--- a/src/components/widgets/SetupTagRollupWidget.tsx
+++ b/src/components/widgets/SetupTagRollupWidget.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { WidgetCard } from "@/components/widgets/WidgetCard";
+import { useAccountFilterContext } from "@/contexts/AccountFilterContext";
+import { formatCurrency, safeNumber } from "@/components/widgets/utils";
+import type { SetupSummaryRecord } from "@/types/api";
+
+interface SetupsPayload {
+  data: SetupSummaryRecord[];
+}
+
+export function SetupTagRollupWidget() {
+  const { selectedAccounts } = useAccountFilterContext();
+  const [rows, setRows] = useState<SetupSummaryRecord[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadRows() {
+      const response = await fetch("/api/setups?page=1&pageSize=1000", { cache: "no-store" });
+      if (!response.ok) {
+        return;
+      }
+
+      const payload = (await response.json()) as SetupsPayload;
+      if (!cancelled) {
+        setRows(payload.data);
+      }
+    }
+
+    void loadRows();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const chartData = useMemo(() => {
+    const grouped = new Map<string, { pnl: number; count: number }>();
+
+    for (const row of rows) {
+      if (!selectedAccounts.includes(row.accountId)) {
+        continue;
+      }
+
+      const key = row.overrideTag ?? row.tag;
+      const current = grouped.get(key) ?? { pnl: 0, count: 0 };
+      current.pnl += safeNumber(row.realizedPnl);
+      current.count += 1;
+      grouped.set(key, current);
+    }
+
+    return Array.from(grouped.entries())
+      .map(([tag, value]) => ({ tag, pnl: value.pnl, count: value.count }))
+      .sort((left, right) => right.pnl - left.pnl);
+  }, [rows, selectedAccounts]);
+
+  return (
+    <WidgetCard title="Setup Tag Rollup">
+      <div className="h-52">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={chartData}>
+            <XAxis dataKey="tag" tick={{ fill: "var(--muted)", fontSize: 10 }} />
+            <YAxis tick={{ fill: "var(--muted)", fontSize: 10 }} />
+            <Tooltip
+              contentStyle={{ background: "var(--panel-2)", borderColor: "var(--border)", color: "var(--text)" }}
+              formatter={(value: number) => [formatCurrency(value), "P&L"]}
+            />
+            <Bar dataKey="pnl" fill="var(--accent)" />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+      <div className="mt-2 flex flex-wrap gap-2 text-[10px] text-muted">
+        {chartData.map((entry) => (
+          <span key={entry.tag}>{entry.tag + " (" + entry.count + ")"}</span>
+        ))}
+      </div>
+    </WidgetCard>
+  );
+}

--- a/src/components/widgets/StreakWidget.tsx
+++ b/src/components/widgets/StreakWidget.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { WidgetCard } from "@/components/widgets/WidgetCard";
+
+interface StreakPayload {
+  currentStreak: number;
+  currentStreakType: "WIN" | "LOSS" | null;
+  longestWinStreak: number;
+  longestLossStreak: number;
+}
+
+interface ResponsePayload {
+  data?: StreakPayload;
+  currentStreak?: number;
+  currentStreakType?: "WIN" | "LOSS" | null;
+  longestWinStreak?: number;
+  longestLossStreak?: number;
+}
+
+export function StreakWidget() {
+  const [data, setData] = useState<StreakPayload | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadData() {
+      const response = await fetch("/api/overview/streaks", { cache: "no-store" });
+      if (!response.ok) {
+        return;
+      }
+
+      const payload = (await response.json()) as ResponsePayload;
+      const streak = payload.data
+        ? payload.data
+        : {
+            currentStreak: payload.currentStreak ?? 0,
+            currentStreakType: payload.currentStreakType ?? null,
+            longestWinStreak: payload.longestWinStreak ?? 0,
+            longestLossStreak: payload.longestLossStreak ?? 0,
+          };
+
+      if (!cancelled) {
+        setData(streak);
+      }
+    }
+
+    void loadData();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const headline = data
+    ? data.currentStreakType === "WIN"
+      ? data.currentStreak + "W"
+      : data.currentStreakType === "LOSS"
+        ? data.currentStreak + "L"
+        : "0"
+    : "—";
+
+  return (
+    <WidgetCard title="Win / Loss Streak">
+      <p className={data?.currentStreakType === "WIN" ? "text-3xl font-bold text-accent-2" : "text-3xl font-bold text-red-300"}>{headline}</p>
+      <p className="mt-2 text-xs text-muted">Longest win streak: {data?.longestWinStreak ?? 0}</p>
+      <p className="text-xs text-muted">Longest loss streak: {data?.longestLossStreak ?? 0}</p>
+    </WidgetCard>
+  );
+}

--- a/src/components/widgets/SymbolPnlWidget.tsx
+++ b/src/components/widgets/SymbolPnlWidget.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { WidgetCard } from "@/components/widgets/WidgetCard";
+import { useAccountFilterContext } from "@/contexts/AccountFilterContext";
+import { formatCurrency, safeNumber } from "@/components/widgets/utils";
+import type { MatchedLotRecord } from "@/types/api";
+
+interface MatchedLotsPayload {
+  data: MatchedLotRecord[];
+}
+
+export function SymbolPnlWidget() {
+  const { selectedAccounts } = useAccountFilterContext();
+  const [rows, setRows] = useState<MatchedLotRecord[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadRows() {
+      const response = await fetch("/api/matched-lots?page=1&pageSize=1000", { cache: "no-store" });
+      if (!response.ok) {
+        return;
+      }
+
+      const payload = (await response.json()) as MatchedLotsPayload;
+      if (!cancelled) {
+        setRows(payload.data);
+      }
+    }
+
+    void loadRows();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const grouped = useMemo(() => {
+    const map = new Map<string, number>();
+
+    for (const row of rows) {
+      if (!selectedAccounts.includes(row.accountId)) {
+        continue;
+      }
+
+      map.set(row.symbol, (map.get(row.symbol) ?? 0) + safeNumber(row.realizedPnl));
+    }
+
+    return Array.from(map.entries()).map(([symbol, pnl]) => ({ symbol, pnl }));
+  }, [rows, selectedAccounts]);
+
+  const winners = useMemo(() => grouped.filter((entry) => entry.pnl >= 0).sort((left, right) => right.pnl - left.pnl).slice(0, 10), [grouped]);
+  const losers = useMemo(() => grouped.filter((entry) => entry.pnl < 0).sort((left, right) => left.pnl - right.pnl).slice(0, 10), [grouped]);
+
+  return (
+    <WidgetCard title="Symbol P&L Ranking">
+      <div className="grid gap-3 md:grid-cols-2">
+        <div>
+          <p className="mb-1 text-xs text-muted">Top Winners</p>
+          <div className="space-y-1">
+            {winners.map((row) => (
+              <div key={row.symbol} className="flex items-center justify-between text-xs">
+                <span className="text-text">{row.symbol}</span>
+                <span className="text-accent-2">{formatCurrency(row.pnl)}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div>
+          <p className="mb-1 text-xs text-muted">Top Losers</p>
+          <div className="space-y-1">
+            {losers.map((row) => (
+              <div key={row.symbol} className="flex items-center justify-between text-xs">
+                <span className="text-text">{row.symbol}</span>
+                <span className="text-red-300">{formatCurrency(row.pnl)}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </WidgetCard>
+  );
+}

--- a/src/components/widgets/TopSetupsWidget.tsx
+++ b/src/components/widgets/TopSetupsWidget.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { WidgetCard } from "@/components/widgets/WidgetCard";
+import { useAccountFilterContext } from "@/contexts/AccountFilterContext";
+import { formatCurrency, safeNumber } from "@/components/widgets/utils";
+import type { SetupSummaryRecord } from "@/types/api";
+
+interface SetupsPayload {
+  data: SetupSummaryRecord[];
+}
+
+export function TopSetupsWidget() {
+  const { selectedAccounts } = useAccountFilterContext();
+  const [rows, setRows] = useState<SetupSummaryRecord[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadRows() {
+      const response = await fetch("/api/setups?page=1&pageSize=1000", { cache: "no-store" });
+      if (!response.ok) {
+        return;
+      }
+
+      const payload = (await response.json()) as SetupsPayload;
+      if (!cancelled) {
+        setRows(payload.data);
+      }
+    }
+
+    void loadRows();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const topRows = useMemo(() => {
+    return rows
+      .filter((row) => selectedAccounts.includes(row.accountId))
+      .sort((left, right) => safeNumber(right.realizedPnl) - safeNumber(left.realizedPnl))
+      .slice(0, 10);
+  }, [rows, selectedAccounts]);
+
+  const maxAbs = useMemo(() => Math.max(1, ...topRows.map((row) => Math.abs(safeNumber(row.realizedPnl)))), [topRows]);
+
+  return (
+    <WidgetCard title="Top Setups by P&L">
+      <div className="space-y-2">
+        {topRows.map((row) => {
+          const pnl = safeNumber(row.realizedPnl);
+          const barWidth = Math.round((Math.abs(pnl) / maxAbs) * 100);
+
+          return (
+            <div key={row.id} className="space-y-1">
+              <div className="flex items-center justify-between text-xs">
+                <p className="text-text">{(row.overrideTag ?? row.tag) + " · " + row.underlyingSymbol}</p>
+                <p className={pnl >= 0 ? "text-accent-2" : "text-red-300"}>{formatCurrency(pnl)}</p>
+              </div>
+              <div className="h-2 rounded bg-panel-2">
+                <div className={pnl >= 0 ? "h-2 rounded bg-accent-2" : "h-2 rounded bg-red-300"} style={{ width: `${barWidth}%` }} />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </WidgetCard>
+  );
+}

--- a/src/components/widgets/TtsReadinessWidget.tsx
+++ b/src/components/widgets/TtsReadinessWidget.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { WidgetCard } from "@/components/widgets/WidgetCard";
+import { formatCompactCurrency, safeNumber } from "@/components/widgets/utils";
+import { useAccountFilterContext } from "@/contexts/AccountFilterContext";
+import type { ExecutionRecord, MatchedLotRecord } from "@/types/api";
+
+interface ExecutionsPayload {
+  data: ExecutionRecord[];
+}
+
+interface MatchedLotsPayload {
+  data: MatchedLotRecord[];
+}
+
+export function TtsReadinessWidget() {
+  const { selectedAccounts } = useAccountFilterContext();
+  const [executions, setExecutions] = useState<ExecutionRecord[]>([]);
+  const [lots, setLots] = useState<MatchedLotRecord[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadInputs() {
+      const [executionResponse, lotsResponse] = await Promise.all([
+        fetch("/api/executions?page=1&pageSize=1000", { cache: "no-store" }),
+        fetch("/api/matched-lots?page=1&pageSize=1000", { cache: "no-store" }),
+      ]);
+
+      if (!executionResponse.ok || !lotsResponse.ok) {
+        return;
+      }
+
+      const executionsPayload = (await executionResponse.json()) as ExecutionsPayload;
+      const lotsPayload = (await lotsResponse.json()) as MatchedLotsPayload;
+
+      if (!cancelled) {
+        setExecutions(executionsPayload.data);
+        setLots(lotsPayload.data);
+      }
+    }
+
+    void loadInputs();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const metrics = useMemo(() => {
+    const filteredExecutions = executions.filter((row) => selectedAccounts.includes(row.accountId));
+    const filteredLots = lots.filter((row) => selectedAccounts.includes(row.accountId));
+
+    const totalTrades = filteredExecutions.length;
+    const activeDays = new Set(filteredExecutions.map((row) => row.tradeDate.slice(0, 10))).size;
+    const grossProceeds = filteredExecutions.reduce((sum, row) => {
+      const qty = Math.abs(safeNumber(row.quantity));
+      const price = safeNumber(row.price);
+      return sum + qty * price;
+    }, 0);
+
+    const sortedExecutionDates = filteredExecutions
+      .map((row) => new Date(row.tradeDate).getTime())
+      .sort((left, right) => left - right);
+
+    let monthCount = 1;
+    let weekCount = 1;
+    if (sortedExecutionDates.length > 1) {
+      const firstDate = new Date(sortedExecutionDates[0]);
+      const lastDate = new Date(sortedExecutionDates[sortedExecutionDates.length - 1]);
+      const yearDiff = lastDate.getUTCFullYear() - firstDate.getUTCFullYear();
+      const monthDiff = lastDate.getUTCMonth() - firstDate.getUTCMonth();
+      monthCount = Math.max(1, yearDiff * 12 + monthDiff + 1);
+
+      const dayDiff = Math.max(1, Math.floor((lastDate.getTime() - firstDate.getTime()) / (24 * 60 * 60 * 1000)) + 1);
+      weekCount = Math.max(1, dayDiff / 7);
+    }
+
+    const holdingDays = filteredLots.map((row) => row.holdingDays).sort((left, right) => left - right);
+    const averageHold = holdingDays.length === 0 ? 0 : holdingDays.reduce((sum, value) => sum + value, 0) / holdingDays.length;
+    const middle = Math.floor(holdingDays.length / 2);
+    const medianHold =
+      holdingDays.length === 0
+        ? 0
+        : holdingDays.length % 2 === 0
+          ? (holdingDays[middle - 1] + holdingDays[middle]) / 2
+          : holdingDays[middle];
+
+    const tradesPerMonth = totalTrades / monthCount;
+
+    return {
+      tradesPerMonth: tradesPerMonth,
+      activeDaysPerWeek: activeDays / weekCount,
+      annualizedTradeCount: tradesPerMonth * 12,
+      averageHoldingPeriodDays: averageHold,
+      medianHoldingPeriodDays: medianHold,
+      grossProceedsProxy: grossProceeds,
+    };
+  }, [executions, lots, selectedAccounts]);
+
+  return (
+    <WidgetCard title="TTS Readiness">
+      <div className="grid grid-cols-2 gap-2 text-xs text-muted">
+        <p>Trades/mo: {metrics.tradesPerMonth.toFixed(2)}</p>
+        <p>Active days/wk: {metrics.activeDaysPerWeek.toFixed(2)}</p>
+        <p>Annualized count: {metrics.annualizedTradeCount.toFixed(0)}</p>
+        <p>Avg hold: {metrics.averageHoldingPeriodDays.toFixed(2)}d</p>
+        <p>Median hold: {metrics.medianHoldingPeriodDays.toFixed(2)}d</p>
+        <p>Gross proceeds: {formatCompactCurrency(metrics.grossProceedsProxy)}</p>
+      </div>
+      <p className="mt-2 text-[10px] text-muted">evidence/readiness signals — not legal determinations</p>
+    </WidgetCard>
+  );
+}

--- a/src/components/widgets/WidgetCard.tsx
+++ b/src/components/widgets/WidgetCard.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from "react";
+
+interface WidgetCardProps {
+  title: string;
+  children: ReactNode;
+  action?: ReactNode;
+}
+
+export function WidgetCard({ title, children, action }: WidgetCardProps) {
+  return (
+    <article className="h-full rounded-xl border border-border bg-panel p-4">
+      <header className="mb-3 flex items-center justify-between gap-2">
+        <h3 className="text-sm font-semibold text-text">{title}</h3>
+        {action ?? null}
+      </header>
+      {children}
+    </article>
+  );
+}

--- a/src/components/widgets/WinLossFlatWidget.tsx
+++ b/src/components/widgets/WinLossFlatWidget.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
+import { WidgetCard } from "@/components/widgets/WidgetCard";
+import { useAccountFilterContext } from "@/contexts/AccountFilterContext";
+import type { MatchedLotRecord } from "@/types/api";
+
+interface MatchedLotsPayload {
+  data: MatchedLotRecord[];
+}
+
+export function WinLossFlatWidget() {
+  const { selectedAccounts } = useAccountFilterContext();
+  const [rows, setRows] = useState<MatchedLotRecord[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadRows() {
+      const response = await fetch("/api/matched-lots?page=1&pageSize=1000", { cache: "no-store" });
+      if (!response.ok) {
+        return;
+      }
+
+      const payload = (await response.json()) as MatchedLotsPayload;
+      if (!cancelled) {
+        setRows(payload.data);
+      }
+    }
+
+    void loadRows();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const counts = useMemo(() => {
+    const initial = { WIN: 0, LOSS: 0, FLAT: 0 };
+    for (const row of rows) {
+      if (!selectedAccounts.includes(row.accountId)) {
+        continue;
+      }
+
+      if (row.outcome === "WIN") {
+        initial.WIN += 1;
+      } else if (row.outcome === "LOSS") {
+        initial.LOSS += 1;
+      } else {
+        initial.FLAT += 1;
+      }
+    }
+
+    return initial;
+  }, [rows, selectedAccounts]);
+
+  const chartData = [
+    { name: "WIN", value: counts.WIN, color: "var(--accent-2)" },
+    { name: "LOSS", value: counts.LOSS, color: "var(--danger)" },
+    { name: "FLAT", value: counts.FLAT, color: "var(--muted)" },
+  ];
+
+  const winRate = counts.WIN + counts.LOSS === 0 ? 0 : (counts.WIN / (counts.WIN + counts.LOSS)) * 100;
+
+  return (
+    <WidgetCard title="Win / Loss / Flat">
+      <div className="grid grid-cols-[140px_1fr] items-center gap-2">
+        <div className="h-36">
+          <ResponsiveContainer width="100%" height="100%">
+            <PieChart>
+              <Pie data={chartData} dataKey="value" innerRadius={35} outerRadius={52} paddingAngle={2}>
+                {chartData.map((entry) => (
+                  <Cell key={entry.name} fill={entry.color} />
+                ))}
+              </Pie>
+              <Tooltip contentStyle={{ background: "var(--panel-2)", borderColor: "var(--border)", color: "var(--text)" }} />
+            </PieChart>
+          </ResponsiveContainer>
+        </div>
+        <div className="space-y-1 text-xs text-muted">
+          <p className="text-base font-semibold text-text">Win rate: {winRate.toFixed(1)}%</p>
+          {chartData.map((entry) => (
+            <p key={entry.name}>
+              {entry.name}: {entry.value}
+            </p>
+          ))}
+        </div>
+      </div>
+    </WidgetCard>
+  );
+}

--- a/src/components/widgets/utils.ts
+++ b/src/components/widgets/utils.ts
@@ -1,0 +1,17 @@
+export function formatCurrency(value: number): string {
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 2 }).format(value);
+}
+
+export function formatCompactCurrency(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(value);
+}
+
+export function safeNumber(value: string | number | null | undefined): number {
+  const parsed = Number(value ?? 0);
+  return Number.isFinite(parsed) ? parsed : 0;
+}

--- a/src/contexts/AccountFilterContext.tsx
+++ b/src/contexts/AccountFilterContext.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
+import type { ExecutionRecord, ImportRecord } from "@/types/api";
+
+interface ExecutionListPayload {
+  data: ExecutionRecord[];
+  meta: {
+    total: number;
+    page: number;
+    pageSize: number;
+  };
+}
+
+interface ImportListPayload {
+  data: ImportRecord[];
+  meta: {
+    total: number;
+    page: number;
+    pageSize: number;
+  };
+}
+
+interface AccountFilterContextValue {
+  availableAccounts: string[];
+  selectedAccounts: string[];
+  setSelectedAccounts: (ids: string[]) => void;
+}
+
+const AccountFilterContext = createContext<AccountFilterContextValue | null>(null);
+
+function uniqueSorted(values: string[]): string[] {
+  return Array.from(new Set(values.filter((value) => value.trim().length > 0))).sort((left, right) => left.localeCompare(right));
+}
+
+export function AccountFilterContextProvider({ children }: { children: React.ReactNode }) {
+  const [availableAccounts, setAvailableAccounts] = useState<string[]>([]);
+  const [selectedAccounts, setSelectedAccountsState] = useState<string[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadAccounts() {
+      try {
+        const executionResponse = await fetch("/api/executions?page=1&pageSize=1000", { cache: "no-store" });
+        let accountIds: string[] = [];
+
+        if (executionResponse.ok) {
+          const payload = (await executionResponse.json()) as ExecutionListPayload;
+          accountIds = payload.data.map((row) => row.accountId);
+        }
+
+        // Fallback to imports so the selector still hydrates before executions exist.
+        if (accountIds.length === 0) {
+          const importResponse = await fetch("/api/imports?page=1&pageSize=1000", { cache: "no-store" });
+          if (importResponse.ok) {
+            const payload = (await importResponse.json()) as ImportListPayload;
+            accountIds = payload.data.map((row) => row.accountId);
+          }
+        }
+
+        if (cancelled) {
+          return;
+        }
+
+        const uniqueAccounts = uniqueSorted(accountIds);
+        setAvailableAccounts(uniqueAccounts);
+        setSelectedAccountsState((current) => {
+          if (current.length === 0) {
+            return uniqueAccounts;
+          }
+
+          const filtered = current.filter((accountId) => uniqueAccounts.includes(accountId));
+          return filtered.length > 0 ? filtered : uniqueAccounts;
+        });
+      } catch {
+        if (!cancelled) {
+          setAvailableAccounts([]);
+          setSelectedAccountsState([]);
+        }
+      }
+    }
+
+    void loadAccounts();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const value = useMemo<AccountFilterContextValue>(() => {
+    return {
+      availableAccounts,
+      selectedAccounts,
+      setSelectedAccounts: (ids: string[]) => {
+        const unique = uniqueSorted(ids);
+        const valid = unique.filter((accountId) => availableAccounts.includes(accountId));
+        setSelectedAccountsState(valid.length === 0 ? availableAccounts : valid);
+      },
+    };
+  }, [availableAccounts, selectedAccounts]);
+
+  return <AccountFilterContext.Provider value={value}>{children}</AccountFilterContext.Provider>;
+}
+
+export function useAccountFilterContext(): AccountFilterContextValue {
+  const context = useContext(AccountFilterContext);
+  if (!context) {
+    throw new Error("useAccountFilterContext must be used inside AccountFilterContextProvider");
+  }
+
+  return context;
+}

--- a/src/hooks/useNetLiquidationValue.ts
+++ b/src/hooks/useNetLiquidationValue.ts
@@ -1,0 +1,167 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useOpenPositions } from "@/hooks/useOpenPositions";
+import type {
+  NlvResult,
+  OptionQuoteRecord,
+  OptionQuoteResponse,
+  OverviewSummaryResponse,
+  QuoteUnavailableResponse,
+  QuotesResponse,
+} from "@/types/api";
+
+interface OverviewPayload {
+  data: OverviewSummaryResponse;
+}
+
+function isUnavailable(value: unknown): value is QuoteUnavailableResponse {
+  return typeof value === "object" && value !== null && "error" in value && (value as { error?: string }).error === "unavailable";
+}
+
+export function useNetLiquidationValue(accountId: string): NlvResult {
+  const { positions, loading: positionsLoading } = useOpenPositions();
+
+  const [nlv, setNlv] = useState<number | null>(null);
+  const [cash, setCash] = useState(0);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const accountPositions = useMemo(() => positions.filter((position) => position.accountId === accountId), [accountId, positions]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadNlv() {
+      if (positionsLoading) {
+        setLoading(true);
+        return;
+      }
+
+      setLoading(true);
+
+      try {
+        const summaryResponse = await fetch("/api/overview/summary", { cache: "no-store" });
+        if (!summaryResponse.ok) {
+          throw new Error("Unable to load overview summary for NLV.");
+        }
+
+        const summaryPayload = (await summaryResponse.json()) as OverviewPayload;
+        const latestSnapshot = [...summaryPayload.data.snapshotSeries]
+          .filter((snapshot) => snapshot.accountId === accountId)
+          .sort((left, right) => new Date(right.snapshotDate).getTime() - new Date(left.snapshotDate).getTime())[0];
+
+        const latestCash = Number(latestSnapshot?.balance ?? 0);
+        if (!cancelled) {
+          setCash(latestCash);
+        }
+
+        const equityPositions = accountPositions.filter((position) => position.assetClass === "EQUITY");
+        const optionPositions = accountPositions.filter((position) => position.assetClass === "OPTION");
+
+        let quoteUnavailable = false;
+        let equityValue = 0;
+        let optionValue = 0;
+
+        if (equityPositions.length > 0) {
+          const symbols = Array.from(new Set(equityPositions.map((position) => position.symbol))).join(",");
+          const quotesResponse = await fetch(`/api/quotes?symbols=${encodeURIComponent(symbols)}`, { cache: "no-store" });
+          const quotesPayload = (await quotesResponse.json()) as QuotesResponse;
+
+          if (isUnavailable(quotesPayload)) {
+            quoteUnavailable = true;
+          } else {
+            for (const position of equityPositions) {
+              const quote = quotesPayload[position.symbol];
+              if (!quote) {
+                quoteUnavailable = true;
+                break;
+              }
+
+              equityValue += quote.mark * position.netQty;
+            }
+          }
+        }
+
+        if (!quoteUnavailable && optionPositions.length > 0) {
+          const optionQuotes = await Promise.all(
+            optionPositions.map(async (position) => {
+              const expDate = position.expirationDate?.slice(0, 10);
+              if (!position.optionType || !position.strike || !expDate) {
+                return null;
+              }
+
+              const response = await fetch(
+                `/api/option-quote?symbol=${encodeURIComponent(position.underlyingSymbol)}&strike=${encodeURIComponent(
+                  position.strike,
+                )}&expDate=${encodeURIComponent(expDate)}&contractType=${position.optionType}`,
+                { cache: "no-store" },
+              );
+
+              return {
+                key: position.instrumentKey,
+                payload: (await response.json()) as OptionQuoteResponse,
+              };
+            }),
+          );
+
+          const optionQuoteMap = new Map<string, OptionQuoteRecord>();
+          for (const quote of optionQuotes) {
+            if (!quote || isUnavailable(quote.payload)) {
+              quoteUnavailable = true;
+              break;
+            }
+
+            optionQuoteMap.set(quote.key, quote.payload);
+          }
+
+          if (!quoteUnavailable) {
+            for (const position of optionPositions) {
+              const quote = optionQuoteMap.get(position.instrumentKey);
+              if (!quote) {
+                quoteUnavailable = true;
+                break;
+              }
+
+              optionValue += quote.mark * 100 * position.netQty;
+            }
+          }
+        }
+
+        if (cancelled) {
+          return;
+        }
+
+        if (quoteUnavailable) {
+          setNlv(null);
+          setLastUpdated(null);
+          setLoading(false);
+          return;
+        }
+
+        setNlv(latestCash + equityValue + optionValue);
+        setLastUpdated(new Date());
+        setLoading(false);
+      } catch {
+        if (!cancelled) {
+          setNlv(null);
+          setLastUpdated(null);
+          setLoading(false);
+        }
+      }
+    }
+
+    void loadNlv();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [accountId, accountPositions, positionsLoading]);
+
+  return {
+    nlv,
+    cash,
+    lastUpdated,
+    loading,
+  };
+}

--- a/src/hooks/useOpenPositions.ts
+++ b/src/hooks/useOpenPositions.ts
@@ -1,0 +1,128 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { ExecutionRecord, MatchedLotRecord, OpenPosition } from "@/types/api";
+
+interface ExecutionsPayload {
+  data: ExecutionRecord[];
+}
+
+interface MatchedLotsPayload {
+  data: MatchedLotRecord[];
+}
+
+function signedQuantity(side: string | null, quantity: number): number {
+  return side === "SELL" ? quantity * -1 : quantity;
+}
+
+function fallbackInstrumentKey(execution: ExecutionRecord): string {
+  const expiration = execution.expirationDate ? execution.expirationDate.slice(0, 10) : "";
+  return [
+    execution.accountId,
+    execution.assetClass,
+    execution.underlyingSymbol ?? execution.symbol,
+    execution.optionType ?? "",
+    execution.strike ?? "",
+    expiration,
+  ].join("|");
+}
+
+export function useOpenPositions(): { positions: OpenPosition[]; loading: boolean; error: string | null } {
+  const [positions, setPositions] = useState<OpenPosition[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadPositions() {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const [executionResponse, matchedLotsResponse] = await Promise.all([
+          fetch("/api/executions?page=1&pageSize=1000", { cache: "no-store" }),
+          fetch("/api/matched-lots?page=1&pageSize=1000", { cache: "no-store" }),
+        ]);
+
+        if (!executionResponse.ok || !matchedLotsResponse.ok) {
+          throw new Error("Unable to load open position inputs.");
+        }
+
+        const executionsPayload = (await executionResponse.json()) as ExecutionsPayload;
+        const matchedLotsPayload = (await matchedLotsResponse.json()) as MatchedLotsPayload;
+
+        const matchedOpenExecutionIds = new Set(matchedLotsPayload.data.map((row) => row.openExecutionId));
+        const grouped = new Map<string, OpenPosition>();
+
+        for (const execution of executionsPayload.data) {
+          if (execution.openingClosingEffect !== "TO_OPEN") {
+            continue;
+          }
+
+          if (matchedOpenExecutionIds.has(execution.id)) {
+            continue;
+          }
+
+          const key = execution.instrumentKey ?? fallbackInstrumentKey(execution);
+          const groupKey = execution.accountId + "::" + key;
+          const quantity = Number(execution.quantity);
+          const price = Number(execution.price ?? 0);
+          const qtySigned = signedQuantity(execution.side, quantity);
+
+          const existing = grouped.get(groupKey);
+          if (existing) {
+            existing.netQty += qtySigned;
+            existing.costBasis += qtySigned * price;
+            continue;
+          }
+
+          grouped.set(groupKey, {
+            symbol: execution.symbol,
+            underlyingSymbol: execution.underlyingSymbol ?? execution.symbol,
+            assetClass: execution.assetClass === "OPTION" ? "OPTION" : "EQUITY",
+            optionType: execution.optionType === "CALL" || execution.optionType === "PUT" ? execution.optionType : null,
+            strike: execution.strike,
+            expirationDate: execution.expirationDate,
+            instrumentKey: key,
+            netQty: qtySigned,
+            costBasis: qtySigned * price,
+            accountId: execution.accountId,
+          });
+        }
+
+        const openPositions = Array.from(grouped.values())
+          .filter((position) => position.netQty !== 0)
+          .sort((left, right) => {
+            const symbolOrder = left.underlyingSymbol.localeCompare(right.underlyingSymbol);
+            if (symbolOrder !== 0) {
+              return symbolOrder;
+            }
+
+            return left.instrumentKey.localeCompare(right.instrumentKey);
+          });
+
+        if (!cancelled) {
+          setPositions(openPositions);
+        }
+      } catch (loadError) {
+        if (!cancelled) {
+          setError(loadError instanceof Error ? loadError.message : "Unable to compute open positions.");
+          setPositions([]);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void loadPositions();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { positions, loading, error };
+}

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -1,14 +1,73 @@
 export interface NavItem {
   href: string;
   label: string;
+  badgeKey?: "executionCount" | "importCount";
 }
 
-export const navItems: NavItem[] = [
-  { href: "/", label: "Overview" },
-  { href: "/imports", label: "Imports & Connections" },
-  { href: "/executions", label: "Executions" },
-  { href: "/matched-lots", label: "Matched Lots" },
-  { href: "/setups", label: "Setups" },
-  { href: "/tts-evidence", label: "TTS Evidence" },
-  { href: "/diagnostics", label: "Diagnostics" },
+export interface NavGroup {
+  label: string;
+  items: NavItem[];
+}
+
+export const navGroups: NavGroup[] = [
+  {
+    label: "WORKSPACE",
+    items: [
+      { href: "/dashboard", label: "Dashboard" },
+      { href: "/analytics", label: "Analytics" },
+      { href: "/positions", label: "Open Positions" },
+    ],
+  },
+  {
+    label: "TRADE RECORDS",
+    items: [{ href: "/trade-records", label: "Executions / Lots / Setups", badgeKey: "executionCount" }],
+  },
+  {
+    label: "IMPORT & DATA",
+    items: [{ href: "/imports", label: "Imports & Connections", badgeKey: "importCount" }],
+  },
+  {
+    label: "EVIDENCE & AUDIT",
+    items: [
+      { href: "/tts-evidence", label: "TTS Evidence" },
+      { href: "/diagnostics", label: "Diagnostics" },
+    ],
+  },
 ];
+
+export function getRouteTitle(pathname: string): string {
+  const normalized = pathname === "/" ? "/dashboard" : pathname;
+
+  for (const group of navGroups) {
+    const matched = group.items.find((item) => normalized === item.href || normalized.startsWith(item.href + "/"));
+    if (matched) {
+      return matched.label;
+    }
+  }
+
+  return "KapMan Trading Journal";
+}
+
+export function getTopbarContextTags(pathname: string): string[] {
+  if (pathname.startsWith("/dashboard")) {
+    return ["KPI strip", "Widget grid"];
+  }
+
+  if (pathname.startsWith("/trade-records")) {
+    return ["T1", "T2", "T3"];
+  }
+
+  if (pathname.startsWith("/imports")) {
+    return ["Upload", "History", "Adapters"];
+  }
+
+  if (pathname.startsWith("/positions")) {
+    return ["Live marks"];
+  }
+
+  if (pathname.startsWith("/analytics")) {
+    return ["Derived metrics"];
+  }
+
+  return [];
+}

--- a/src/lib/schwab-auth.ts
+++ b/src/lib/schwab-auth.ts
@@ -1,0 +1,75 @@
+export class SchwabCredentialsUnavailableError extends Error {
+  public readonly code = "SCHWAB_CREDENTIALS_UNAVAILABLE";
+
+  constructor() {
+    super("Schwab credentials are not configured.");
+  }
+}
+
+interface TokenCacheEntry {
+  accessToken: string;
+  expiresAtMs: number;
+}
+
+let cachedToken: TokenCacheEntry | null = null;
+let inFlightTokenPromise: Promise<string> | null = null;
+
+function getRequiredCredential(name: "SCHWAB_CLIENT_ID" | "SCHWAB_CLIENT_SECRET" | "SCHWAB_REFRESH_TOKEN"): string {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    throw new SchwabCredentialsUnavailableError();
+  }
+
+  return value;
+}
+
+async function requestAccessToken(): Promise<string> {
+  const clientId = getRequiredCredential("SCHWAB_CLIENT_ID");
+  const clientSecret = getRequiredCredential("SCHWAB_CLIENT_SECRET");
+  const refreshToken = getRequiredCredential("SCHWAB_REFRESH_TOKEN");
+
+  const response = await fetch("https://api.schwabapi.com/v1/oauth/token", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Authorization: "Basic " + Buffer.from(clientId + ":" + clientSecret).toString("base64"),
+    },
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+    }).toString(),
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error("Unable to refresh Schwab access token.");
+  }
+
+  const payload = (await response.json()) as { access_token?: string; expires_in?: number };
+  if (!payload.access_token || !payload.expires_in) {
+    throw new Error("Invalid token response from Schwab.");
+  }
+
+  const now = Date.now();
+  cachedToken = {
+    accessToken: payload.access_token,
+    expiresAtMs: now + payload.expires_in * 1000,
+  };
+
+  return cachedToken.accessToken;
+}
+
+export async function getAccessToken(): Promise<string> {
+  const now = Date.now();
+  if (cachedToken && now < cachedToken.expiresAtMs - 60_000) {
+    return cachedToken.accessToken;
+  }
+
+  if (!inFlightTokenPromise) {
+    inFlightTokenPromise = requestAccessToken().finally(() => {
+      inFlightTokenPromise = null;
+    });
+  }
+
+  return inFlightTokenPromise;
+}

--- a/src/lib/ui/page-copy.ts
+++ b/src/lib/ui/page-copy.ts
@@ -6,38 +6,38 @@ export interface DataPageCopy {
 
 export const dataPageCopy: Record<string, DataPageCopy> = {
   overview: {
-    title: "OverviewPage",
-    subtitle: "Placeholder overview summary while ingestion and analytics are implemented.",
+    title: "Overview",
+    subtitle: "Portfolio summary, import quality, and account snapshots.",
     nextAction: "Upload a thinkorswim statement in Imports & Connections.",
   },
   imports: {
-    title: "ImportsConnectionsPage",
-    subtitle: "Placeholder import workflow surface.",
+    title: "Imports & Connections",
+    subtitle: "Upload statements, inspect previews, and commit results.",
     nextAction: "Select Upload Statement to start a new import.",
   },
   executions: {
-    title: "ExecutionsPage",
-    subtitle: "Placeholder canonical execution table view.",
+    title: "Executions",
+    subtitle: "Canonical execution table with broker and account context.",
     nextAction: "Commit an import to generate execution rows.",
   },
   matchedLots: {
-    title: "MatchedLotsPage",
-    subtitle: "Placeholder FIFO matched lots view.",
+    title: "Matched Lots",
+    subtitle: "FIFO open/close matching with realized P&L and holding periods.",
     nextAction: "Run matching after imports are persisted.",
   },
   setups: {
-    title: "SetupsPage",
-    subtitle: "Placeholder setup analytics view.",
+    title: "Setups",
+    subtitle: "Setup-level analytics grouped from matched lots.",
     nextAction: "Generate setup groups from matched lots.",
   },
   ttsEvidence: {
-    title: "TtsEvidencePage",
-    subtitle: "Placeholder TTS evidence/readiness view.",
+    title: "TTS Evidence",
+    subtitle: "Evidence and readiness metrics from historical trading activity.",
     nextAction: "Load matched lot history to compute evidence metrics.",
   },
   diagnostics: {
-    title: "DiagnosticsPage",
-    subtitle: "Placeholder parser/matcher diagnostics view.",
+    title: "Diagnostics",
+    subtitle: "Parser, matcher, and setup-inference diagnostic metrics.",
     nextAction: "Run imports and matching to populate diagnostics.",
   },
 };

--- a/src/lib/widget-registry.ts
+++ b/src/lib/widget-registry.ts
@@ -1,0 +1,75 @@
+import type { ComponentType } from "react";
+import { AccountBalancesWidget } from "@/components/widgets/AccountBalancesWidget";
+import { DiagnosticsWidget } from "@/components/widgets/DiagnosticsWidget";
+import { EquityCurveWidget } from "@/components/widgets/EquityCurveWidget";
+import { ExpectancyScatterWidget } from "@/components/widgets/ExpectancyScatterWidget";
+import { HoldingDistributionWidget } from "@/components/widgets/HoldingDistributionWidget";
+import { ImportHealthWidget } from "@/components/widgets/ImportHealthWidget";
+import { MonthlyPnlWidget } from "@/components/widgets/MonthlyPnlWidget";
+import { OpenPositionsSummaryWidget } from "@/components/widgets/OpenPositionsSummaryWidget";
+import { RecentExecutionsWidget } from "@/components/widgets/RecentExecutionsWidget";
+import { SetupTagRollupWidget } from "@/components/widgets/SetupTagRollupWidget";
+import { StreakWidget } from "@/components/widgets/StreakWidget";
+import { SymbolPnlWidget } from "@/components/widgets/SymbolPnlWidget";
+import { TopSetupsWidget } from "@/components/widgets/TopSetupsWidget";
+import { TtsReadinessWidget } from "@/components/widgets/TtsReadinessWidget";
+import { WinLossFlatWidget } from "@/components/widgets/WinLossFlatWidget";
+
+export interface WidgetDefinition {
+  id: string;
+  name: string;
+  description: string;
+  defaultColSpan: 1 | 2;
+  component: ComponentType;
+}
+
+export const WIDGET_REGISTRY: WidgetDefinition[] = [
+  { id: "equity-curve", name: "Equity Curve", description: "Daily balance trajectory by account.", defaultColSpan: 2, component: EquityCurveWidget },
+  {
+    id: "account-balances",
+    name: "Account Balances + NLV",
+    description: "Cash and mark-to-market net liquidation values.",
+    defaultColSpan: 1,
+    component: AccountBalancesWidget,
+  },
+  { id: "win-loss-flat", name: "Win / Loss / Flat", description: "Outcome mix and win-rate center label.", defaultColSpan: 1, component: WinLossFlatWidget },
+  {
+    id: "holding-dist",
+    name: "Holding Distribution",
+    description: "Time-in-market holding-day buckets.",
+    defaultColSpan: 1,
+    component: HoldingDistributionWidget,
+  },
+  { id: "top-setups", name: "Top Setups by P&L", description: "Highest P&L setup groups.", defaultColSpan: 1, component: TopSetupsWidget },
+  { id: "symbol-pnl", name: "Symbol P&L Ranking", description: "Top winning and losing symbols.", defaultColSpan: 2, component: SymbolPnlWidget },
+  { id: "monthly-pnl", name: "Monthly P&L Bars", description: "P&L trend by month.", defaultColSpan: 2, component: MonthlyPnlWidget },
+  { id: "setup-tags", name: "Setup Tag Rollup", description: "Realized P&L totals by setup tag.", defaultColSpan: 1, component: SetupTagRollupWidget },
+  { id: "import-health", name: "Import Health", description: "Import quality and failure/skipped checks.", defaultColSpan: 1, component: ImportHealthWidget },
+  { id: "tts-scorecard", name: "TTS Readiness", description: "Evidence scorecard from trading activity.", defaultColSpan: 1, component: TtsReadinessWidget },
+  { id: "diag-badge", name: "Diagnostics Badge", description: "Parser/matching quality and warnings.", defaultColSpan: 1, component: DiagnosticsWidget },
+  { id: "recent-execs", name: "Recent Executions", description: "Latest execution feed from selected accounts.", defaultColSpan: 2, component: RecentExecutionsWidget },
+  {
+    id: "open-pos-summary",
+    name: "Open Positions Summary",
+    description: "Open-position totals and unrealized mark deltas.",
+    defaultColSpan: 1,
+    component: OpenPositionsSummaryWidget,
+  },
+  {
+    id: "scatter",
+    name: "Expectancy vs Hold",
+    description: "Setup expectancy scatter against hold duration.",
+    defaultColSpan: 2,
+    component: ExpectancyScatterWidget,
+  },
+  { id: "streaks", name: "Win / Loss Streak", description: "Current and longest streak statistics.", defaultColSpan: 1, component: StreakWidget },
+];
+
+export const DEFAULT_DASHBOARD_LAYOUT = [
+  "equity-curve",
+  "account-balances",
+  "win-loss-flat",
+  "holding-dist",
+  "top-setups",
+  "import-health",
+];

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,13 +8,26 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      colors: {
+        bg: "var(--bg)",
+        panel: "var(--panel)",
+        "panel-2": "var(--panel-2)",
+        muted: "var(--muted)",
+        text: "var(--text)",
+        accent: "var(--accent)",
+        "accent-2": "var(--accent-2)",
+        border: "var(--border)",
+      },
+      borderColor: {
+        border: "var(--border)",
+      },
       backgroundImage: {
         "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
-        "gradient-conic":
-          "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
+        "gradient-conic": "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
       },
     },
   },
   plugins: [],
 };
+
 export default config;

--- a/types/api.ts
+++ b/types/api.ts
@@ -258,6 +258,61 @@ export interface AdapterSummaryRecord {
   coverage: AdapterCoverageRecord;
 }
 
+export interface QuoteUnavailableResponse {
+  error: "unavailable";
+}
+
+export interface EquityQuoteRecord {
+  mark: number;
+  bid: number;
+  ask: number;
+  last: number;
+  netChange: number;
+  netPctChange: number;
+}
+
+export type QuotesResponse = Record<string, EquityQuoteRecord> | QuoteUnavailableResponse;
+
+export interface OptionQuoteRecord {
+  mark: number;
+  bid: number;
+  ask: number;
+  delta: number;
+  theta: number;
+  iv: number;
+  dte: number;
+  inTheMoney: boolean;
+}
+
+export type OptionQuoteResponse = OptionQuoteRecord | QuoteUnavailableResponse;
+
+export interface OpenPosition {
+  symbol: string;
+  underlyingSymbol: string;
+  assetClass: "OPTION" | "EQUITY";
+  optionType: "CALL" | "PUT" | null;
+  strike: string | null;
+  expirationDate: string | null;
+  instrumentKey: string;
+  netQty: number;
+  costBasis: number;
+  accountId: string;
+}
+
+export interface NlvResult {
+  nlv: number | null;
+  cash: number;
+  lastUpdated: Date | null;
+  loading: boolean;
+}
+
+export interface StreakSummaryResponse {
+  currentStreak: number;
+  currentStreakType: "WIN" | "LOSS" | null;
+  longestWinStreak: number;
+  longestLossStreak: number;
+}
+
 export type ImportsListApiResponse = ApiListResponse<ImportRecord> | ApiErrorResponse;
 export type UploadImportApiResponse = ApiDetailResponse<UploadImportResponse> | ApiErrorResponse;
 export type CommitImportApiResponse = ApiDetailResponse<CommitImportResponse> | ApiErrorResponse;


### PR DESCRIPTION
## Summary
- executed all v7 phases from KM-001 through KM-035 in the required order
- added the new v7 shell, routes, account context, dashboard widgets, quote proxy routes, open positions/NLV hooks, analytics page, and table show-all mode
- preserved frozen layers (prisma schema, existing route handlers, adapter, ledger, setup inference, existing tests)

## Validation
- npm run typecheck
- npm run lint
- npm run test

## Tracking
- phase completion and assumptions are recorded in CHANGES.md
- DONE.md lists all completed v7 issues
