### PR TITLE
Fix equity curve: persist daily snapshots on import commit

### DIFF
--- a/src/app/api/imports/[id]/commit/route.ts
+++ b/src/app/api/imports/[id]/commit/route.ts
@@ -4,6 +4,7 @@ import { detectAdapter } from "@/lib/adapters/registry";
 import { rebuildAccountSetups } from "@/lib/analytics/rebuild-account-setups";
 import { prisma } from "@/lib/db/prisma";
 import { replaceImportExecutions } from "@/lib/imports/replace-import-executions";
+import { replaceImportSnapshots } from "@/lib/imports/replace-import-snapshots";
 import { deriveInstrumentKeyFromNormalizedExecution } from "@/lib/ledger/instrument-key";
 import { rebuildAccountLedger } from "@/lib/ledger/rebuild-account-ledger";
 import type { CommitImportResponse } from "@/types/api";
@@ -89,11 +90,20 @@ export async function POST(_request: Request, context: { params: { id: string } 
   try {
     transactionResult = await prisma.$transaction(async (tx) => {
       const ingestResult = await replaceImportExecutions(tx, importId, executionData);
+      const snapshotResult = await replaceImportSnapshots(tx, importId, existingImport.accountId, parsed.snapshots);
 
       const rebuildResult = await rebuildAccountLedger(tx, existingImport.accountId, new Date());
       const setupResult = await rebuildAccountSetups(tx, existingImport.accountId);
       const combinedWarnings = [
         ...parsed.warnings,
+        ...(matched.adapter.coverage().snapshots && snapshotResult.parsed === 0
+          ? [
+              {
+                code: "NO_SNAPSHOT_ROWS",
+                message: "No Cash Balance BAL rows were parsed into daily snapshots for this import.",
+              },
+            ]
+          : []),
         ...ingestResult.failures.map((message, index) => ({
           code: "INGEST_ROW_FAILED",
           message,

--- a/src/app/api/overview/summary/route.ts
+++ b/src/app/api/overview/summary/route.ts
@@ -3,18 +3,19 @@ import { prisma } from "@/lib/db/prisma";
 import type { OverviewSummaryResponse } from "@/types/api";
 
 export async function GET() {
-  const [executionCount, matchedLots, setupCount, imports, snapshots] = await Promise.all([
+  const [executionCount, matchedLots, setupCount, imports, snapshotCount, snapshots] = await Promise.all([
     prisma.execution.count(),
     prisma.matchedLot.findMany({ select: { realizedPnl: true, holdingDays: true } }),
     prisma.setupGroup.count(),
     prisma.import.findMany({ select: { status: true, parsedRows: true, skippedRows: true } }),
+    prisma.dailyAccountSnapshot.count(),
     prisma.dailyAccountSnapshot.findMany({
       include: {
         account: {
           select: { accountId: true },
         },
       },
-      orderBy: [{ snapshotDate: "asc" }, { id: "asc" }],
+      orderBy: [{ snapshotDate: "desc" }, { id: "desc" }],
       take: 500,
     }),
   ]);
@@ -35,7 +36,7 @@ export async function GET() {
     matchedLotCount: matchedLots.length,
     setupCount,
     averageHoldDays: avgHold.toFixed(2),
-    snapshotCount: snapshots.length,
+    snapshotCount,
     importQuality: {
       totalImports: imports.length,
       committedImports,

--- a/src/lib/adapters/thinkorswim/cash-balance.ts
+++ b/src/lib/adapters/thinkorswim/cash-balance.ts
@@ -1,7 +1,4 @@
-export interface CashBalanceSnapshot {
-  snapshotDate: Date;
-  balance: number;
-}
+import type { NormalizedDailyAccountSnapshot } from "../types";
 
 function splitCsvLine(line: string): string[] {
   const columns: string[] = [];
@@ -63,9 +60,9 @@ function parseCurrency(value: string): number | null {
   return parsed;
 }
 
-export function parseCashBalanceSnapshots(csvText: string): CashBalanceSnapshot[] {
+export function parseCashBalanceSnapshots(csvText: string): NormalizedDailyAccountSnapshot[] {
   const lines = csvText.replace(/^\uFEFF/, "").split(/\r?\n/);
-  const snapshots: CashBalanceSnapshot[] = [];
+  const snapshots: NormalizedDailyAccountSnapshot[] = [];
 
   let inCashBalanceSection = false;
 

--- a/src/lib/adapters/thinkorswim/trade-history.test.ts
+++ b/src/lib/adapters/thinkorswim/trade-history.test.ts
@@ -16,6 +16,10 @@ describe("parseThinkorswimTradeHistory", () => {
     expect(resultTwo.executions.length).toBeGreaterThan(0);
     expect(resultSynthetic.executions.length).toBeGreaterThan(0);
 
+    expect(resultOne.snapshots.length).toBeGreaterThan(0);
+    expect(resultTwo.snapshots.length).toBeGreaterThan(0);
+    expect(Array.isArray(resultSynthetic.snapshots)).toBe(true);
+
     const spreads = new Set(resultOne.executions.map((row) => row.spread));
     expect(spreads.has("CALENDAR")).toBe(true);
     expect(spreads.has("COMBO")).toBe(true);

--- a/src/lib/adapters/thinkorswim/trade-history.ts
+++ b/src/lib/adapters/thinkorswim/trade-history.ts
@@ -1,4 +1,5 @@
 import { parseAccountMetadataFromCsv } from "../../accounts/parse-account-metadata";
+import { parseCashBalanceSnapshots } from "./cash-balance";
 import type { AdapterWarning, NormalizedExecution, ParseResult } from "../types";
 
 const TRADE_HISTORY_HEADER = ",Exec Time,Spread,Side,Qty,Pos Effect,Symbol,Exp,Strike,Type,Price,Net Price,Order Type";
@@ -308,6 +309,7 @@ export function parseThinkorswimTradeHistory(csvText: string): ParseResult {
     },
     warnings,
     executions,
+    snapshots: parseCashBalanceSnapshots(csvText),
     parsedRows,
     skippedRows,
   };

--- a/src/lib/adapters/types.ts
+++ b/src/lib/adapters/types.ts
@@ -35,10 +35,16 @@ export interface ParsedAccountMetadata {
   paperMoney: boolean;
 }
 
+export interface NormalizedDailyAccountSnapshot {
+  snapshotDate: Date;
+  balance: number;
+}
+
 export interface ParseResult {
   warnings: AdapterWarning[];
   accountMetadata: ParsedAccountMetadata;
   executions: NormalizedExecution[];
+  snapshots: NormalizedDailyAccountSnapshot[];
   parsedRows: number;
   skippedRows: number;
 }

--- a/src/lib/imports/replace-import-snapshots.test.ts
+++ b/src/lib/imports/replace-import-snapshots.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import { replaceImportSnapshots } from "./replace-import-snapshots";
+import type { NormalizedDailyAccountSnapshot } from "@/lib/adapters/types";
+
+interface StoredSnapshot {
+  id: string;
+  accountId: string;
+  snapshotDate: Date;
+  balance: number;
+  sourceRef: string | null;
+}
+
+class InMemorySnapshotStore {
+  private rowsByKey = new Map<string, StoredSnapshot>();
+  private idCounter = 0;
+
+  private buildKey(accountId: string, snapshotDate: Date): string {
+    return `${accountId}|${snapshotDate.toISOString()}`;
+  }
+
+  public snapshotCount(): number {
+    return this.rowsByKey.size;
+  }
+
+  public getRow(accountId: string, snapshotDate: Date): StoredSnapshot | undefined {
+    return this.rowsByKey.get(this.buildKey(accountId, snapshotDate));
+  }
+
+  public seed(row: Omit<StoredSnapshot, "id">) {
+    this.idCounter += 1;
+    const created: StoredSnapshot = { id: `snapshot-${this.idCounter}`, ...row };
+    this.rowsByKey.set(this.buildKey(row.accountId, row.snapshotDate), created);
+  }
+
+  public get tx() {
+    return {
+      dailyAccountSnapshot: {
+        deleteMany: async ({
+          where,
+        }: {
+          where: {
+            accountId: string;
+            sourceRef: string;
+            snapshotDate?: { notIn: Date[] };
+          };
+        }) => {
+          const notIn = where.snapshotDate?.notIn ?? null;
+          const keysToDelete = Array.from(this.rowsByKey.values())
+            .filter((row) => {
+              if (row.accountId !== where.accountId) return false;
+              if (row.sourceRef !== where.sourceRef) return false;
+              if (!notIn) return true;
+              return notIn.every((value) => value.toISOString() !== row.snapshotDate.toISOString());
+            })
+            .map((row) => this.buildKey(row.accountId, row.snapshotDate));
+
+          for (const key of keysToDelete) {
+            this.rowsByKey.delete(key);
+          }
+
+          return { count: keysToDelete.length };
+        },
+        upsert: async ({
+          where,
+          update,
+          create,
+        }: {
+          where: { accountId_snapshotDate: { accountId: string; snapshotDate: Date } };
+          update: { balance: number; sourceRef: string };
+          create: { accountId: string; snapshotDate: Date; balance: number; sourceRef: string };
+        }) => {
+          const key = this.buildKey(where.accountId_snapshotDate.accountId, where.accountId_snapshotDate.snapshotDate);
+          const existing = this.rowsByKey.get(key);
+          if (existing) {
+            const updated: StoredSnapshot = {
+              ...existing,
+              balance: update.balance,
+              sourceRef: update.sourceRef,
+            };
+            this.rowsByKey.set(key, updated);
+            return updated;
+          }
+
+          this.idCounter += 1;
+          const created: StoredSnapshot = {
+            id: `snapshot-${this.idCounter}`,
+            accountId: create.accountId,
+            snapshotDate: create.snapshotDate,
+            balance: create.balance,
+            sourceRef: create.sourceRef,
+          };
+          this.rowsByKey.set(key, created);
+          return created;
+        },
+      },
+    };
+  }
+}
+
+function snapshots(rows: Array<[string, string, number]>): NormalizedDailyAccountSnapshot[] {
+  return rows.map((row) => ({
+    snapshotDate: new Date(row[1]),
+    balance: row[2],
+  }));
+}
+
+describe("replaceImportSnapshots", () => {
+  it("upserts daily snapshots and stays idempotent for re-commits", async () => {
+    const store = new InMemorySnapshotStore();
+    const importId = "import-a";
+    const accountId = "account-1";
+    const rows = snapshots([
+      [accountId, "2026-03-01T00:00:00.000Z", 100000],
+      [accountId, "2026-03-02T00:00:00.000Z", 99500],
+    ]);
+
+    const first = await replaceImportSnapshots(store.tx as never, importId, accountId, rows);
+    expect(first.parsed).toBe(2);
+    expect(first.upserted).toBe(2);
+    expect(store.snapshotCount()).toBe(2);
+
+    const second = await replaceImportSnapshots(store.tx as never, importId, accountId, rows);
+    expect(second.parsed).toBe(2);
+    expect(second.upserted).toBe(2);
+    expect(store.snapshotCount()).toBe(2);
+
+    const updated = store.getRow(accountId, new Date("2026-03-02T00:00:00.000Z"));
+    expect(updated?.balance).toBe(99500);
+    expect(updated?.sourceRef).toBe(importId);
+  });
+
+  it("deletes stale snapshots previously attributed to the same import", async () => {
+    const store = new InMemorySnapshotStore();
+    const importId = "import-a";
+    const accountId = "account-1";
+
+    store.seed({
+      accountId,
+      snapshotDate: new Date("2026-03-01T00:00:00.000Z"),
+      balance: 100000,
+      sourceRef: importId,
+    });
+    store.seed({
+      accountId,
+      snapshotDate: new Date("2026-03-02T00:00:00.000Z"),
+      balance: 99000,
+      sourceRef: importId,
+    });
+
+    const result = await replaceImportSnapshots(store.tx as never, importId, accountId, [
+      { snapshotDate: new Date("2026-03-02T00:00:00.000Z"), balance: 99500 },
+    ]);
+
+    expect(result.deleted).toBe(1);
+    expect(store.snapshotCount()).toBe(1);
+    expect(store.getRow(accountId, new Date("2026-03-01T00:00:00.000Z"))).toBeUndefined();
+  });
+
+  it("does not delete snapshots that were superseded by another import", async () => {
+    const store = new InMemorySnapshotStore();
+    const importId = "import-a";
+    const otherImportId = "import-b";
+    const accountId = "account-1";
+
+    store.seed({
+      accountId,
+      snapshotDate: new Date("2026-03-01T00:00:00.000Z"),
+      balance: 100000,
+      sourceRef: otherImportId,
+    });
+
+    const result = await replaceImportSnapshots(store.tx as never, importId, accountId, []);
+
+    expect(result.deleted).toBe(0);
+    expect(store.snapshotCount()).toBe(1);
+    expect(store.getRow(accountId, new Date("2026-03-01T00:00:00.000Z"))?.sourceRef).toBe(otherImportId);
+  });
+});
+

--- a/src/lib/imports/replace-import-snapshots.ts
+++ b/src/lib/imports/replace-import-snapshots.ts
@@ -1,0 +1,55 @@
+import type { Prisma } from "@prisma/client";
+import type { NormalizedDailyAccountSnapshot } from "@/lib/adapters/types";
+
+export interface ReplaceImportSnapshotsResult {
+  parsed: number;
+  upserted: number;
+  deleted: number;
+}
+
+export async function replaceImportSnapshots(
+  tx: Prisma.TransactionClient,
+  importId: string,
+  accountId: string,
+  snapshots: NormalizedDailyAccountSnapshot[],
+): Promise<ReplaceImportSnapshotsResult> {
+  const snapshotDates = snapshots.map((snapshot) => snapshot.snapshotDate);
+
+  const deleted = await tx.dailyAccountSnapshot.deleteMany({
+    where: {
+      accountId,
+      sourceRef: importId,
+      ...(snapshotDates.length > 0 ? { snapshotDate: { notIn: snapshotDates } } : {}),
+    },
+  });
+
+  let upserted = 0;
+  for (const snapshot of snapshots) {
+    await tx.dailyAccountSnapshot.upsert({
+      where: {
+        accountId_snapshotDate: {
+          accountId,
+          snapshotDate: snapshot.snapshotDate,
+        },
+      },
+      update: {
+        balance: snapshot.balance,
+        sourceRef: importId,
+      },
+      create: {
+        accountId,
+        snapshotDate: snapshot.snapshotDate,
+        balance: snapshot.balance,
+        sourceRef: importId,
+      },
+    });
+    upserted += 1;
+  }
+
+  return {
+    parsed: snapshots.length,
+    upserted,
+    deleted: deleted.count,
+  };
+}
+


### PR DESCRIPTION
Closes #18.

Persist Cash Balance `BAL` rows into `daily_account_snapshots` during import commit, and update Overview summary to return the latest snapshot window.

Validation:
- npm test
- npm run typecheck
- npm run lint
