### PR TITLE
Fix open-position math and dashboard layout persistence; add reconciliation report

### DIFF
--- a/docs/reconciliation/open-positions-reconciliation-2026-04-10.md
+++ b/docs/reconciliation/open-positions-reconciliation-2026-04-10.md
@@ -1,0 +1,68 @@
+# Open Positions Reconciliation Report (2026-04-10)
+
+## Scope
+Compare KapMan-derived open positions against user-provided broker references for:
+- `D-68011053` (app internal id suffix `em3s`)
+- `D-68011054` (app internal id suffix `tvc3`)
+
+This report covers quantity and cost basis reconciliation first, then account-level totals.
+
+## Method
+- Source-of-truth in app: `Execution` + `MatchedLot` tables, with open positions computed by subtracting matched quantity per `openExecutionId`.
+- Broker reference: screenshots provided in thread for accounts ending `053` and `054`.
+
+## Code Fixes Included
+1. Open positions now compute **remaining quantity** per open execution (`openQty - matchedQty`) rather than dropping any open execution that appears in matched lots.
+2. Option cost basis now applies multiplier-aware math (`x100` for options, `x1` for equities).
+3. Dashboard widget layout persistence now uses hydration-safe localStorage flow to prevent default-layout overwrite on first render.
+
+## Reconciliation Summary
+
+### Account D-68011054
+- Status: **Reconciled** for all visible open positions and totals in provided reference.
+- Row checks (AVGO, SPHQ, QQQM, TGT): quantity and cost basis match.
+- Account total cost basis: **$90,588.36** (broker) vs **$90,588.36** (app-derived from imported data).
+
+### Account D-68011053
+- Status: **Partially reconciled**.
+- 16 of 18 broker-listed open positions match quantity and cost basis.
+- Two deltas remain:
+  - `SDS`
+    - Broker: Qty `30`, Cost `$2,220.60`
+    - App-derived: Qty `270`, Cost `$3,994.90`
+    - Delta: `+240` shares, `+$1,774.30` cost basis
+  - `XLU`
+    - Broker: Qty `100`, Cost `$4,589.00`
+    - App-derived: **not open**
+    - Delta: `-100` shares, `-$4,589.00` cost basis
+
+- Account total cost basis:
+  - Broker total: **$180,016.35**
+  - App-derived total: **$177,201.65**
+  - Delta: **-$2,814.70**
+
+- The two symbol deltas explain the full account total delta exactly:
+  - `(-$4,589.00 from missing XLU) + (+$1,774.30 excess SDS) = -$2,814.70`
+
+## Data Evidence (Imported Executions)
+For `D-68011053`:
+- `SDS` executions in DB show:
+  - BUY 200 @ 14.87 (TO_OPEN)
+  - BUY 100 @ 14.67 (TO_OPEN)
+  - SELL 30 @ 68.72 (TO_CLOSE)
+- Matched lots for SDS show only one close quantity of `30` against the first open.
+- Therefore remaining SDS quantity from imported data is `270`.
+
+For `XLU` executions in DB show:
+- BUY 100 @ 91.78 (TO_OPEN)
+- SELL 100 @ 47.00 (TO_CLOSE) on 2026-02-24
+- Therefore XLU is closed in imported data and does not appear as open.
+
+## Interpretation
+The remaining mismatches are consistent with a **data parity gap** between imported statements and broker reference point-in-time (or statement coverage/content differences), not with the open-position math bug addressed in this patch.
+
+## Recommended Remediation
+1. Re-export and re-import the latest full statement set for `D-68011053` ensuring Trade History includes all closes relevant to current open holdings.
+2. Validate SDS and XLU specifically after import by comparing execution timeline and matched-lot coverage.
+3. Add a diagnostics check for symbol-level parity gaps (optional follow-up issue):
+   - flag symbols where broker-open references disagree with imported open quantity.

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -14,6 +14,15 @@ interface OverviewPayload {
   data: OverviewSummaryResponse;
 }
 
