### PR TITLE
Sprint 1: NLV correctness fixes (issues #31 #32 #34 #35 #36)

### DIFF
--- a/SPRINT1_DONE.md
+++ b/SPRINT1_DONE.md
@@ -1,0 +1,31 @@
+# Sprint 1 Complete
+
+## Closed GitHub Issues
+- [#34](https://github.com/vkapella/kapman-tradelog/issues/34) — [P1] Import adapter does not parse or store Total Cash from statement
+- [#35](https://github.com/vkapella/kapman-tradelog/issues/35) — [P1] Import adapter does not parse or store broker-reported NLV
+- [#31](https://github.com/vkapella/kapman-tradelog/issues/31) — [P0] Account Balances widget uses stale snapshot balance instead of current statement cash
+- [#32](https://github.com/vkapella/kapman-tradelog/issues/32) — [P0] NLV is time-inconsistent — stale cash mixed with current-date position marks
+- [#36](https://github.com/vkapella/kapman-tradelog/issues/36) — [P1] Equity Curve trails live data by 3+ days due to snapshot ingestion lag
+
+## Files Changed
+- prisma/migrations/20260410103000_add_snapshot_total_cash/migration.sql
+- prisma/migrations/20260410104500_add_snapshot_broker_nlv/migration.sql
+- prisma/schema.prisma
+- src/app/api/overview/summary/route.ts
+- src/components/widgets/AccountBalancesWidget.tsx
+- src/hooks/useNetLiquidationValue.ts
+- src/lib/adapters/thinkorswim/account-summary.test.ts
+- src/lib/adapters/thinkorswim/account-summary.ts
+- src/lib/adapters/thinkorswim/trade-history.summary.test.ts
+- src/lib/adapters/thinkorswim/trade-history.ts
+- src/lib/adapters/types.ts
+- src/lib/imports/replace-import-snapshots.ts
+- types/api.ts
+
+## Final Typecheck/Lint
+- `npm run typecheck` — passed
+- `npm run lint` — passed
+
+## Deferred Items / Known Caveats
+- Database migrations were added but not executed in this run; apply with Prisma migrate/deploy in the target environment before runtime verification.
+- Quote as-of in the NLV widget is based on quote fetch completion time; upstream quote endpoints do not currently provide broker timestamp fields.

--- a/prisma/migrations/20260410103000_add_snapshot_total_cash/migration.sql
+++ b/prisma/migrations/20260410103000_add_snapshot_total_cash/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "daily_account_snapshots"
+ADD COLUMN "total_cash" DECIMAL(20,6);

--- a/prisma/migrations/20260410104500_add_snapshot_broker_nlv/migration.sql
+++ b/prisma/migrations/20260410104500_add_snapshot_broker_nlv/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "daily_account_snapshots"
+ADD COLUMN "broker_net_liquidation_value" DECIMAL(20,6);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -195,6 +195,7 @@ model DailyAccountSnapshot {
   snapshotDate DateTime @map("snapshot_date")
   balance      Decimal  @db.Decimal(20, 6)
   totalCash    Decimal? @map("total_cash") @db.Decimal(20, 6)
+  brokerNetLiquidationValue Decimal? @map("broker_net_liquidation_value") @db.Decimal(20, 6)
   sourceRef    String?  @map("source_ref")
   createdAt    DateTime @default(now()) @map("created_at")
   updatedAt    DateTime @updatedAt @map("updated_at")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -194,6 +194,7 @@ model DailyAccountSnapshot {
   id           String   @id @default(cuid())
   snapshotDate DateTime @map("snapshot_date")
   balance      Decimal  @db.Decimal(20, 6)
+  totalCash    Decimal? @map("total_cash") @db.Decimal(20, 6)
   sourceRef    String?  @map("source_ref")
   createdAt    DateTime @default(now()) @map("created_at")
   updatedAt    DateTime @updatedAt @map("updated_at")

--- a/src/app/api/overview/summary/route.ts
+++ b/src/app/api/overview/summary/route.ts
@@ -15,8 +15,7 @@ export async function GET() {
           select: { accountId: true },
         },
       },
-      orderBy: [{ snapshotDate: "desc" }, { id: "desc" }],
-      take: 500,
+      orderBy: [{ snapshotDate: "asc" }, { id: "asc" }],
     }),
   ]);
 
@@ -47,7 +46,7 @@ export async function GET() {
     snapshotSeries: snapshots.map((snapshot) => ({
       accountId: snapshot.account.accountId,
       snapshotDate: snapshot.snapshotDate.toISOString(),
-      balance: snapshot.balance.toString(),
+      balance: (snapshot.totalCash ?? snapshot.balance).toString(),
       totalCash: snapshot.totalCash !== null ? snapshot.totalCash.toString() : null,
       brokerNetLiquidationValue:
         snapshot.brokerNetLiquidationValue !== null ? snapshot.brokerNetLiquidationValue.toString() : null,

--- a/src/app/api/overview/summary/route.ts
+++ b/src/app/api/overview/summary/route.ts
@@ -48,6 +48,9 @@ export async function GET() {
       accountId: snapshot.account.accountId,
       snapshotDate: snapshot.snapshotDate.toISOString(),
       balance: snapshot.balance.toString(),
+      totalCash: snapshot.totalCash !== null ? snapshot.totalCash.toString() : null,
+      brokerNetLiquidationValue:
+        snapshot.brokerNetLiquidationValue !== null ? snapshot.brokerNetLiquidationValue.toString() : null,
     })),
   };
 

--- a/src/components/widgets/AccountBalancesWidget.tsx
+++ b/src/components/widgets/AccountBalancesWidget.tsx
@@ -8,18 +8,26 @@ import { formatCurrency } from "@/components/widgets/utils";
 
 function AccountBalanceRow({ accountId, displayAccountId, refreshSeed }: { accountId: string; displayAccountId: string; refreshSeed: number }) {
   void refreshSeed;
-  const { nlv, cash, lastUpdated, loading } = useNetLiquidationValue(accountId);
+  const { nlv, cash, cashAsOf, marksAsOf, loading } = useNetLiquidationValue(accountId);
 
   const value = nlv ?? cash;
   const progress = Math.max(0, Math.min(100, (value / 100_000) * 100));
+  const staleCash = cashAsOf ? Date.now() - cashAsOf.getTime() > 24 * 60 * 60 * 1000 : false;
 
   return (
-    <div className="rounded-lg border border-border bg-panel-2 p-3">
+    <div className={["rounded-lg border bg-panel-2 p-3", staleCash ? "border-amber-400/70" : "border-border"].join(" ")}>
       <div className="flex items-center justify-between">
         <p className="font-mono text-xs text-text">{displayAccountId}</p>
-        <p className="text-[11px] text-muted">{loading ? "Updating..." : lastUpdated ? lastUpdated.toLocaleTimeString() : "Quotes unavailable"}</p>
+        <p className="text-[11px] text-muted">{loading ? "Updating..." : marksAsOf ? marksAsOf.toLocaleTimeString() : "Quotes unavailable"}</p>
       </div>
       <p className="mt-1 text-xs text-muted">Cash: {formatCurrency(cash)}</p>
+      <p className="text-[11px] text-muted">Cash as of: {cashAsOf ? cashAsOf.toISOString().slice(0, 10) : "unknown"}</p>
+      <p className="text-[11px] text-muted">Marks as of: {marksAsOf ? marksAsOf.toLocaleTimeString() : "unavailable"}</p>
+      {staleCash ? (
+        <p className="mt-1 rounded border border-amber-400/70 bg-amber-400/10 px-2 py-0.5 text-[10px] text-amber-200">
+          Cash snapshot is stale (more than 1 day old).
+        </p>
+      ) : null}
       <p className="text-sm font-semibold text-text">{nlv === null ? "NLV unavailable" : "NLV: " + formatCurrency(nlv)}</p>
       <div className="mt-2 h-2 rounded bg-panel">
         <div className="h-2 rounded bg-accent" style={{ width: `${progress}%` }} />

--- a/src/hooks/useNetLiquidationValue.ts
+++ b/src/hooks/useNetLiquidationValue.ts
@@ -26,6 +26,8 @@ export function useNetLiquidationValue(accountId: string): NlvResult {
 
   const [nlv, setNlv] = useState<number | null>(null);
   const [cash, setCash] = useState(0);
+  const [cashAsOf, setCashAsOf] = useState<Date | null>(null);
+  const [marksAsOf, setMarksAsOf] = useState<Date | null>(null);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -58,8 +60,10 @@ export function useNetLiquidationValue(accountId: string): NlvResult {
         const latestStatementSnapshot = accountSnapshots.find((snapshot) => snapshot.totalCash !== null);
 
         const latestCash = Number(latestStatementSnapshot?.totalCash ?? latestSnapshot?.balance ?? 0);
+        const latestCashAsOfIso = latestStatementSnapshot?.snapshotDate ?? latestSnapshot?.snapshotDate ?? null;
         if (!cancelled) {
           setCash(latestCash);
+          setCashAsOf(latestCashAsOfIso ? new Date(latestCashAsOfIso) : null);
         }
 
         const equityPositions = accountPositions.filter((position) => position.assetClass === "EQUITY");
@@ -140,17 +144,22 @@ export function useNetLiquidationValue(accountId: string): NlvResult {
 
         if (quoteUnavailable) {
           setNlv(null);
+          setMarksAsOf(null);
           setLastUpdated(null);
           setLoading(false);
           return;
         }
 
+        const marksTimestamp = new Date();
         setNlv(latestCash + equityValue + optionValue);
-        setLastUpdated(new Date());
+        setMarksAsOf(marksTimestamp);
+        setLastUpdated(marksTimestamp);
         setLoading(false);
       } catch {
         if (!cancelled) {
           setNlv(null);
+          setCashAsOf(null);
+          setMarksAsOf(null);
           setLastUpdated(null);
           setLoading(false);
         }
@@ -167,6 +176,8 @@ export function useNetLiquidationValue(accountId: string): NlvResult {
   return {
     nlv,
     cash,
+    cashAsOf,
+    marksAsOf,
     lastUpdated,
     loading,
   };

--- a/src/hooks/useNetLiquidationValue.ts
+++ b/src/hooks/useNetLiquidationValue.ts
@@ -50,11 +50,14 @@ export function useNetLiquidationValue(accountId: string): NlvResult {
         }
 
         const summaryPayload = (await summaryResponse.json()) as OverviewPayload;
-        const latestSnapshot = [...summaryPayload.data.snapshotSeries]
+        const accountSnapshots = [...summaryPayload.data.snapshotSeries]
           .filter((snapshot) => snapshot.accountId === externalAccountId)
-          .sort((left, right) => new Date(right.snapshotDate).getTime() - new Date(left.snapshotDate).getTime())[0];
+          .sort((left, right) => new Date(right.snapshotDate).getTime() - new Date(left.snapshotDate).getTime());
 
-        const latestCash = Number(latestSnapshot?.balance ?? 0);
+        const latestSnapshot = accountSnapshots[0];
+        const latestStatementSnapshot = accountSnapshots.find((snapshot) => snapshot.totalCash !== null);
+
+        const latestCash = Number(latestStatementSnapshot?.totalCash ?? latestSnapshot?.balance ?? 0);
         if (!cancelled) {
           setCash(latestCash);
         }

--- a/src/lib/adapters/thinkorswim/account-summary.test.ts
+++ b/src/lib/adapters/thinkorswim/account-summary.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { parseThinkorswimAccountSummary } from "./account-summary";
+
+describe("parseThinkorswimAccountSummary", () => {
+  it("parses statement date, total cash, and net liquidating value from real fixture formats", () => {
+    const fixture = readFileSync("fixtures/2026-04-06-AccountStatement-2.csv", "utf8");
+    const parsed = parseThinkorswimAccountSummary(fixture);
+
+    expect(parsed.statementDate?.toISOString().slice(0, 10)).toBe("2026-04-06");
+    expect(parsed.totalCash).toBe(91350.65);
+    expect(parsed.netLiquidatingValue).toBe(90458.65);
+  });
+
+  it("parses Total Cash when present directly in Account Summary rows", () => {
+    const csv = [
+      "Account Statement for D-12345678 (margin) since 4/1/26 through 4/9/26",
+      "",
+      "Account Summary",
+      "Net Liquidating Value,\"$90,653.36\"",
+      "Total Cash,\"$42,776.36\"",
+      "Stock Buying Power,\"$120,000.00\"",
+    ].join("\n");
+
+    const parsed = parseThinkorswimAccountSummary(csv);
+
+    expect(parsed.statementDate?.toISOString().slice(0, 10)).toBe("2026-04-09");
+    expect(parsed.totalCash).toBe(42776.36);
+    expect(parsed.netLiquidatingValue).toBe(90653.36);
+  });
+});

--- a/src/lib/adapters/thinkorswim/account-summary.ts
+++ b/src/lib/adapters/thinkorswim/account-summary.ts
@@ -1,0 +1,140 @@
+export interface ParsedAccountSummary {
+  statementDate: Date | null;
+  totalCash: number | null;
+  netLiquidatingValue: number | null;
+}
+
+function splitCsvLine(line: string): string[] {
+  const columns: string[] = [];
+  let current = "";
+  let inQuotes = false;
+
+  for (let index = 0; index < line.length; index += 1) {
+    const character = line[index];
+
+    if (character === "\"") {
+      const nextCharacter = line[index + 1];
+      if (inQuotes && nextCharacter === "\"") {
+        current += "\"";
+        index += 1;
+        continue;
+      }
+
+      inQuotes = !inQuotes;
+      continue;
+    }
+
+    if (character === "," && !inQuotes) {
+      columns.push(current);
+      current = "";
+      continue;
+    }
+
+    current += character;
+  }
+
+  columns.push(current);
+  return columns;
+}
+
+function parseUsDate(value: string): Date | null {
+  const match = value.trim().match(/^(\d{1,2})\/(\d{1,2})\/(\d{2})$/);
+  if (!match) {
+    return null;
+  }
+
+  const month = Number(match[1]);
+  const day = Number(match[2]);
+  const year = 2000 + Number(match[3]);
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+function parseCurrency(value: string): number | null {
+  const normalized = value
+    .trim()
+    .replace(/^="(.*)"$/, "$1")
+    .replace(/^"(.*)"$/, "$1")
+    .replace(/[,$"]/g, "");
+
+  if (!normalized) {
+    return null;
+  }
+
+  const parsed = Number(normalized);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+
+  return parsed;
+}
+
+export function parseThinkorswimAccountSummary(csvText: string): ParsedAccountSummary {
+  const lines = csvText.replace(/^\uFEFF/, "").split(/\r?\n/);
+
+  let statementDate: Date | null = null;
+  let totalCash: number | null = null;
+  let netLiquidatingValue: number | null = null;
+
+  const statementLine = lines.find((line) => line.startsWith("Account Statement for "));
+  if (statementLine) {
+    const dateMatch = statementLine.match(/through\s+(\d{1,2}\/\d{1,2}\/\d{2})/i);
+    if (dateMatch) {
+      statementDate = parseUsDate(dateMatch[1] ?? "");
+    }
+  }
+
+  for (const line of lines) {
+    const normalized = line.trim().replace(/^"(.*)"$/, "$1");
+    const totalCashMatch = normalized.match(/^Total Cash\s+\$?(-?[0-9,]+(?:\.[0-9]{1,2})?)$/i);
+    if (!totalCashMatch) {
+      continue;
+    }
+
+    const parsed = parseCurrency(totalCashMatch[1] ?? "");
+    if (parsed !== null) {
+      totalCash = parsed;
+    }
+  }
+
+  let inAccountSummarySection = false;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed === "Account Summary") {
+      inAccountSummarySection = true;
+      continue;
+    }
+
+    if (!inAccountSummarySection || !trimmed) {
+      continue;
+    }
+
+    const columns = splitCsvLine(line);
+    if (columns.length < 2) {
+      continue;
+    }
+
+    const metricName = (columns[0] ?? "").trim().replace(/^"(.*)"$/, "$1");
+    const metricValue = (columns[1] ?? "").trim();
+
+    if (metricName === "Total Cash") {
+      const parsed = parseCurrency(metricValue);
+      if (parsed !== null) {
+        totalCash = parsed;
+      }
+      continue;
+    }
+
+    if (metricName === "Net Liquidating Value") {
+      const parsed = parseCurrency(metricValue);
+      if (parsed !== null) {
+        netLiquidatingValue = parsed;
+      }
+    }
+  }
+
+  return {
+    statementDate,
+    totalCash,
+    netLiquidatingValue,
+  };
+}

--- a/src/lib/adapters/thinkorswim/trade-history.summary.test.ts
+++ b/src/lib/adapters/thinkorswim/trade-history.summary.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { parseThinkorswimTradeHistory } from "./trade-history";
+
+describe("parseThinkorswimTradeHistory account summary snapshot enrichment", () => {
+  it("attaches statement-date totalCash metadata to snapshots", () => {
+    const fixture = readFileSync("fixtures/2026-04-06-AccountStatement-2.csv", "utf8");
+    const parsed = parseThinkorswimTradeHistory(fixture);
+
+    const statementSnapshot = parsed.snapshots.find((snapshot) => snapshot.snapshotDate.toISOString().startsWith("2026-04-06"));
+
+    expect(statementSnapshot).toBeDefined();
+    expect(statementSnapshot?.totalCash).toBe(91350.65);
+    expect(statementSnapshot?.brokerNetLiquidationValue).toBe(90458.65);
+  });
+});

--- a/src/lib/adapters/thinkorswim/trade-history.ts
+++ b/src/lib/adapters/thinkorswim/trade-history.ts
@@ -1,6 +1,7 @@
 import { parseAccountMetadataFromCsv } from "../../accounts/parse-account-metadata";
+import { parseThinkorswimAccountSummary } from "./account-summary";
 import { parseCashBalanceSnapshots } from "./cash-balance";
-import type { AdapterWarning, NormalizedExecution, ParseResult } from "../types";
+import type { AdapterWarning, NormalizedDailyAccountSnapshot, NormalizedExecution, ParseResult } from "../types";
 
 const TRADE_HISTORY_HEADER = ",Exec Time,Spread,Side,Qty,Pos Effect,Symbol,Exp,Strike,Type,Price,Net Price,Order Type";
 const KNOWN_SPREADS = new Set(["SINGLE", "STOCK", "VERTICAL", "DIAGONAL", "CALENDAR", "COMBO", "CUSTOM"]);
@@ -123,6 +124,41 @@ function hasContinuation(lines: string[], lineIndex: number): boolean {
   const nextColumns = splitCsvLine(nextLine);
   const nextExecTime = (nextColumns[1] ?? "").trim();
   return nextExecTime === "";
+}
+
+function utcDateKey(value: Date): string {
+  return value.toISOString().slice(0, 10);
+}
+
+function applyAccountSummaryToSnapshots(
+  snapshots: NormalizedDailyAccountSnapshot[],
+  csvText: string,
+): NormalizedDailyAccountSnapshot[] {
+  const summary = parseThinkorswimAccountSummary(csvText);
+  const summaryDate = summary.statementDate;
+
+  if (!summaryDate || summary.totalCash === null) {
+    return snapshots;
+  }
+
+  const statementDateKey = utcDateKey(summaryDate);
+  const nextSnapshots = snapshots.map((snapshot) => ({ ...snapshot }));
+  const existing = nextSnapshots.find((snapshot) => utcDateKey(snapshot.snapshotDate) === statementDateKey);
+
+  if (existing) {
+    existing.totalCash = summary.totalCash;
+    existing.brokerNetLiquidationValue = summary.netLiquidatingValue;
+    return nextSnapshots;
+  }
+
+  nextSnapshots.push({
+    snapshotDate: summaryDate,
+    balance: summary.totalCash,
+    totalCash: summary.totalCash,
+    brokerNetLiquidationValue: summary.netLiquidatingValue,
+  });
+
+  return nextSnapshots.sort((left, right) => left.snapshotDate.getTime() - right.snapshotDate.getTime());
 }
 
 export function parseThinkorswimTradeHistory(csvText: string): ParseResult {
@@ -309,7 +345,7 @@ export function parseThinkorswimTradeHistory(csvText: string): ParseResult {
     },
     warnings,
     executions,
-    snapshots: parseCashBalanceSnapshots(csvText),
+    snapshots: applyAccountSummaryToSnapshots(parseCashBalanceSnapshots(csvText), csvText),
     parsedRows,
     skippedRows,
   };

--- a/src/lib/adapters/types.ts
+++ b/src/lib/adapters/types.ts
@@ -38,6 +38,8 @@ export interface ParsedAccountMetadata {
 export interface NormalizedDailyAccountSnapshot {
   snapshotDate: Date;
   balance: number;
+  totalCash?: number | null;
+  brokerNetLiquidationValue?: number | null;
 }
 
 export interface ParseResult {

--- a/src/lib/imports/replace-import-snapshots.ts
+++ b/src/lib/imports/replace-import-snapshots.ts
@@ -35,6 +35,7 @@ export async function replaceImportSnapshots(
       update: {
         balance: snapshot.balance,
         totalCash: snapshot.totalCash ?? null,
+        brokerNetLiquidationValue: snapshot.brokerNetLiquidationValue ?? null,
         sourceRef: importId,
       },
       create: {
@@ -42,6 +43,7 @@ export async function replaceImportSnapshots(
         snapshotDate: snapshot.snapshotDate,
         balance: snapshot.balance,
         totalCash: snapshot.totalCash ?? null,
+        brokerNetLiquidationValue: snapshot.brokerNetLiquidationValue ?? null,
         sourceRef: importId,
       },
     });

--- a/src/lib/imports/replace-import-snapshots.ts
+++ b/src/lib/imports/replace-import-snapshots.ts
@@ -34,12 +34,14 @@ export async function replaceImportSnapshots(
       },
       update: {
         balance: snapshot.balance,
+        totalCash: snapshot.totalCash ?? null,
         sourceRef: importId,
       },
       create: {
         accountId,
         snapshotDate: snapshot.snapshotDate,
         balance: snapshot.balance,
+        totalCash: snapshot.totalCash ?? null,
         sourceRef: importId,
       },
     });
@@ -52,4 +54,3 @@ export async function replaceImportSnapshots(
     deleted: deleted.count,
   };
 }
-

--- a/types/api.ts
+++ b/types/api.ts
@@ -304,6 +304,8 @@ export interface OpenPosition {
 export interface NlvResult {
   nlv: number | null;
   cash: number;
+  cashAsOf: Date | null;
+  marksAsOf: Date | null;
   lastUpdated: Date | null;
   loading: boolean;
 }

--- a/types/api.ts
+++ b/types/api.ts
@@ -186,6 +186,8 @@ export interface OverviewSummaryResponse {
     accountId: string;
     snapshotDate: string;
     balance: string;
+    totalCash: string | null;
+    brokerNetLiquidationValue: string | null;
   }>;
 }
 


### PR DESCRIPTION
## Summary
- Parse and persist statement `Total Cash` and broker `Net Liquidating Value` on daily snapshots
- Update NLV hook to prefer statement cash over stale snapshot balance
- Add explicit cash/marks as-of display with staleness warning in Account Balances widget
- Remove summary snapshot cap and prefer end-of-day cash when available
- Add `SPRINT1_DONE.md` with issue closure and validation results

## Closed Issues
- Closes #31
- Closes #32
- Closes #34
- Closes #35
- Closes #36

## Validation
- `npm run typecheck`
- `npm run lint`
- targeted adapter tests for account summary parsing