### PR TITLE
Fix Open Positions manual quote refresh cache bypass

### DIFF
--- a/src/app/api/option-quote/route.test.ts
+++ b/src/app/api/option-quote/route.test.ts
@@ -73,4 +73,31 @@ describe("GET /api/option-quote", () => {
     });
     expect(optionRouteMocks.getOptionQuote).toHaveBeenCalledTimes(1);
   });
+
+  it("bypasses cache when refresh=1 is set", async () => {
+    optionRouteMocks.getOptionQuote.mockResolvedValue({
+      mark: 3.1,
+      bid: 3.0,
+      ask: 3.2,
+      delta: 0.45,
+      theta: -0.04,
+      iv: 22.5,
+      dte: 252,
+      inTheMoney: false,
+    });
+    const { GET } = await import("./route");
+
+    const cachedRequest = new Request(
+      "http://localhost/api/option-quote?symbol=SPY&strike=500&expDate=2026-12-18&contractType=CALL",
+    );
+    const refreshRequest = new Request(
+      "http://localhost/api/option-quote?symbol=SPY&strike=500&expDate=2026-12-18&contractType=CALL&refresh=1",
+    );
+
+    await GET(cachedRequest);
+    await GET(cachedRequest);
+    await GET(refreshRequest);
+
+    expect(optionRouteMocks.getOptionQuote).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/app/api/option-quote/route.ts
+++ b/src/app/api/option-quote/route.ts
@@ -19,6 +19,7 @@ export async function GET(request: Request) {
   const strikeRaw = (url.searchParams.get("strike") ?? "").trim();
   const expDate = (url.searchParams.get("expDate") ?? "").trim();
   const contractType = (url.searchParams.get("contractType") ?? "").trim().toUpperCase();
+  const forceRefresh = url.searchParams.get("refresh") === "1";
   const strike = Number(strikeRaw);
 
   if (!symbol || !expDate || !Number.isFinite(strike) || (contractType !== "CALL" && contractType !== "PUT")) {
@@ -27,9 +28,11 @@ export async function GET(request: Request) {
 
   const now = Date.now();
   const cacheKey = [symbol, String(strike), expDate, contractType].join("|");
-  const cached = optionQuoteCache.get(cacheKey);
-  if (cached && cached.expiresAtMs > now) {
-    return NextResponse.json(cached.value);
+  if (!forceRefresh) {
+    const cached = optionQuoteCache.get(cacheKey);
+    if (cached && cached.expiresAtMs > now) {
+      return NextResponse.json(cached.value);
+    }
   }
 
   try {

--- a/src/app/api/quotes/route.test.ts
+++ b/src/app/api/quotes/route.test.ts
@@ -27,4 +27,55 @@ describe("GET /api/quotes", () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ error: "unavailable" });
   });
+
+  it("uses cache within TTL and bypasses cache when refresh=1 is set", async () => {
+    quotesRouteMocks.getEquityQuotes.mockResolvedValue({
+      SPY: {
+        mark: 100,
+        bid: 99.9,
+        ask: 100.1,
+        last: 100,
+        netChange: 1,
+        netPctChange: 1,
+      },
+    });
+    const { GET } = await import("./route");
+
+    const first = await GET(new Request("http://localhost/api/quotes?symbols=SPY"));
+    const second = await GET(new Request("http://localhost/api/quotes?symbols=SPY"));
+    const refreshed = await GET(new Request("http://localhost/api/quotes?symbols=SPY&refresh=1"));
+
+    await expect(first.json()).resolves.toEqual({
+      SPY: {
+        mark: 100,
+        bid: 99.9,
+        ask: 100.1,
+        last: 100,
+        netChange: 1,
+        netPctChange: 1,
+      },
+    });
+    await expect(second.json()).resolves.toEqual({
+      SPY: {
+        mark: 100,
+        bid: 99.9,
+        ask: 100.1,
+        last: 100,
+        netChange: 1,
+        netPctChange: 1,
+      },
+    });
+    await expect(refreshed.json()).resolves.toEqual({
+      SPY: {
+        mark: 100,
+        bid: 99.9,
+        ask: 100.1,
+        last: 100,
+        netChange: 1,
+        netPctChange: 1,
+      },
+    });
+
+    expect(quotesRouteMocks.getEquityQuotes).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/app/api/quotes/route.ts
+++ b/src/app/api/quotes/route.ts
@@ -16,6 +16,7 @@ function unavailable(): QuoteUnavailableResponse {
 export async function GET(request: Request) {
   const url = new URL(request.url);
   const symbolsRaw = url.searchParams.get("symbols") ?? "";
+  const forceRefresh = url.searchParams.get("refresh") === "1";
   const symbols = Array.from(
     new Set(
       symbolsRaw
@@ -31,9 +32,11 @@ export async function GET(request: Request) {
 
   const cacheKey = symbols.join(",");
   const now = Date.now();
-  const cached = quoteCache.get(cacheKey);
-  if (cached && cached.expiresAtMs > now) {
-    return NextResponse.json(cached.value);
+  if (!forceRefresh) {
+    const cached = quoteCache.get(cacheKey);
+    if (cached && cached.expiresAtMs > now) {
+      return NextResponse.json(cached.value);
+    }
   }
 
   try {

--- a/src/app/positions/page.tsx
+++ b/src/app/positions/page.tsx
@@ -82,13 +82,14 @@ export default function Page() {
       try {
         const nextMap: Record<string, number | null> = {};
         let unavailable = false;
+        const forceRefreshParam = refreshCounter > 0 ? "&refresh=1" : "";
 
         const equityPositions = filteredPositions.filter((position) => position.assetClass === "EQUITY");
         const optionPositions = filteredPositions.filter((position) => position.assetClass === "OPTION");
 
         if (equityPositions.length > 0) {
           const symbols = Array.from(new Set(equityPositions.map((position) => position.symbol))).join(",");
-          const equityResponse = await fetch(`/api/quotes?symbols=${encodeURIComponent(symbols)}`, { cache: "no-store" });
+          const equityResponse = await fetch(`/api/quotes?symbols=${encodeURIComponent(symbols)}${forceRefreshParam}`, { cache: "no-store" });
           const equityPayload = (await equityResponse.json()) as QuotesResponse;
 
           if (isQuoteUnavailable(equityPayload)) {
@@ -117,7 +118,7 @@ export default function Page() {
               const response = await fetch(
                 `/api/option-quote?symbol=${encodeURIComponent(position.underlyingSymbol)}&strike=${encodeURIComponent(
                   position.strike,
-                )}&expDate=${encodeURIComponent(expDate)}&contractType=${position.optionType}`,
+                )}&expDate=${encodeURIComponent(expDate)}&contractType=${position.optionType}${forceRefreshParam}`,
                 { cache: "no-store" },
               );
 


### PR DESCRIPTION
## Summary
- Add `refresh=1` cache-bypass support to `/api/quotes` and `/api/option-quote`.
- Update Open Positions refresh flow to include `refresh=1` only on manual refresh clicks.
- Add route tests verifying TTL cache behavior and manual refresh bypass behavior.

## Validation
- `npm test -- src/app/api/quotes/route.test.ts src/app/api/option-quote/route.test.ts`
- `npm run typecheck`
- `npm run lint`
