### PR TITLE
[codex] Fix equity curve filtering with account ID aliasing

### DIFF
--- a/src/components/widgets/AccountBalancesWidget.tsx
+++ b/src/components/widgets/AccountBalancesWidget.tsx
@@ -6,7 +6,7 @@ import { useNetLiquidationValue } from "@/hooks/useNetLiquidationValue";
 import { WidgetCard } from "@/components/widgets/WidgetCard";
 import { formatCurrency } from "@/components/widgets/utils";
 
-function AccountBalanceRow({ accountId, refreshSeed }: { accountId: string; refreshSeed: number }) {
+function AccountBalanceRow({ accountId, displayAccountId, refreshSeed }: { accountId: string; displayAccountId: string; refreshSeed: number }) {
   void refreshSeed;
   const { nlv, cash, lastUpdated, loading } = useNetLiquidationValue(accountId);
 
@@ -16,7 +16,7 @@ function AccountBalanceRow({ accountId, refreshSeed }: { accountId: string; refr
   return (
     <div className="rounded-lg border border-border bg-panel-2 p-3">
       <div className="flex items-center justify-between">
-        <p className="font-mono text-xs text-text">{accountId}</p>
+        <p className="font-mono text-xs text-text">{displayAccountId}</p>
         <p className="text-[11px] text-muted">{loading ? "Updating..." : lastUpdated ? lastUpdated.toLocaleTimeString() : "Quotes unavailable"}</p>
       </div>
       <p className="mt-1 text-xs text-muted">Cash: {formatCurrency(cash)}</p>
@@ -29,7 +29,7 @@ function AccountBalanceRow({ accountId, refreshSeed }: { accountId: string; refr
 }
 
 export function AccountBalancesWidget() {
-  const { selectedAccounts } = useAccountFilterContext();
+  const { selectedAccounts, toExternalAccountId } = useAccountFilterContext();
   const [refreshSeed, setRefreshSeed] = useState(0);
 
   const action = useMemo(
@@ -50,7 +50,12 @@ export function AccountBalancesWidget() {
       <div className="space-y-2">
         {selectedAccounts.length === 0 ? <p className="text-xs text-muted">No accounts selected.</p> : null}
         {selectedAccounts.map((accountId) => (
-          <AccountBalanceRow key={`${accountId}-${refreshSeed}`} accountId={accountId} refreshSeed={refreshSeed} />
+          <AccountBalanceRow
+            key={`${accountId}-${refreshSeed}`}
+            accountId={accountId}
+            displayAccountId={toExternalAccountId(accountId)}
+            refreshSeed={refreshSeed}
+          />
         ))}
       </div>
     </WidgetCard>

--- a/src/components/widgets/EquityCurveWidget.tsx
+++ b/src/components/widgets/EquityCurveWidget.tsx
@@ -12,7 +12,7 @@ interface OverviewPayload {
 }
 
 export function EquityCurveWidget() {
-  const { selectedAccounts } = useAccountFilterContext();
+  const { isSelectedAccount } = useAccountFilterContext();
   const [viewMode, setViewMode] = useState<"combined" | "accounts">("combined");
   const [data, setData] = useState<OverviewSummaryResponse["snapshotSeries"]>([]);
 
@@ -39,14 +39,14 @@ export function EquityCurveWidget() {
   }, []);
 
   const accounts = useMemo(() => {
-    return Array.from(new Set(data.map((point) => point.accountId).filter((accountId) => selectedAccounts.includes(accountId)))).sort();
-  }, [data, selectedAccounts]);
+    return Array.from(new Set(data.map((point) => point.accountId).filter((accountId) => isSelectedAccount(accountId)))).sort();
+  }, [data, isSelectedAccount]);
 
   const chartRows = useMemo(() => {
     const rowsByDate = new Map<string, Record<string, number | string>>();
 
     for (const point of data) {
-      if (!selectedAccounts.includes(point.accountId)) {
+      if (!isSelectedAccount(point.accountId)) {
         continue;
       }
 
@@ -59,7 +59,7 @@ export function EquityCurveWidget() {
     }
 
     return Array.from(rowsByDate.values()).sort((left, right) => String(left.date).localeCompare(String(right.date)));
-  }, [data, selectedAccounts]);
+  }, [data, isSelectedAccount]);
 
   return (
     <WidgetCard

--- a/src/components/widgets/ImportHealthWidget.tsx
+++ b/src/components/widgets/ImportHealthWidget.tsx
@@ -11,7 +11,7 @@ interface ImportsPayload {
 }
 
 export function ImportHealthWidget() {
-  const { selectedAccounts } = useAccountFilterContext();
+  const { isSelectedAccount } = useAccountFilterContext();
   const [rows, setRows] = useState<ImportRecord[]>([]);
 
   useEffect(() => {
@@ -37,7 +37,7 @@ export function ImportHealthWidget() {
   }, []);
 
   const summary = useMemo(() => {
-    const filtered = rows.filter((row) => selectedAccounts.includes(row.accountId));
+    const filtered = rows.filter((row) => isSelectedAccount(row.accountId));
     const committed = filtered.filter((row) => row.status === "COMMITTED").length;
     const failed = filtered.filter((row) => row.status === "FAILED").length;
     const parsedRows = filtered.reduce((sum, row) => sum + row.parsedRows, 0);
@@ -50,7 +50,7 @@ export function ImportHealthWidget() {
       parsedRows,
       skippedRows,
     };
-  }, [rows, selectedAccounts]);
+  }, [rows, isSelectedAccount]);
 
   const healthy = summary.failedImports === 0 && summary.skippedRows === 0;
 

--- a/src/contexts/AccountFilterContext.tsx
+++ b/src/contexts/AccountFilterContext.tsx
@@ -25,6 +25,8 @@ interface AccountFilterContextValue {
   availableAccounts: string[];
   selectedAccounts: string[];
   setSelectedAccounts: (ids: string[]) => void;
+  isSelectedAccount: (accountId: string) => boolean;
+  toExternalAccountId: (accountId: string) => string;
 }
 
 const AccountFilterContext = createContext<AccountFilterContextValue | null>(null);
@@ -36,34 +38,52 @@ function uniqueSorted(values: string[]): string[] {
 export function AccountFilterContextProvider({ children }: { children: React.ReactNode }) {
   const [availableAccounts, setAvailableAccounts] = useState<string[]>([]);
   const [selectedAccounts, setSelectedAccountsState] = useState<string[]>([]);
+  const [externalByInternal, setExternalByInternal] = useState<Record<string, string>>({});
 
   useEffect(() => {
     let cancelled = false;
 
     async function loadAccounts() {
       try {
-        const executionResponse = await fetch("/api/executions?page=1&pageSize=1000", { cache: "no-store" });
+        const [executionResponse, importResponse] = await Promise.all([
+          fetch("/api/executions?page=1&pageSize=1000", { cache: "no-store" }),
+          fetch("/api/imports?page=1&pageSize=1000", { cache: "no-store" }),
+        ]);
         let accountIds: string[] = [];
+        let executionRows: ExecutionRecord[] = [];
+        let importRows: ImportRecord[] = [];
 
         if (executionResponse.ok) {
           const payload = (await executionResponse.json()) as ExecutionListPayload;
-          accountIds = payload.data.map((row) => row.accountId);
+          executionRows = payload.data;
+          accountIds = executionRows.map((row) => row.accountId);
+        }
+
+        if (importResponse.ok) {
+          const payload = (await importResponse.json()) as ImportListPayload;
+          importRows = payload.data;
         }
 
         // Fallback to imports so the selector still hydrates before executions exist.
         if (accountIds.length === 0) {
-          const importResponse = await fetch("/api/imports?page=1&pageSize=1000", { cache: "no-store" });
-          if (importResponse.ok) {
-            const payload = (await importResponse.json()) as ImportListPayload;
-            accountIds = payload.data.map((row) => row.accountId);
-          }
+          accountIds = importRows.map((row) => row.accountId);
         }
 
         if (cancelled) {
           return;
         }
 
+        const externalByInternalNext: Record<string, string> = {};
+        const importById = new Map(importRows.map((row) => [row.id, row.accountId]));
+        for (const executionRow of executionRows) {
+          const externalAccountId = importById.get(executionRow.importId);
+          if (externalAccountId) {
+            externalByInternalNext[executionRow.accountId] = externalAccountId;
+          }
+        }
+
         const uniqueAccounts = uniqueSorted(accountIds);
+        setExternalByInternal(externalByInternalNext);
         setAvailableAccounts(uniqueAccounts);
         setSelectedAccountsState((current) => {
           if (current.length === 0) {
@@ -75,6 +95,7 @@ export function AccountFilterContextProvider({ children }: { children: React.Rea
         });
       } catch {
         if (!cancelled) {
+          setExternalByInternal({});
           setAvailableAccounts([]);
           setSelectedAccountsState([]);
         }
@@ -89,6 +110,9 @@ export function AccountFilterContextProvider({ children }: { children: React.Rea
   }, []);
 
   const value = useMemo<AccountFilterContextValue>(() => {
+    const selectedSet = new Set(selectedAccounts);
+    const selectedExternalSet = new Set(selectedAccounts.map((accountId) => externalByInternal[accountId] ?? accountId));
+
     return {
       availableAccounts,
       selectedAccounts,
@@ -97,8 +121,17 @@ export function AccountFilterContextProvider({ children }: { children: React.Rea
         const valid = unique.filter((accountId) => availableAccounts.includes(accountId));
         setSelectedAccountsState(valid.length === 0 ? availableAccounts : valid);
       },
+      toExternalAccountId: (accountId: string) => externalByInternal[accountId] ?? accountId,
+      isSelectedAccount: (accountId: string) => {
+        if (selectedSet.has(accountId) || selectedExternalSet.has(accountId)) {
+          return true;
+        }
+
+        const externalAccountId = externalByInternal[accountId];
+        return externalAccountId ? selectedExternalSet.has(externalAccountId) : false;
+      },
     };
-  }, [availableAccounts, selectedAccounts]);
+  }, [availableAccounts, selectedAccounts, externalByInternal]);
 
   return <AccountFilterContext.Provider value={value}>{children}</AccountFilterContext.Provider>;
 }

--- a/src/hooks/useNetLiquidationValue.ts
+++ b/src/hooks/useNetLiquidationValue.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { useAccountFilterContext } from "@/contexts/AccountFilterContext";
 import { useOpenPositions } from "@/hooks/useOpenPositions";
 import type {
   NlvResult,
@@ -20,6 +21,7 @@ function isUnavailable(value: unknown): value is QuoteUnavailableResponse {
 }
 
 export function useNetLiquidationValue(accountId: string): NlvResult {
+  const { toExternalAccountId } = useAccountFilterContext();
   const { positions, loading: positionsLoading } = useOpenPositions();
 
   const [nlv, setNlv] = useState<number | null>(null);
@@ -28,6 +30,7 @@ export function useNetLiquidationValue(accountId: string): NlvResult {
   const [loading, setLoading] = useState(true);
 
   const accountPositions = useMemo(() => positions.filter((position) => position.accountId === accountId), [accountId, positions]);
+  const externalAccountId = useMemo(() => toExternalAccountId(accountId), [accountId, toExternalAccountId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -48,7 +51,7 @@ export function useNetLiquidationValue(accountId: string): NlvResult {
 
         const summaryPayload = (await summaryResponse.json()) as OverviewPayload;
         const latestSnapshot = [...summaryPayload.data.snapshotSeries]
-          .filter((snapshot) => snapshot.accountId === accountId)
+          .filter((snapshot) => snapshot.accountId === externalAccountId)
           .sort((left, right) => new Date(right.snapshotDate).getTime() - new Date(left.snapshotDate).getTime())[0];
 
         const latestCash = Number(latestSnapshot?.balance ?? 0);
@@ -156,7 +159,7 @@ export function useNetLiquidationValue(accountId: string): NlvResult {
     return () => {
       cancelled = true;
     };
-  }, [accountId, accountPositions, positionsLoading]);
+  }, [accountId, accountPositions, externalAccountId, positionsLoading]);
 
   return {
     nlv,


### PR DESCRIPTION
## Summary
- add account ID alias resolution in `AccountFilterContext` to map internal account FK IDs to external business account IDs
- use normalized account selection matching in Equity Curve and Import Health widgets
- use external account IDs for snapshot lookup in NLV hook while preserving internal IDs for open positions
- display external account IDs in Account Balances rows

## Root cause
Different endpoints expose different `accountId` shapes (internal FK vs external business account ID). Widgets backed by snapshot/import APIs filtered against selection derived from execution APIs and incorrectly dropped all rows.

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm run test`

Fixes #21