### PR TITLE
Fix partial open-position refresh from MCP option quote resolution

### DIFF
--- a/src/app/api/option-quote/route.test.ts
+++ b/src/app/api/option-quote/route.test.ts
@@ -100,4 +100,42 @@ describe("GET /api/option-quote", () => {
 
     expect(optionRouteMocks.getOptionQuote).toHaveBeenCalledTimes(2);
   });
+
+  it("falls back to cached option quote when refresh lookup is unavailable", async () => {
+    optionRouteMocks.getOptionQuote
+      .mockResolvedValueOnce({
+        mark: 3.1,
+        bid: 3.0,
+        ask: 3.2,
+        delta: 0.45,
+        theta: -0.04,
+        iv: 22.5,
+        dte: 252,
+        inTheMoney: false,
+      })
+      .mockResolvedValueOnce(null);
+    const { GET } = await import("./route");
+
+    const cachedRequest = new Request(
+      "http://localhost/api/option-quote?symbol=SPY&strike=500&expDate=2026-12-18&contractType=CALL",
+    );
+    const refreshRequest = new Request(
+      "http://localhost/api/option-quote?symbol=SPY&strike=500&expDate=2026-12-18&contractType=CALL&refresh=1",
+    );
+
+    await GET(cachedRequest);
+    const refreshed = await GET(refreshRequest);
+
+    await expect(refreshed.json()).resolves.toEqual({
+      mark: 3.1,
+      bid: 3.0,
+      ask: 3.2,
+      delta: 0.45,
+      theta: -0.04,
+      iv: 22.5,
+      dte: 252,
+      inTheMoney: false,
+    });
+    expect(optionRouteMocks.getOptionQuote).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/app/api/option-quote/route.ts
+++ b/src/app/api/option-quote/route.ts
@@ -28,8 +28,8 @@ export async function GET(request: Request) {
 
   const now = Date.now();
   const cacheKey = [symbol, String(strike), expDate, contractType].join("|");
+  const cached = optionQuoteCache.get(cacheKey);
   if (!forceRefresh) {
-    const cached = optionQuoteCache.get(cacheKey);
     if (cached && cached.expiresAtMs > now) {
       return NextResponse.json(cached.value);
     }
@@ -38,6 +38,10 @@ export async function GET(request: Request) {
   try {
     const responsePayload = await getOptionQuote(symbol, strike, expDate, contractType);
     if (responsePayload === null) {
+      if (cached) {
+        return NextResponse.json(cached.value);
+      }
+
       return NextResponse.json(unavailable());
     }
 
@@ -48,6 +52,10 @@ export async function GET(request: Request) {
 
     return NextResponse.json(responsePayload);
   } catch {
+    if (cached) {
+      return NextResponse.json(cached.value);
+    }
+
     return NextResponse.json(unavailable());
   }
 }

--- a/src/app/api/quotes/route.test.ts
+++ b/src/app/api/quotes/route.test.ts
@@ -78,4 +78,35 @@ describe("GET /api/quotes", () => {
 
     expect(quotesRouteMocks.getEquityQuotes).toHaveBeenCalledTimes(2);
   });
+
+  it("falls back to cached quotes when refresh lookup is unavailable", async () => {
+    quotesRouteMocks.getEquityQuotes
+      .mockResolvedValueOnce({
+        SPY: {
+          mark: 100,
+          bid: 99.9,
+          ask: 100.1,
+          last: 100,
+          netChange: 1,
+          netPctChange: 1,
+        },
+      })
+      .mockResolvedValueOnce(null);
+    const { GET } = await import("./route");
+
+    await GET(new Request("http://localhost/api/quotes?symbols=SPY"));
+    const refreshed = await GET(new Request("http://localhost/api/quotes?symbols=SPY&refresh=1"));
+
+    await expect(refreshed.json()).resolves.toEqual({
+      SPY: {
+        mark: 100,
+        bid: 99.9,
+        ask: 100.1,
+        last: 100,
+        netChange: 1,
+        netPctChange: 1,
+      },
+    });
+    expect(quotesRouteMocks.getEquityQuotes).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/app/api/quotes/route.ts
+++ b/src/app/api/quotes/route.ts
@@ -32,8 +32,8 @@ export async function GET(request: Request) {
 
   const cacheKey = symbols.join(",");
   const now = Date.now();
+  const cached = quoteCache.get(cacheKey);
   if (!forceRefresh) {
-    const cached = quoteCache.get(cacheKey);
     if (cached && cached.expiresAtMs > now) {
       return NextResponse.json(cached.value);
     }
@@ -42,8 +42,11 @@ export async function GET(request: Request) {
   try {
     const responsePayload = await getEquityQuotes(symbols);
     if (responsePayload === null) {
-      const payload = unavailable();
-      return NextResponse.json(payload);
+      if (cached) {
+        return NextResponse.json(cached.value);
+      }
+
+      return NextResponse.json(unavailable());
     }
 
     quoteCache.set(cacheKey, {
@@ -53,6 +56,10 @@ export async function GET(request: Request) {
 
     return NextResponse.json(responsePayload);
   } catch {
+    if (cached) {
+      return NextResponse.json(cached.value);
+    }
+
     return NextResponse.json(unavailable());
   }
 }

--- a/src/lib/mcp/market-data.test.ts
+++ b/src/lib/mcp/market-data.test.ts
@@ -95,4 +95,93 @@ describe("market-data MCP adapter", () => {
 
     expect(result).toBeNull();
   });
+
+  it("retries VIX option chain lookup using $VIX fallback symbol", async () => {
+    marketDataMocks.callMcpTool
+      .mockResolvedValueOnce({
+        callExpDateMap: {
+          "2026-06-17:68": {},
+        },
+      })
+      .mockResolvedValueOnce({
+        callExpDateMap: {
+          "2026-06-17:68": {
+            "25.0": [
+              {
+                mark: 2.15,
+                bid: 0.1,
+                ask: 4.2,
+                delta: 0.648,
+                theta: -0.059,
+                volatility: 55.977,
+                daysToExpiration: 68,
+                inTheMoney: false,
+              },
+            ],
+          },
+        },
+      });
+
+    const { getOptionQuote } = await import("./market-data");
+    const result = await getOptionQuote("VIX", 25, "2026-06-17", "CALL");
+
+    expect(result).toEqual({
+      mark: 2.15,
+      bid: 0.1,
+      ask: 4.2,
+      delta: 0.648,
+      theta: -0.059,
+      iv: 55.977,
+      dte: 68,
+      inTheMoney: false,
+    });
+    expect(marketDataMocks.callMcpTool).toHaveBeenNthCalledWith(
+      1,
+      "get_option_chain",
+      expect.objectContaining({ symbol: "VIX" }),
+    );
+    expect(marketDataMocks.callMcpTool).toHaveBeenNthCalledWith(
+      2,
+      "get_option_chain",
+      expect.objectContaining({ symbol: "$VIX" }),
+    );
+  });
+
+  it("continues to $VIX fallback when VIX call fails", async () => {
+    marketDataMocks.callMcpTool
+      .mockRejectedValueOnce(new marketDataMocks.MockMcpUnavailableError("VIX unavailable"))
+      .mockResolvedValueOnce({
+        callExpDateMap: {
+          "2026-06-17:68": {
+            "25.0": [
+              {
+                mark: 2.15,
+                bid: 0.1,
+                ask: 4.2,
+                delta: 0.648,
+                theta: -0.059,
+                volatility: 55.977,
+                daysToExpiration: 68,
+                inTheMoney: false,
+              },
+            ],
+          },
+        },
+      });
+
+    const { getOptionQuote } = await import("./market-data");
+    const result = await getOptionQuote("VIX", 25, "2026-06-17", "CALL");
+
+    expect(result).toEqual({
+      mark: 2.15,
+      bid: 0.1,
+      ask: 4.2,
+      delta: 0.648,
+      theta: -0.059,
+      iv: 55.977,
+      dte: 68,
+      inTheMoney: false,
+    });
+    expect(marketDataMocks.callMcpTool).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/lib/mcp/market-data.ts
+++ b/src/lib/mcp/market-data.ts
@@ -72,6 +72,31 @@ function pickOptionExpMap(payload: unknown, contractType: "CALL" | "PUT"): Optio
   return expMap && typeof expMap === "object" ? (expMap as OptionContractMap) : null;
 }
 
+function mapOptionContract(contract: Record<string, unknown>): OptionQuoteRecord | null {
+  const mark = numberOrNull(contract.mark) ?? numberOrNull(contract.markChange) ?? numberOrNull(contract.last);
+  const bid = numberOrNull(contract.bid);
+  const ask = numberOrNull(contract.ask);
+  const delta = numberOrNull(contract.delta);
+  const theta = numberOrNull(contract.theta);
+  const iv = numberOrNull(contract.volatility);
+  const dte = numberOrNull(contract.daysToExpiration);
+
+  if (mark === null || bid === null || ask === null || delta === null || theta === null || iv === null || dte === null) {
+    return null;
+  }
+
+  return {
+    mark,
+    bid,
+    ask,
+    delta,
+    theta,
+    iv,
+    dte,
+    inTheMoney: Boolean(contract.inTheMoney),
+  };
+}
+
 export async function getEquityQuotes(symbols: string[]): Promise<Record<string, EquityQuoteRecord> | null> {
   try {
     const result = await callMcpTool<unknown>("get_quotes", {
@@ -105,45 +130,52 @@ export async function getOptionQuote(
   contractType: "CALL" | "PUT",
 ): Promise<OptionQuoteRecord | null> {
   try {
-    const chainResult = await callMcpTool<unknown>("get_option_chain", {
-      symbol,
-      strikeCount: 50,
-      fromDate: expDate,
-      toDate: expDate,
-      contractType,
-    });
-    const expMap = pickOptionExpMap(chainResult, contractType);
-    if (!expMap) {
+    const symbolCandidates = symbol === "VIX" ? ["VIX", "$VIX"] : [symbol];
+    let mappedQuote: OptionQuoteRecord | null = null;
+
+    for (let index = 0; index < symbolCandidates.length; index += 1) {
+      const symbolCandidate = symbolCandidates[index];
+      const hasMoreCandidates = index < symbolCandidates.length - 1;
+
+      let chainResult: unknown;
+      try {
+        chainResult = await callMcpTool<unknown>("get_option_chain", {
+          symbol: symbolCandidate,
+          contract_type: contractType,
+          strike_count: 50,
+          include_quotes: true,
+          from_date: expDate,
+          to_date: expDate,
+        });
+      } catch (error) {
+        if (error instanceof McpUnavailableError && hasMoreCandidates) {
+          continue;
+        }
+
+        throw error;
+      }
+
+      const expMap = pickOptionExpMap(chainResult, contractType);
+      if (!expMap) {
+        continue;
+      }
+
+      const contract = getOptionContract(expMap, expDate, strike);
+      if (!contract) {
+        continue;
+      }
+
+      mappedQuote = mapOptionContract(contract);
+      if (mappedQuote) {
+        break;
+      }
+    }
+
+    if (!mappedQuote) {
       return null;
     }
 
-    const contract = getOptionContract(expMap, expDate, strike);
-    if (!contract) {
-      return null;
-    }
-
-    const mark = numberOrNull(contract.mark) ?? numberOrNull(contract.markChange) ?? numberOrNull(contract.last);
-    const bid = numberOrNull(contract.bid);
-    const ask = numberOrNull(contract.ask);
-    const delta = numberOrNull(contract.delta);
-    const theta = numberOrNull(contract.theta);
-    const iv = numberOrNull(contract.volatility);
-    const dte = numberOrNull(contract.daysToExpiration);
-
-    if (mark === null || bid === null || ask === null || delta === null || theta === null || iv === null || dte === null) {
-      return null;
-    }
-
-    return {
-      mark,
-      bid,
-      ask,
-      delta,
-      theta,
-      iv,
-      dte,
-      inTheMoney: Boolean(contract.inTheMoney),
-    };
+    return mappedQuote;
   } catch (error) {
     if (error instanceof McpUnavailableError) {
       return null;


### PR DESCRIPTION
## Summary
- Fix MCP option-chain argument mapping to the Schwab MCP schema (snake_case):
  - `contract_type`, `strike_count`, `include_quotes`, `from_date`, `to_date`
- Add VIX option fallback behavior (`VIX` -> `$VIX`) with robust retry path.
- Keep quote refresh resilient during transient MCP failures:
  - when a refresh lookup fails, return cached quote (if present) instead of `{error:"unavailable"}`.
- Add/expand tests for:
  - VIX fallback,
  - refresh cache bypass,
  - fallback-to-cache on refresh failures.

## Validation
- `npm test -- src/lib/mcp/market-data.test.ts src/app/api/quotes/route.test.ts src/app/api/option-quote/route.test.ts`
- `npm run typecheck`
- `npm run lint`

## Live verification
- Re-checked all 16 option contracts currently shown in Open Positions via `/api/option-quote?...&refresh=1`.
- Current result: `ok=16 fail=0`.