+function sanitizeStoredLayout(value: unknown, validWidgetIds: ReadonlySet<string>): string[] {
+  if (!Array.isArray(value)) {
+    return DEFAULT_DASHBOARD_LAYOUT;
+  }
+
+  const filtered = value.filter((item): item is string => typeof item === "string" && validWidgetIds.has(item));
+  return filtered.length > 0 ? filtered : DEFAULT_DASHBOARD_LAYOUT;
+}
+
 function reorder<T>(items: T[], from: number, to: number): T[] {
   const next = [...items];
   const [moved] = next.splice(from, 1);
@@ -68,7 +77,9 @@ function DashboardTile({
 
 export default function Page() {
   const widgetMap = useMemo(() => new Map(WIDGET_REGISTRY.map((widget) => [widget.id, widget])), []);
+  const validWidgetIds = useMemo(() => new Set(WIDGET_REGISTRY.map((widget) => widget.id)), []);
   const [layout, setLayout] = useState<string[]>(DEFAULT_DASHBOARD_LAYOUT);
+  const [layoutHydrated, setLayoutHydrated] = useState(false);
   const [editMode, setEditMode] = useState(false);
   const [pickerOpen, setPickerOpen] = useState(false);
 
@@ -79,26 +90,28 @@ export default function Page() {
   useEffect(() => {
     try {
       const stored = window.localStorage.getItem(LAYOUT_STORAGE_KEY);
-      if (!stored) {
-        return;
-      }
-
-      const parsed = JSON.parse(stored) as string[];
-      if (Array.isArray(parsed) && parsed.every((value) => typeof value === "string") && parsed.length > 0) {
-        setLayout(parsed);
+      if (stored) {
+        const parsed = JSON.parse(stored) as unknown;
+        setLayout(sanitizeStoredLayout(parsed, validWidgetIds));
       }
     } catch {
       setLayout(DEFAULT_DASHBOARD_LAYOUT);
+    } finally {
+      setLayoutHydrated(true);
     }
-  }, []);
+  }, [validWidgetIds]);
 
   useEffect(() => {
+    if (!layoutHydrated) {
+      return;
+    }
+
     try {
       window.localStorage.setItem(LAYOUT_STORAGE_KEY, JSON.stringify(layout));
     } catch {
       // Ignore localStorage errors.
     }
-  }, [layout]);
+  }, [layout, layoutHydrated]);
 
   useEffect(() => {
     let cancelled = false;

--- a/src/hooks/useOpenPositions.ts
+++ b/src/hooks/useOpenPositions.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import type { ExecutionRecord, MatchedLotRecord, OpenPosition } from "@/types/api";
+import { computeOpenPositions } from "@/lib/positions/compute-open-positions";
 
 interface ExecutionsPayload {
   data: ExecutionRecord[];
@@ -9,22 +10,6 @@ interface ExecutionsPayload {
 
 interface MatchedLotsPayload {
   data: MatchedLotRecord[];
-}
-
-function signedQuantity(side: string | null, quantity: number): number {
-  return side === "SELL" ? quantity * -1 : quantity;
-}
-
-function fallbackInstrumentKey(execution: ExecutionRecord): string {
-  const expiration = execution.expirationDate ? execution.expirationDate.slice(0, 10) : "";
-  return [
-    execution.accountId,
-    execution.assetClass,
-    execution.underlyingSymbol ?? execution.symbol,
-    execution.optionType ?? "",
-    execution.strike ?? "",
-    expiration,
-  ].join("|");
 }
 
 export function useOpenPositions(): { positions: OpenPosition[]; loading: boolean; error: string | null } {
@@ -52,55 +37,7 @@ export function useOpenPositions(): { positions: OpenPosition[]; loading: boolea
         const executionsPayload = (await executionResponse.json()) as ExecutionsPayload;
         const matchedLotsPayload = (await matchedLotsResponse.json()) as MatchedLotsPayload;
 
-        const matchedOpenExecutionIds = new Set(matchedLotsPayload.data.map((row) => row.openExecutionId));
-        const grouped = new Map<string, OpenPosition>();
-
-        for (const execution of executionsPayload.data) {
-          if (execution.openingClosingEffect !== "TO_OPEN") {
-            continue;
-          }
-
-          if (matchedOpenExecutionIds.has(execution.id)) {
-            continue;
-          }
-
-          const key = execution.instrumentKey ?? fallbackInstrumentKey(execution);
-          const groupKey = execution.accountId + "::" + key;
-          const quantity = Number(execution.quantity);
-          const price = Number(execution.price ?? 0);
-          const qtySigned = signedQuantity(execution.side, quantity);
-
-          const existing = grouped.get(groupKey);
-          if (existing) {
-            existing.netQty += qtySigned;
-            existing.costBasis += qtySigned * price;
-            continue;
-          }
-
-          grouped.set(groupKey, {
-            symbol: execution.symbol,
-            underlyingSymbol: execution.underlyingSymbol ?? execution.symbol,
-            assetClass: execution.assetClass === "OPTION" ? "OPTION" : "EQUITY",
-            optionType: execution.optionType === "CALL" || execution.optionType === "PUT" ? execution.optionType : null,
-            strike: execution.strike,
-            expirationDate: execution.expirationDate,
-            instrumentKey: key,
-            netQty: qtySigned,
-            costBasis: qtySigned * price,
-            accountId: execution.accountId,
-          });
-        }
-
-        const openPositions = Array.from(grouped.values())
-          .filter((position) => position.netQty !== 0)
-          .sort((left, right) => {
-            const symbolOrder = left.underlyingSymbol.localeCompare(right.underlyingSymbol);
-            if (symbolOrder !== 0) {
-              return symbolOrder;
-            }
-
-            return left.instrumentKey.localeCompare(right.instrumentKey);
-          });
+        const openPositions = computeOpenPositions(executionsPayload.data, matchedLotsPayload.data);
 
         if (!cancelled) {
           setPositions(openPositions);

--- a/src/lib/positions/compute-open-positions.test.ts
+++ b/src/lib/positions/compute-open-positions.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import type { ExecutionRecord, MatchedLotRecord } from "@/types/api";
+import { computeOpenPositions } from "./compute-open-positions";
+
+function execution(overrides: Partial<ExecutionRecord> & Pick<ExecutionRecord, "id" | "symbol" | "accountId">): ExecutionRecord {
+  return {
+    id: overrides.id,
+    accountId: overrides.accountId,
+    broker: "SCHWAB_THINKORSWIM",
+    symbol: overrides.symbol,
+    tradeDate: overrides.tradeDate ?? "2026-01-01T00:00:00.000Z",
+    eventTimestamp: overrides.eventTimestamp ?? "2026-01-01T13:00:00.000Z",
+    eventType: overrides.eventType ?? "TRADE",
+    assetClass: overrides.assetClass ?? "EQUITY",
+    side: overrides.side ?? "BUY",
+    quantity: overrides.quantity ?? "1",
+    price: overrides.price ?? "1",
+    openingClosingEffect: overrides.openingClosingEffect ?? "TO_OPEN",
+    instrumentKey: overrides.instrumentKey ?? overrides.symbol,
+    underlyingSymbol: overrides.underlyingSymbol ?? overrides.symbol,
+    optionType: overrides.optionType ?? null,
+    strike: overrides.strike ?? null,
+    expirationDate: overrides.expirationDate ?? null,
+    spreadGroupId: overrides.spreadGroupId ?? null,
+    importId: overrides.importId ?? "import-1",
+  };
+}
+
+function matchedLot(overrides: Partial<MatchedLotRecord> & Pick<MatchedLotRecord, "id" | "openExecutionId">): MatchedLotRecord {
+  return {
+    id: overrides.id,
+    accountId: overrides.accountId ?? "account-1",
+    symbol: overrides.symbol ?? "SDS",
+    openTradeDate: overrides.openTradeDate ?? "2026-01-01T00:00:00.000Z",
+    closeTradeDate: overrides.closeTradeDate ?? "2026-01-02T00:00:00.000Z",
+    openImportId: overrides.openImportId ?? "import-1",
+    closeImportId: overrides.closeImportId ?? "import-2",
+    quantity: overrides.quantity ?? "1",
+    realizedPnl: overrides.realizedPnl ?? "0",
+    holdingDays: overrides.holdingDays ?? 1,
+    outcome: overrides.outcome ?? "WIN",
+    openExecutionId: overrides.openExecutionId,
+    closeExecutionId: overrides.closeExecutionId ?? "close-1",
+  };
+}
+
+describe("computeOpenPositions", () => {
+  it("subtracts partial matches from open quantity per execution instead of dropping full opens", () => {
+    const executions: ExecutionRecord[] = [
+      execution({ id: "open-a", accountId: "account-1", symbol: "SDS", quantity: "200", price: "14.87", instrumentKey: "SDS" }),
+      execution({ id: "open-b", accountId: "account-1", symbol: "SDS", quantity: "100", price: "14.67", instrumentKey: "SDS" }),
+    ];
+
+    const lots: MatchedLotRecord[] = [
+      matchedLot({ id: "lot-a", openExecutionId: "open-a", quantity: "30", symbol: "SDS", accountId: "account-1" }),
+    ];
+
+    const result = computeOpenPositions(executions, lots);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.symbol).toBe("SDS");
+    expect(result[0]?.netQty).toBe(270);
+    expect(result[0]?.costBasis).toBeCloseTo(3994.9, 6);
+  });
+
+  it("uses option multiplier when computing remaining cost basis", () => {
+    const executions: ExecutionRecord[] = [
+      execution({
+        id: "open-opt",
+        accountId: "account-1",
+        symbol: "AVGO",
+        assetClass: "OPTION",
+        optionType: "PUT",
+        strike: "320",
+        expirationDate: "2026-05-15T00:00:00.000Z",
+        side: "SELL",
+        quantity: "2",
+        price: "1.98",
+        instrumentKey: "AVGO|PUT|320|2026-05-15",
+      }),
+    ];
+
+    const lots: MatchedLotRecord[] = [
+      matchedLot({ id: "lot-opt", openExecutionId: "open-opt", quantity: "1", symbol: "AVGO", accountId: "account-1" }),
+    ];
+
+    const result = computeOpenPositions(executions, lots);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.netQty).toBe(-1);
+    expect(result[0]?.costBasis).toBeCloseTo(-198, 6);
+  });
+});

--- a/src/lib/positions/compute-open-positions.ts
+++ b/src/lib/positions/compute-open-positions.ts
@@ -1,0 +1,87 @@
+import type { ExecutionRecord, MatchedLotRecord, OpenPosition } from "@/types/api";
+
+function signedQuantity(side: string | null, quantity: number): number {
+  return side === "SELL" ? quantity * -1 : quantity;
+}
+
+function fallbackInstrumentKey(execution: ExecutionRecord): string {
+  const expiration = execution.expirationDate ? execution.expirationDate.slice(0, 10) : "";
+  return [
+    execution.accountId,
+    execution.assetClass,
+    execution.underlyingSymbol ?? execution.symbol,
+    execution.optionType ?? "",
+    execution.strike ?? "",
+    expiration,
+  ].join("|");
+}
+
+export function computeOpenPositions(executions: ExecutionRecord[], matchedLots: MatchedLotRecord[]): OpenPosition[] {
+  const matchedQtyByOpenExecutionId = new Map<string, number>();
+  for (const lot of matchedLots) {
+    const quantity = Number(lot.quantity);
+    if (!Number.isFinite(quantity) || quantity <= 0) {
+      continue;
+    }
+
+    const current = matchedQtyByOpenExecutionId.get(lot.openExecutionId) ?? 0;
+    matchedQtyByOpenExecutionId.set(lot.openExecutionId, current + quantity);
+  }
+
+  const grouped = new Map<string, OpenPosition>();
+
+  for (const execution of executions) {
+    if (execution.openingClosingEffect !== "TO_OPEN") {
+      continue;
+    }
+
+    const openQuantity = Number(execution.quantity);
+    if (!Number.isFinite(openQuantity) || openQuantity <= 0) {
+      continue;
+    }
+
+    const matchedQuantity = matchedQtyByOpenExecutionId.get(execution.id) ?? 0;
+    const remainingQuantity = Math.max(0, openQuantity - matchedQuantity);
+    if (remainingQuantity === 0) {
+      continue;
+    }
+
+    const key = execution.instrumentKey ?? fallbackInstrumentKey(execution);
+    const groupKey = execution.accountId + "::" + key;
+
+    const price = Number(execution.price ?? 0);
+    const qtySigned = signedQuantity(execution.side, remainingQuantity);
+    const multiplier = execution.assetClass === "OPTION" ? 100 : 1;
+
+    const existing = grouped.get(groupKey);
+    if (existing) {
+      existing.netQty += qtySigned;
+      existing.costBasis += qtySigned * price * multiplier;
+      continue;
+    }
+
+    grouped.set(groupKey, {
+      symbol: execution.symbol,
+      underlyingSymbol: execution.underlyingSymbol ?? execution.symbol,
+      assetClass: execution.assetClass === "OPTION" ? "OPTION" : "EQUITY",
+      optionType: execution.optionType === "CALL" || execution.optionType === "PUT" ? execution.optionType : null,
+      strike: execution.strike,
+      expirationDate: execution.expirationDate,
+      instrumentKey: key,
+      netQty: qtySigned,
+      costBasis: qtySigned * price * multiplier,
+      accountId: execution.accountId,
+    });
+  }
+
+  return Array.from(grouped.values())
+    .filter((position) => position.netQty !== 0)
+    .sort((left, right) => {
+      const symbolOrder = left.underlyingSymbol.localeCompare(right.underlyingSymbol);
+      if (symbolOrder !== 0) {
+        return symbolOrder;
+      }
+
+      return left.instrumentKey.localeCompare(right.instrumentKey);
+    });
+}


### PR DESCRIPTION
## Summary
- Fix open-position calculation to subtract matched quantity per `openExecutionId` (partial-close aware).
- Apply option multiplier-aware cost basis math (`x100` for options).
- Fix dashboard widget layout persistence race by guarding writes until localStorage hydration completes and sanitizing stored widget IDs.
- Add reconciliation report for accounts ending `053` and `054`.

## Validation
- `npm test`
- `npm run typecheck`
- `npm run lint`

## Reconciliation artifact
- `docs/reconciliation/open-positions-reconciliation-2026-04-10.md`

Fixes #24
Fixes #25
