### PR TITLE
Sprint 2 Step 1: manual adjustment ledger for split corrections

### DIFF
--- a/prisma/migrations/20260410233000_add_manual_adjustments/migration.sql
+++ b/prisma/migrations/20260410233000_add_manual_adjustments/migration.sql
@@ -1,0 +1,35 @@
+-- CreateEnum
+CREATE TYPE "AdjustmentType" AS ENUM ('SPLIT', 'QTY_OVERRIDE', 'PRICE_OVERRIDE', 'ADD_POSITION', 'REMOVE_POSITION');
+
+-- CreateEnum
+CREATE TYPE "AdjustmentStatus" AS ENUM ('ACTIVE', 'REVERSED');
+
+-- CreateTable
+CREATE TABLE "manual_adjustments" (
+    "id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "created_by" TEXT NOT NULL,
+    "symbol" TEXT NOT NULL,
+    "effective_date" TIMESTAMP(3) NOT NULL,
+    "adjustment_type" "AdjustmentType" NOT NULL,
+    "payload_json" JSONB NOT NULL,
+    "reason" TEXT NOT NULL,
+    "evidence_ref" TEXT,
+    "status" "AdjustmentStatus" NOT NULL DEFAULT 'ACTIVE',
+    "reversed_by_adjustment_id" TEXT,
+    "account_id" TEXT NOT NULL,
+
+    CONSTRAINT "manual_adjustments_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "manual_adjustments_account_id_symbol_effective_date_idx" ON "manual_adjustments"("account_id", "symbol", "effective_date");
+
+-- CreateIndex
+CREATE INDEX "manual_adjustments_status_effective_date_idx" ON "manual_adjustments"("status", "effective_date");
+
+-- AddForeignKey
+ALTER TABLE "manual_adjustments" ADD CONSTRAINT "manual_adjustments_account_id_fkey" FOREIGN KEY ("account_id") REFERENCES "accounts"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "manual_adjustments" ADD CONSTRAINT "manual_adjustments_reversed_by_adjustment_id_fkey" FOREIGN KEY ("reversed_by_adjustment_id") REFERENCES "manual_adjustments"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -44,6 +44,19 @@ enum OpeningClosingEffect {
   UNKNOWN
 }
 
+enum AdjustmentType {
+  SPLIT
+  QTY_OVERRIDE
+  PRICE_OVERRIDE
+  ADD_POSITION
+  REMOVE_POSITION
+}
+
+enum AdjustmentStatus {
+  ACTIVE
+  REVERSED
+}
+
 model Account {
   id         String   @id @default(cuid())
   accountId  String   @unique @map("account_id")
@@ -56,6 +69,7 @@ model Account {
   imports     Import[]
   executions  Execution[]
   snapshots   DailyAccountSnapshot[]
+  adjustments ManualAdjustment[]
   setupGroups SetupGroup[]
   matchedLots MatchedLot[]
 
@@ -206,4 +220,28 @@ model DailyAccountSnapshot {
   @@unique([accountId, snapshotDate])
   @@index([snapshotDate])
   @@map("daily_account_snapshots")
+}
+
+model ManualAdjustment {
+  id                     String           @id @default(cuid())
+  createdAt              DateTime         @default(now()) @map("created_at")
+  createdBy              String           @map("created_by")
+  symbol                 String
+  effectiveDate          DateTime         @map("effective_date")
+  adjustmentType         AdjustmentType   @map("adjustment_type")
+  payloadJson            Json             @map("payload_json")
+  reason                 String
+  evidenceRef            String?          @map("evidence_ref")
+  status                 AdjustmentStatus @default(ACTIVE)
+  reversedByAdjustmentId String?          @map("reversed_by_adjustment_id")
+
+  accountId String  @map("account_id")
+  account   Account @relation(fields: [accountId], references: [id], onDelete: Cascade)
+
+  reversedBy ManualAdjustment?  @relation("ReversalChain", fields: [reversedByAdjustmentId], references: [id], onDelete: SetNull)
+  reversals  ManualAdjustment[] @relation("ReversalChain")
+
+  @@index([accountId, symbol, effectiveDate])
+  @@index([status, effectiveDate])
+  @@map("manual_adjustments")
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -16,6 +16,58 @@ const seedFiles = [
   "fixtures/2026-04-06-AccountStatement-2.csv",
 ];
 
+async function seedCorporateActionAdjustments(accountInternalId: string, externalAccountId: string) {
+  if (externalAccountId !== "D-68011053") {
+    return;
+  }
+
+  const entries = [
+    {
+      symbol: "SDS",
+      effectiveDate: "2025-11-20T00:00:00.000Z",
+      payload: { from: 5, to: 1 },
+      reason: "ProShares 1-for-5 reverse split effective 2025-11-20",
+      evidenceRef: "https://www.proshares.com/press-releases/proshares-announces-etf-share-splits5",
+    },
+    {
+      symbol: "XLU",
+      effectiveDate: "2025-12-05T00:00:00.000Z",
+      payload: { from: 1, to: 2 },
+      reason: "State Street 2-for-1 forward split effective 2025-12-05",
+      evidenceRef:
+        "https://investors.statestreet.com/investor-news-events/press-releases/news-details/2025/State-Street-Investment-Management-Announces-Share-Splits-for-Five-Select-Sector-SPDR-ETFs/default.aspx",
+    },
+  ] as const;
+
+  for (const entry of entries) {
+    const existing = await prisma.manualAdjustment.findFirst({
+      where: {
+        accountId: accountInternalId,
+        symbol: entry.symbol,
+        adjustmentType: "SPLIT",
+        effectiveDate: new Date(entry.effectiveDate),
+        status: "ACTIVE",
+      },
+    });
+
+    if (!existing) {
+      await prisma.manualAdjustment.create({
+        data: {
+          createdBy: "seed",
+          accountId: accountInternalId,
+          symbol: entry.symbol,
+          effectiveDate: new Date(entry.effectiveDate),
+          adjustmentType: "SPLIT",
+          payloadJson: entry.payload as unknown as Prisma.InputJsonValue,
+          reason: entry.reason,
+          evidenceRef: entry.evidenceRef,
+          status: "ACTIVE",
+        },
+      });
+    }
+  }
+}
+
 async function main() {
   for (const fixturePath of seedFiles) {
     const csvText = readFileSync(join(process.cwd(), fixturePath), "utf8");
@@ -154,6 +206,8 @@ async function main() {
         },
       });
     });
+
+    await seedCorporateActionAdjustments(account.id, metadata.accountId);
   }
 }
 

--- a/src/app/adjustments/page.tsx
+++ b/src/app/adjustments/page.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { AdjustmentForm } from "@/components/adjustments/adjustment-form";
+import { AdjustmentList } from "@/components/adjustments/adjustment-list";
+import { AdjustmentPreview } from "@/components/adjustments/adjustment-preview";
+import type { AdjustmentPreviewResponse, ManualAdjustmentRecord } from "@/types/api";
+
+interface AdjustmentListPayload {
+  data: ManualAdjustmentRecord[];
+  meta: {
+    total: number;
+    page: number;
+    pageSize: number;
+  };
+}
+
+export default function Page() {
+  const [adjustments, setAdjustments] = useState<ManualAdjustmentRecord[]>([]);
+  const [preview, setPreview] = useState<AdjustmentPreviewResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [reversingId, setReversingId] = useState<string | null>(null);
+
+  async function loadAdjustments() {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/adjustments?page=1&pageSize=1000", { cache: "no-store" });
+      const payload = (await response.json()) as AdjustmentListPayload;
+      if (!response.ok) {
+        throw new Error("Unable to load adjustments.");
+      }
+      setAdjustments(payload.data);
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : "Unable to load adjustments.");
+      setAdjustments([]);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadAdjustments();
+  }, []);
+
+  async function handleReverse(adjustmentId: string) {
+    setReversingId(adjustmentId);
+    setError(null);
+    try {
+      const response = await fetch(`/api/adjustments/${adjustmentId}/reverse`, { method: "POST" });
+      const payload = await response.json();
+      if (!response.ok) {
+        throw new Error(payload?.error?.message ?? "Reverse failed.");
+      }
+      await loadAdjustments();
+    } catch (reverseError) {
+      setError(reverseError instanceof Error ? reverseError.message : "Reverse failed.");
+    } finally {
+      setReversingId(null);
+    }
+  }
+
+  return (
+    <section className="space-y-4">
+      <header className="rounded-xl border border-border bg-panel p-4">
+        <p className="text-sm font-semibold text-text">Manual Adjustments</p>
+        <p className="mt-1 text-xs text-muted">
+          Add auditable reconciliation overlays for corporate actions and exceptional corrections without mutating raw executions.
+        </p>
+      </header>
+
+      {error ? <p className="rounded border border-red-400/60 bg-red-400/10 px-3 py-2 text-xs text-red-200">{error}</p> : null}
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <AdjustmentForm
+          onPreview={setPreview}
+          onCreated={(created) => {
+            setAdjustments((current) => [...current, created].sort((left, right) => left.effectiveDate.localeCompare(right.effectiveDate)));
+          }}
+        />
+        <AdjustmentPreview preview={preview} />
+      </div>
+
+      {loading ? <p className="text-xs text-muted">Loading adjustments...</p> : null}
+      {!loading ? <AdjustmentList adjustments={adjustments} onReverse={handleReverse} reversingId={reversingId} /> : null}
+    </section>
+  );
+}

--- a/src/app/api/adjustments/[id]/reverse/route.ts
+++ b/src/app/api/adjustments/[id]/reverse/route.ts
@@ -1,0 +1,52 @@
+import { Prisma } from "@prisma/client";
+import { detailResponse, errorResponse } from "@/lib/api/responses";
+import { prisma } from "@/lib/db/prisma";
+import type { ReverseManualAdjustmentResponse } from "@/types/api";
+
+export async function POST(_request: Request, context: { params: { id: string } }) {
+  const adjustmentId = context.params.id;
+
+  const existing = await prisma.manualAdjustment.findUnique({
+    where: { id: adjustmentId },
+  });
+  if (!existing) {
+    return errorResponse("NOT_FOUND", "Adjustment not found.", [`Adjustment ${adjustmentId} does not exist.`], 404);
+  }
+
+  if (existing.status === "REVERSED") {
+    return errorResponse("ALREADY_REVERSED", "Adjustment is already reversed.", [`Adjustment ${adjustmentId} is already reversed.`], 409);
+  }
+
+  const reversal = await prisma.$transaction(async (tx) => {
+    const createdReversal = await tx.manualAdjustment.create({
+      data: {
+        createdBy: "local-user",
+        accountId: existing.accountId,
+        symbol: existing.symbol,
+        effectiveDate: new Date(),
+        adjustmentType: existing.adjustmentType,
+        payloadJson: existing.payloadJson as Prisma.InputJsonValue,
+        reason: `Reversal of adjustment ${existing.id}`,
+        evidenceRef: existing.evidenceRef,
+        status: "REVERSED",
+      },
+    });
+
+    await tx.manualAdjustment.update({
+      where: { id: existing.id },
+      data: {
+        status: "REVERSED",
+        reversedByAdjustmentId: createdReversal.id,
+      },
+    });
+
+    return createdReversal;
+  });
+
+  const payload: ReverseManualAdjustmentResponse = {
+    reversedId: existing.id,
+    reversalId: reversal.id,
+  };
+
+  return detailResponse(payload);
+}

--- a/src/app/api/adjustments/preview/route.ts
+++ b/src/app/api/adjustments/preview/route.ts
@@ -1,0 +1,242 @@
+import { parsePayloadByType } from "@/lib/adjustments/types";
+import { detailResponse, errorResponse } from "@/lib/api/responses";
+import { prisma } from "@/lib/db/prisma";
+import { computeOpenPositions } from "@/lib/positions/compute-open-positions";
+import type { AdjustmentPreviewResponse, AdjustmentType, ExecutionRecord, ManualAdjustmentRecord, MatchedLotRecord } from "@/types/api";
+
+function mapExecution(row: {
+  id: string;
+  accountId: string;
+  broker: string;
+  symbol: string;
+  tradeDate: Date;
+  eventTimestamp: Date;
+  eventType: string;
+  assetClass: string;
+  side: string | null;
+  quantity: { toString: () => string };
+  price: { toString: () => string } | null;
+  openingClosingEffect: string | null;
+  instrumentKey: string | null;
+  underlyingSymbol: string | null;
+  optionType: string | null;
+  strike: { toString: () => string } | null;
+  expirationDate: Date | null;
+  spreadGroupId: string | null;
+  importId: string;
+}): ExecutionRecord {
+  return {
+    id: row.id,
+    accountId: row.accountId,
+    broker: row.broker,
+    symbol: row.symbol,
+    tradeDate: row.tradeDate.toISOString(),
+    eventTimestamp: row.eventTimestamp.toISOString(),
+    eventType: row.eventType,
+    assetClass: row.assetClass,
+    side: row.side,
+    quantity: row.quantity.toString(),
+    price: row.price?.toString() ?? null,
+    openingClosingEffect: row.openingClosingEffect,
+    instrumentKey: row.instrumentKey,
+    underlyingSymbol: row.underlyingSymbol,
+    optionType: row.optionType,
+    strike: row.strike?.toString() ?? null,
+    expirationDate: row.expirationDate?.toISOString() ?? null,
+    spreadGroupId: row.spreadGroupId,
+    importId: row.importId,
+  };
+}
+
+function mapMatchedLot(row: {
+  id: string;
+  accountId: string;
+  openExecutionId: string;
+  closeExecutionId: string | null;
+  quantity: { toString: () => string };
+  realizedPnl: { toString: () => string };
+  holdingDays: number;
+  outcome: string;
+  openExecution: { symbol: string; tradeDate: Date; importId: string };
+  closeExecution: { tradeDate: Date; importId: string } | null;
+}): MatchedLotRecord {
+  return {
+    id: row.id,
+    accountId: row.accountId,
+    symbol: row.openExecution.symbol,
+    openTradeDate: row.openExecution.tradeDate.toISOString(),
+    closeTradeDate: row.closeExecution?.tradeDate.toISOString() ?? null,
+    openImportId: row.openExecution.importId,
+    closeImportId: row.closeExecution?.importId ?? null,
+    quantity: row.quantity.toString(),
+    realizedPnl: row.realizedPnl.toString(),
+    holdingDays: row.holdingDays,
+    outcome: row.outcome,
+    openExecutionId: row.openExecutionId,
+    closeExecutionId: row.closeExecutionId,
+  };
+}
+
+function summarizeForAdjustment(
+  adjustmentType: AdjustmentType,
+  symbol: string,
+  payload: unknown,
+  positions: ReturnType<typeof computeOpenPositions>,
+) {
+  if (adjustmentType === "SPLIT") {
+    const relevant = positions.filter((position) => position.assetClass === "EQUITY" && position.symbol.toUpperCase() === symbol.toUpperCase());
+    const openQty = relevant.reduce((sum, row) => sum + row.netQty, 0);
+    const grossCost = relevant.reduce((sum, row) => sum + row.costBasis, 0);
+    const costBasisPerShare = openQty !== 0 ? grossCost / openQty : null;
+    return { openQty, grossCost, costBasisPerShare };
+  }
+
+  if (adjustmentType === "QTY_OVERRIDE" || adjustmentType === "PRICE_OVERRIDE" || adjustmentType === "ADD_POSITION" || adjustmentType === "REMOVE_POSITION") {
+    const parsed = parsePayloadByType(adjustmentType, payload);
+    if (!("instrumentKey" in parsed)) {
+      return { openQty: 0, grossCost: 0, costBasisPerShare: null };
+    }
+    const relevant = positions.filter((position) => position.instrumentKey === parsed.instrumentKey);
+    const openQty = relevant.reduce((sum, row) => sum + row.netQty, 0);
+    const grossCost = relevant.reduce((sum, row) => sum + row.costBasis, 0);
+    const multiplier = relevant[0]?.assetClass === "OPTION" ? 100 : 1;
+    const costBasisPerShare = openQty !== 0 ? grossCost / (openQty * multiplier) : null;
+    return { openQty, grossCost, costBasisPerShare };
+  }
+
+  return { openQty: 0, grossCost: 0, costBasisPerShare: null };
+}
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const accountId = url.searchParams.get("accountId");
+  const symbol = url.searchParams.get("symbol");
+  const effectiveDate = url.searchParams.get("effectiveDate");
+  const adjustmentTypeRaw = url.searchParams.get("adjustmentType");
+  const payloadRaw = url.searchParams.get("payload");
+
+  if (!accountId || !symbol || !effectiveDate || !adjustmentTypeRaw || !payloadRaw) {
+    return errorResponse("MISSING_PARAMS", "Missing preview params.", [
+      "accountId, symbol, effectiveDate, adjustmentType, and payload are required.",
+    ]);
+  }
+
+  const adjustmentType = ["SPLIT", "QTY_OVERRIDE", "PRICE_OVERRIDE", "ADD_POSITION", "REMOVE_POSITION"].includes(adjustmentTypeRaw)
+    ? (adjustmentTypeRaw as AdjustmentType)
+    : null;
+  if (!adjustmentType) {
+    return errorResponse("INVALID_TYPE", "Invalid adjustmentType.", [`Unsupported adjustment type: ${adjustmentTypeRaw}`]);
+  }
+
+  let payloadInput: unknown;
+  try {
+    payloadInput = JSON.parse(payloadRaw);
+  } catch {
+    return errorResponse("INVALID_PAYLOAD_JSON", "payload must be valid JSON.", ["Unable to parse payload query param as JSON."]);
+  }
+
+  let payload;
+  try {
+    payload = parsePayloadByType(adjustmentType, payloadInput);
+  } catch (error) {
+    return errorResponse("INVALID_PAYLOAD", "Payload does not match adjustment type.", [
+      error instanceof Error ? error.message : "Unknown payload validation error.",
+    ]);
+  }
+
+  const [executionsRows, matchedLotRows, adjustmentRows] = await Promise.all([
+    prisma.execution.findMany({
+      where: { accountId },
+      orderBy: [{ eventTimestamp: "asc" }, { id: "asc" }],
+    }),
+    prisma.matchedLot.findMany({
+      where: { accountId },
+      include: {
+        openExecution: { select: { symbol: true, tradeDate: true, importId: true } },
+        closeExecution: { select: { tradeDate: true, importId: true } },
+      },
+      orderBy: [{ id: "asc" }],
+    }),
+    prisma.manualAdjustment.findMany({
+      where: {
+        accountId,
+        status: "ACTIVE",
+      },
+      include: { account: { select: { accountId: true } } },
+      orderBy: [{ effectiveDate: "asc" }, { createdAt: "asc" }],
+    }),
+  ]);
+
+  const executions = executionsRows.map(mapExecution);
+  const matchedLots = matchedLotRows.map(mapMatchedLot);
+
+  const existingAdjustments: ManualAdjustmentRecord[] = adjustmentRows.map((row) => ({
+    id: row.id,
+    createdAt: row.createdAt.toISOString(),
+    createdBy: row.createdBy,
+    accountId: row.accountId,
+    accountExternalId: row.account.accountId,
+    symbol: row.symbol,
+    effectiveDate: row.effectiveDate.toISOString(),
+    adjustmentType: row.adjustmentType,
+    payload: parsePayloadByType(row.adjustmentType, row.payloadJson),
+    reason: row.reason,
+    evidenceRef: row.evidenceRef,
+    status: row.status,
+    reversedByAdjustmentId: row.reversedByAdjustmentId,
+  }));
+
+  const before = computeOpenPositions(executions, matchedLots, existingAdjustments);
+
+  const previewAdjustment: ManualAdjustmentRecord = {
+    id: "preview-adjustment",
+    createdAt: new Date().toISOString(),
+    createdBy: "preview",
+    accountId,
+    accountExternalId: accountId,
+    symbol: symbol.toUpperCase(),
+    effectiveDate: new Date(effectiveDate).toISOString(),
+    adjustmentType,
+    payload,
+    reason: "Preview",
+    evidenceRef: null,
+    status: "ACTIVE",
+    reversedByAdjustmentId: null,
+  };
+
+  const after = computeOpenPositions(executions, matchedLots, [...existingAdjustments, previewAdjustment]);
+
+  const beforeSummary = summarizeForAdjustment(adjustmentType, symbol, payload, before);
+  const afterSummary = summarizeForAdjustment(adjustmentType, symbol, payload, after);
+
+  const effectiveTime = new Date(effectiveDate).getTime();
+  const affectedExecutionCount =
+    adjustmentType === "SPLIT"
+      ? executions.filter(
+          (row) =>
+            row.accountId === accountId &&
+            row.assetClass === "EQUITY" &&
+            row.symbol.toUpperCase() === symbol.toUpperCase() &&
+            new Date(row.tradeDate).getTime() < effectiveTime,
+        ).length
+      : 0;
+
+  const result: AdjustmentPreviewResponse = {
+    symbol: symbol.toUpperCase(),
+    adjustmentType,
+    before: {
+      openQty: beforeSummary.openQty,
+      costBasisPerShare: beforeSummary.costBasisPerShare,
+      grossCost: beforeSummary.grossCost,
+    },
+    after: {
+      openQty: afterSummary.openQty,
+      costBasisPerShare: afterSummary.costBasisPerShare,
+      grossCost: afterSummary.grossCost,
+    },
+    affectedExecutionCount,
+    effectiveDate: new Date(effectiveDate).toISOString(),
+  };
+
+  return detailResponse(result);
+}

--- a/src/app/api/adjustments/route.ts
+++ b/src/app/api/adjustments/route.ts
@@ -1,0 +1,129 @@
+import { Prisma } from "@prisma/client";
+import { detailResponse, errorResponse, listResponse, parsePagination } from "@/lib/api/responses";
+import { prisma } from "@/lib/db/prisma";
+import { manualAdjustmentCreateSchema, parsePayloadByType } from "@/lib/adjustments/types";
+import type { ManualAdjustmentRecord } from "@/types/api";
+
+function mapRowToRecord(row: {
+  id: string;
+  createdAt: Date;
+  createdBy: string;
+  accountId: string;
+  symbol: string;
+  effectiveDate: Date;
+  adjustmentType: "SPLIT" | "QTY_OVERRIDE" | "PRICE_OVERRIDE" | "ADD_POSITION" | "REMOVE_POSITION";
+  payloadJson: Prisma.JsonValue;
+  reason: string;
+  evidenceRef: string | null;
+  status: "ACTIVE" | "REVERSED";
+  reversedByAdjustmentId: string | null;
+  account: { accountId: string };
+}): ManualAdjustmentRecord {
+  return {
+    id: row.id,
+    createdAt: row.createdAt.toISOString(),
+    createdBy: row.createdBy,
+    accountId: row.accountId,
+    accountExternalId: row.account.accountId,
+    symbol: row.symbol,
+    effectiveDate: row.effectiveDate.toISOString(),
+    adjustmentType: row.adjustmentType,
+    payload: parsePayloadByType(row.adjustmentType, row.payloadJson),
+    reason: row.reason,
+    evidenceRef: row.evidenceRef,
+    status: row.status,
+    reversedByAdjustmentId: row.reversedByAdjustmentId,
+  };
+}
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const { page, pageSize } = parsePagination(url.searchParams);
+  const accountId = url.searchParams.get("accountId") ?? undefined;
+  const symbol = url.searchParams.get("symbol") ?? undefined;
+  const status = url.searchParams.get("status") ?? undefined;
+
+  const where: Record<string, unknown> = {};
+  if (accountId) {
+    where.accountId = accountId;
+  }
+  if (symbol) {
+    where.symbol = { equals: symbol.toUpperCase(), mode: "insensitive" as const };
+  }
+  if (status === "ACTIVE" || status === "REVERSED") {
+    where.status = status;
+  }
+
+  const [total, rows] = await Promise.all([
+    prisma.manualAdjustment.count({ where }),
+    prisma.manualAdjustment.findMany({
+      where,
+      include: {
+        account: {
+          select: { accountId: true },
+        },
+      },
+      orderBy: [{ effectiveDate: "asc" }, { createdAt: "asc" }],
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+    }),
+  ]);
+
+  const data = rows.map(mapRowToRecord);
+  return listResponse(data, { total, page, pageSize });
+}
+
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse("INVALID_JSON", "Body must be valid JSON.", ["Unable to parse request body."]);
+  }
+
+  const parsed = manualAdjustmentCreateSchema.safeParse(body);
+  if (!parsed.success) {
+    return errorResponse(
+      "VALIDATION_ERROR",
+      "Adjustment payload is invalid.",
+      parsed.error.issues.map((issue) => `${issue.path.join(".")}: ${issue.message}`),
+    );
+  }
+
+  const input = parsed.data;
+  let payload;
+  try {
+    payload = parsePayloadByType(input.adjustmentType, input.payload);
+  } catch (error) {
+    return errorResponse("INVALID_PAYLOAD", "Payload does not match adjustment type.", [
+      error instanceof Error ? error.message : "Unknown payload validation error.",
+    ]);
+  }
+
+  const account = await prisma.account.findUnique({
+    where: { id: input.accountId },
+    select: { id: true, accountId: true },
+  });
+  if (!account) {
+    return errorResponse("ACCOUNT_NOT_FOUND", "Account not found.", [`No account for id ${input.accountId}.`], 404);
+  }
+
+  const created = await prisma.manualAdjustment.create({
+    data: {
+      createdBy: input.createdBy?.trim() || "local-user",
+      accountId: input.accountId,
+      symbol: input.symbol.toUpperCase(),
+      effectiveDate: new Date(input.effectiveDate),
+      adjustmentType: input.adjustmentType,
+      payloadJson: payload as unknown as Prisma.InputJsonValue,
+      reason: input.reason.trim(),
+      evidenceRef: input.evidenceRef?.trim() || null,
+      status: "ACTIVE",
+    },
+    include: {
+      account: { select: { accountId: true } },
+    },
+  });
+
+  return detailResponse(mapRowToRecord(created));
+}

--- a/src/components/adjustments/adjustment-form.tsx
+++ b/src/components/adjustments/adjustment-form.tsx
@@ -1,0 +1,386 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useAccountFilterContext } from "@/contexts/AccountFilterContext";
+import type { AdjustmentPreviewResponse, AdjustmentType, CreateManualAdjustmentRequest, ManualAdjustmentRecord } from "@/types/api";
+
+function defaultEffectiveDate(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function directionLabel(from: number, to: number): string {
+  if (to > from) {
+    return "Forward split";
+  }
+  if (to < from) {
+    return "Reverse split";
+  }
+  return "No ratio change";
+}
+
+export function AdjustmentForm({
+  onCreated,
+  onPreview,
+}: {
+  onCreated: (created: ManualAdjustmentRecord) => void;
+  onPreview: (preview: AdjustmentPreviewResponse | null) => void;
+}) {
+  const { availableAccounts, toExternalAccountId } = useAccountFilterContext();
+  const [accountId, setAccountId] = useState("");
+  const [symbol, setSymbol] = useState("");
+  const [effectiveDate, setEffectiveDate] = useState(defaultEffectiveDate());
+  const [adjustmentType, setAdjustmentType] = useState<AdjustmentType>("SPLIT");
+  const [reason, setReason] = useState("");
+  const [evidenceRef, setEvidenceRef] = useState("");
+  const [createdBy, setCreatedBy] = useState("local-user");
+
+  const [splitFrom, setSplitFrom] = useState(1);
+  const [splitTo, setSplitTo] = useState(1);
+  const [instrumentKey, setInstrumentKey] = useState("");
+  const [overrideQty, setOverrideQty] = useState(0);
+  const [overridePrice, setOverridePrice] = useState(0);
+  const [addAssetClass, setAddAssetClass] = useState<"EQUITY" | "OPTION">("EQUITY");
+  const [addNetQty, setAddNetQty] = useState(0);
+  const [addCostBasis, setAddCostBasis] = useState(0);
+  const [addOptionType, setAddOptionType] = useState<"CALL" | "PUT">("CALL");
+  const [addStrike, setAddStrike] = useState("");
+  const [addExpirationDate, setAddExpirationDate] = useState("");
+
+  const [saving, setSaving] = useState(false);
+  const [previewing, setPreviewing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const payload = useMemo(() => {
+    if (adjustmentType === "SPLIT") {
+      return { from: splitFrom, to: splitTo };
+    }
+    if (adjustmentType === "QTY_OVERRIDE") {
+      return { instrumentKey, overrideQty };
+    }
+    if (adjustmentType === "PRICE_OVERRIDE") {
+      return { instrumentKey, overridePrice };
+    }
+    if (adjustmentType === "ADD_POSITION") {
+      return {
+        instrumentKey,
+        assetClass: addAssetClass,
+        netQty: addNetQty,
+        costBasis: addCostBasis,
+        optionType: addAssetClass === "OPTION" ? addOptionType : undefined,
+        strike: addAssetClass === "OPTION" ? addStrike || undefined : undefined,
+        expirationDate: addAssetClass === "OPTION" ? addExpirationDate || undefined : undefined,
+      };
+    }
+    return { instrumentKey };
+  }, [
+    addAssetClass,
+    addCostBasis,
+    addExpirationDate,
+    addNetQty,
+    addOptionType,
+    addStrike,
+    adjustmentType,
+    instrumentKey,
+    overridePrice,
+    overrideQty,
+    splitFrom,
+    splitTo,
+  ]);
+
+  async function handlePreview() {
+    setPreviewing(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams({
+        accountId,
+        symbol: symbol.toUpperCase(),
+        effectiveDate: new Date(`${effectiveDate}T00:00:00.000Z`).toISOString(),
+        adjustmentType,
+        payload: JSON.stringify(payload),
+      });
+      const response = await fetch(`/api/adjustments/preview?${params.toString()}`, { cache: "no-store" });
+      const result = await response.json();
+      if (!response.ok) {
+        throw new Error(result?.error?.message ?? "Preview failed");
+      }
+      onPreview(result.data as AdjustmentPreviewResponse);
+    } catch (loadError) {
+      onPreview(null);
+      setError(loadError instanceof Error ? loadError.message : "Preview failed");
+    } finally {
+      setPreviewing(false);
+    }
+  }
+
+  async function handleCreate() {
+    setSaving(true);
+    setError(null);
+    try {
+      const body: CreateManualAdjustmentRequest = {
+        createdBy,
+        accountId,
+        symbol: symbol.toUpperCase(),
+        effectiveDate: new Date(`${effectiveDate}T00:00:00.000Z`).toISOString(),
+        adjustmentType,
+        payload,
+        reason,
+        evidenceRef: evidenceRef || undefined,
+      };
+
+      const response = await fetch("/api/adjustments", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const result = await response.json();
+      if (!response.ok) {
+        throw new Error(result?.error?.message ?? "Create failed");
+      }
+
+      onCreated(result.data as ManualAdjustmentRecord);
+      onPreview(null);
+      setReason("");
+      setEvidenceRef("");
+    } catch (saveError) {
+      setError(saveError instanceof Error ? saveError.message : "Create failed");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="rounded-xl border border-border bg-panel p-3">
+      <p className="mb-3 text-sm font-semibold text-text">Create Adjustment</p>
+      <div className="grid gap-2 md:grid-cols-2">
+        <label className="text-xs text-muted">
+          Account
+          <select
+            value={accountId}
+            onChange={(event) => setAccountId(event.target.value)}
+            className="mt-1 w-full rounded border border-border bg-panel-2 px-2 py-2 text-xs text-text"
+          >
+            <option value="">Select account</option>
+            {availableAccounts.map((value) => (
+              <option key={value} value={value}>
+                {toExternalAccountId(value)}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="text-xs text-muted">
+          Symbol
+          <input
+            value={symbol}
+            onChange={(event) => setSymbol(event.target.value)}
+            className="mt-1 w-full rounded border border-border bg-panel-2 px-2 py-2 text-xs text-text"
+            placeholder="SDS"
+          />
+        </label>
+        <label className="text-xs text-muted">
+          Effective Date
+          <input
+            type="date"
+            value={effectiveDate}
+            onChange={(event) => setEffectiveDate(event.target.value)}
+            className="mt-1 w-full rounded border border-border bg-panel-2 px-2 py-2 text-xs text-text"
+          />
+        </label>
+        <label className="text-xs text-muted">
+          Type
+          <select
+            value={adjustmentType}
+            onChange={(event) => setAdjustmentType(event.target.value as AdjustmentType)}
+            className="mt-1 w-full rounded border border-border bg-panel-2 px-2 py-2 text-xs text-text"
+          >
+            <option value="SPLIT">SPLIT</option>
+            <option value="QTY_OVERRIDE">QTY_OVERRIDE</option>
+            <option value="PRICE_OVERRIDE">PRICE_OVERRIDE</option>
+            <option value="ADD_POSITION">ADD_POSITION</option>
+            <option value="REMOVE_POSITION">REMOVE_POSITION</option>
+          </select>
+        </label>
+
+        {adjustmentType === "SPLIT" ? (
+          <>
+            <label className="text-xs text-muted">
+              Ratio From
+              <input
+                type="number"
+                min={1}
+                value={splitFrom}
+                onChange={(event) => setSplitFrom(Number(event.target.value))}
+                className="mt-1 w-full rounded border border-border bg-panel-2 px-2 py-2 text-xs text-text"
+              />
+            </label>
+            <label className="text-xs text-muted">
+              Ratio To
+              <input
+                type="number"
+                min={1}
+                value={splitTo}
+                onChange={(event) => setSplitTo(Number(event.target.value))}
+                className="mt-1 w-full rounded border border-border bg-panel-2 px-2 py-2 text-xs text-text"
+              />
+            </label>
+          </>
+        ) : (
+          <label className="text-xs text-muted md:col-span-2">
+            Instrument Key
+            <input
+              value={instrumentKey}
+              onChange={(event) => setInstrumentKey(event.target.value)}
+              className="mt-1 w-full rounded border border-border bg-panel-2 px-2 py-2 text-xs text-text"
+              placeholder="SDS or SPY|CALL|650|2027-12-17"
+            />
+          </label>
+        )}
+
+        {adjustmentType === "QTY_OVERRIDE" ? (
+          <label className="text-xs text-muted">
+            Override Qty
+            <input
+              type="number"
+              value={overrideQty}
+              onChange={(event) => setOverrideQty(Number(event.target.value))}
+              className="mt-1 w-full rounded border border-border bg-panel-2 px-2 py-2 text-xs text-text"
+            />
+          </label>
+        ) : null}
+
+        {adjustmentType === "PRICE_OVERRIDE" ? (
+          <label className="text-xs text-muted">
+            Override Price
+            <input
+              type="number"
+              min={0}
+              step="0.0001"
+              value={overridePrice}
+              onChange={(event) => setOverridePrice(Number(event.target.value))}
+              className="mt-1 w-full rounded border border-border bg-panel-2 px-2 py-2 text-xs text-text"
+            />
+          </label>
+        ) : null}
+
+        {adjustmentType === "ADD_POSITION" ? (
+          <>
+            <label className="text-xs text-muted">
+              Asset Class
+              <select
+                value={addAssetClass}
+                onChange={(event) => setAddAssetClass(event.target.value as "EQUITY" | "OPTION")}
+                className="mt-1 w-full rounded border border-border bg-panel-2 px-2 py-2 text-xs text-text"
+              >
+                <option value="EQUITY">EQUITY</option>
+                <option value="OPTION">OPTION</option>
+              </select>
+            </label>
+            <label className="text-xs text-muted">
+              Net Qty
+              <input
+                type="number"
+                value={addNetQty}
+                onChange={(event) => setAddNetQty(Number(event.target.value))}
+                className="mt-1 w-full rounded border border-border bg-panel-2 px-2 py-2 text-xs text-text"
+              />
+            </label>
+            <label className="text-xs text-muted">
+              Cost Basis
+              <input
+                type="number"
+                value={addCostBasis}
+                onChange={(event) => setAddCostBasis(Number(event.target.value))}
+                className="mt-1 w-full rounded border border-border bg-panel-2 px-2 py-2 text-xs text-text"
+              />
+            </label>
+            {addAssetClass === "OPTION" ? (
+              <>
+                <label className="text-xs text-muted">
+                  Option Type
+                  <select
+                    value={addOptionType}
+                    onChange={(event) => setAddOptionType(event.target.value as "CALL" | "PUT")}
+                    className="mt-1 w-full rounded border border-border bg-panel-2 px-2 py-2 text-xs text-text"
+                  >
+                    <option value="CALL">CALL</option>
+                    <option value="PUT">PUT</option>
+                  </select>
+                </label>
+                <label className="text-xs text-muted">
+                  Strike
+                  <input
+                    value={addStrike}
+                    onChange={(event) => setAddStrike(event.target.value)}
+                    className="mt-1 w-full rounded border border-border bg-panel-2 px-2 py-2 text-xs text-text"
+                  />
+                </label>
+                <label className="text-xs text-muted">
+                  Expiration
+                  <input
+                    type="date"
+                    value={addExpirationDate}
+                    onChange={(event) => setAddExpirationDate(event.target.value)}
+                    className="mt-1 w-full rounded border border-border bg-panel-2 px-2 py-2 text-xs text-text"
+                  />
+                </label>
+              </>
+            ) : null}
+          </>
+        ) : null}
+
+        <label className="text-xs text-muted md:col-span-2">
+          Reason (required)
+          <input
+            value={reason}
+            onChange={(event) => setReason(event.target.value)}
+            className="mt-1 w-full rounded border border-border bg-panel-2 px-2 py-2 text-xs text-text"
+            placeholder="Corporate action reconciliation"
+          />
+        </label>
+        <label className="text-xs text-muted md:col-span-2">
+          Evidence URL
+          <input
+            value={evidenceRef}
+            onChange={(event) => setEvidenceRef(event.target.value)}
+            className="mt-1 w-full rounded border border-border bg-panel-2 px-2 py-2 text-xs text-text"
+            placeholder="https://..."
+          />
+        </label>
+        <label className="text-xs text-muted md:col-span-2">
+          Created By
+          <input
+            value={createdBy}
+            onChange={(event) => setCreatedBy(event.target.value)}
+            className="mt-1 w-full rounded border border-border bg-panel-2 px-2 py-2 text-xs text-text"
+          />
+        </label>
+      </div>
+
+      {adjustmentType === "SPLIT" ? (
+        <p className="mt-2 text-xs text-muted">
+          {directionLabel(splitFrom, splitTo)} ({splitFrom}:{splitTo})
+        </p>
+      ) : null}
+
+      {error ? <p className="mt-2 text-xs text-red-300">{error}</p> : null}
+
+      <div className="mt-3 flex items-center gap-2">
+        <button
+          type="button"
+          disabled={previewing || !accountId || !symbol || !reason}
+          onClick={handlePreview}
+          className="rounded border border-border bg-panel-2 px-3 py-1 text-xs text-text disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {previewing ? "Previewing..." : "Preview"}
+        </button>
+        <button
+          type="button"
+          disabled={saving || !accountId || !symbol || !reason}
+          onClick={handleCreate}
+          className="rounded border border-border bg-accent/20 px-3 py-1 text-xs text-text disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {saving ? "Saving..." : "Create Adjustment"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/adjustments/adjustment-list.tsx
+++ b/src/components/adjustments/adjustment-list.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import type { ManualAdjustmentRecord } from "@/types/api";
+
+function splitDirection(record: ManualAdjustmentRecord): string | null {
+  if (record.adjustmentType !== "SPLIT") {
+    return null;
+  }
+
+  const payload = record.payload as { from: number; to: number };
+  if (payload.to > payload.from) {
+    return "Forward split";
+  }
+  if (payload.to < payload.from) {
+    return "Reverse split";
+  }
+  return "No ratio change";
+}
+
+export function AdjustmentList({
+  adjustments,
+  onReverse,
+  reversingId,
+}: {
+  adjustments: ManualAdjustmentRecord[];
+  onReverse: (id: string) => void;
+  reversingId: string | null;
+}) {
+  return (
+    <div className="rounded-xl border border-border bg-panel p-3">
+      <p className="mb-3 text-sm font-semibold text-text">Adjustment Ledger</p>
+      {adjustments.length === 0 ? <p className="text-xs text-muted">No adjustments yet.</p> : null}
+      {adjustments.length > 0 ? (
+        <div className="max-h-[520px] overflow-auto rounded border border-border">
+          <table className="min-w-full text-xs">
+            <thead className="bg-panel-2 text-muted">
+              <tr>
+                <th className="px-2 py-2 text-left">Created</th>
+                <th className="px-2 py-2 text-left">Account</th>
+                <th className="px-2 py-2 text-left">Symbol</th>
+                <th className="px-2 py-2 text-left">Type</th>
+                <th className="px-2 py-2 text-left">Effective</th>
+                <th className="px-2 py-2 text-left">Payload</th>
+                <th className="px-2 py-2 text-left">Reason</th>
+                <th className="px-2 py-2 text-left">Status</th>
+                <th className="px-2 py-2 text-right">Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {adjustments.map((record) => (
+                <tr key={record.id} className="border-t border-border text-text">
+                  <td className="px-2 py-2">{new Date(record.createdAt).toLocaleString()}</td>
+                  <td className="px-2 py-2 font-mono">{record.accountExternalId}</td>
+                  <td className="px-2 py-2">{record.symbol}</td>
+                  <td className="px-2 py-2">
+                    {record.adjustmentType}
+                    {splitDirection(record) ? <span className="ml-1 text-[10px] text-muted">({splitDirection(record)})</span> : null}
+                  </td>
+                  <td className="px-2 py-2">{record.effectiveDate.slice(0, 10)}</td>
+                  <td className="max-w-[260px] px-2 py-2 font-mono text-[10px] text-muted">{JSON.stringify(record.payload)}</td>
+                  <td className="max-w-[260px] px-2 py-2 text-muted">{record.reason}</td>
+                  <td className="px-2 py-2">
+                    <span className={record.status === "ACTIVE" ? "text-accent-2" : "text-muted"}>{record.status}</span>
+                  </td>
+                  <td className="px-2 py-2 text-right">
+                    <button
+                      type="button"
+                      disabled={record.status !== "ACTIVE" || reversingId === record.id}
+                      onClick={() => onReverse(record.id)}
+                      className="rounded border border-border bg-panel-2 px-2 py-1 text-[11px] text-text disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {reversingId === record.id ? "Reversing..." : "Reverse"}
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/adjustments/adjustment-preview.tsx
+++ b/src/components/adjustments/adjustment-preview.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import type { AdjustmentPreviewResponse } from "@/types/api";
+
+function formatNumber(value: number | null): string {
+  if (value === null) {
+    return "—";
+  }
+  return value.toFixed(4);
+}
+
+export function AdjustmentPreview({ preview }: { preview: AdjustmentPreviewResponse | null }) {
+  return (
+    <div className="rounded-xl border border-border bg-panel p-3">
+      <p className="mb-3 text-sm font-semibold text-text">Preview</p>
+      {!preview ? <p className="text-xs text-muted">Run preview to see before/after impact.</p> : null}
+      {preview ? (
+        <div className="space-y-2 text-xs text-muted">
+          <p>
+            Symbol: <span className="font-mono text-text">{preview.symbol}</span>
+          </p>
+          <p>
+            Type: <span className="text-text">{preview.adjustmentType}</span>
+          </p>
+          <p>
+            Effective: <span className="text-text">{preview.effectiveDate.slice(0, 10)}</span>
+          </p>
+          <p>
+            Affected executions: <span className="text-text">{preview.affectedExecutionCount}</span>
+          </p>
+
+          <div className="rounded border border-border">
+            <table className="min-w-full text-xs">
+              <thead className="bg-panel-2 text-muted">
+                <tr>
+                  <th className="px-2 py-2 text-left">Metric</th>
+                  <th className="px-2 py-2 text-right">Before</th>
+                  <th className="px-2 py-2 text-right">After</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr className="border-t border-border text-text">
+                  <td className="px-2 py-2">Open Qty</td>
+                  <td className="px-2 py-2 text-right">{formatNumber(preview.before.openQty)}</td>
+                  <td className="px-2 py-2 text-right">{formatNumber(preview.after.openQty)}</td>
+                </tr>
+                <tr className="border-t border-border text-text">
+                  <td className="px-2 py-2">Cost Basis / Share</td>
+                  <td className="px-2 py-2 text-right">{formatNumber(preview.before.costBasisPerShare)}</td>
+                  <td className="px-2 py-2 text-right">{formatNumber(preview.after.costBasisPerShare)}</td>
+                </tr>
+                <tr className="border-t border-border text-text">
+                  <td className="px-2 py-2">Gross Cost</td>
+                  <td className="px-2 py-2 text-right">{formatNumber(preview.before.grossCost)}</td>
+                  <td className="px-2 py-2 text-right">{formatNumber(preview.after.grossCost)}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/hooks/useOpenPositions.ts
+++ b/src/hooks/useOpenPositions.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import type { ExecutionRecord, MatchedLotRecord, OpenPosition } from "@/types/api";
+import type { ExecutionRecord, ManualAdjustmentRecord, OpenPosition, AdjustmentsListApiResponse, MatchedLotRecord } from "@/types/api";
 import { computeOpenPositions } from "@/lib/positions/compute-open-positions";
 
 interface ExecutionsPayload {
@@ -10,6 +10,10 @@ interface ExecutionsPayload {
 
 interface MatchedLotsPayload {
   data: MatchedLotRecord[];
+}
+
+interface AdjustmentsPayload {
+  data: ManualAdjustmentRecord[];
 }
 
 export function useOpenPositions(): { positions: OpenPosition[]; loading: boolean; error: string | null } {
@@ -36,8 +40,20 @@ export function useOpenPositions(): { positions: OpenPosition[]; loading: boolea
 
         const executionsPayload = (await executionResponse.json()) as ExecutionsPayload;
         const matchedLotsPayload = (await matchedLotsResponse.json()) as MatchedLotsPayload;
+        let manualAdjustments: ManualAdjustmentRecord[] = [];
+        try {
+          const adjustmentsResponse = await fetch("/api/adjustments?page=1&pageSize=1000&status=ACTIVE", { cache: "no-store" });
+          if (adjustmentsResponse.ok) {
+            const adjustmentsPayload = (await adjustmentsResponse.json()) as AdjustmentsPayload | AdjustmentsListApiResponse;
+            if ("data" in adjustmentsPayload && Array.isArray(adjustmentsPayload.data)) {
+              manualAdjustments = adjustmentsPayload.data as ManualAdjustmentRecord[];
+            }
+          }
+        } catch {
+          manualAdjustments = [];
+        }
 
-        const openPositions = computeOpenPositions(executionsPayload.data, matchedLotsPayload.data);
+        const openPositions = computeOpenPositions(executionsPayload.data, matchedLotsPayload.data, manualAdjustments);
 
         if (!cancelled) {
           setPositions(openPositions);

--- a/src/lib/adjustments/__tests__/apply-adjustments.test.ts
+++ b/src/lib/adjustments/__tests__/apply-adjustments.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import { applyExecutionSplitAdjustment, applyPositionAdjustments } from "@/lib/adjustments/apply-adjustments";
+import type { ExecutionRecord, ManualAdjustmentRecord, OpenPosition } from "@/types/api";
+
+function splitAdjustment(overrides: Partial<ManualAdjustmentRecord> = {}): ManualAdjustmentRecord {
+  return {
+    id: overrides.id ?? "adj-1",
+    createdAt: overrides.createdAt ?? "2026-01-01T00:00:00.000Z",
+    createdBy: overrides.createdBy ?? "tester",
+    accountId: overrides.accountId ?? "account-1",
+    accountExternalId: overrides.accountExternalId ?? "D-1",
+    symbol: overrides.symbol ?? "SDS",
+    effectiveDate: overrides.effectiveDate ?? "2025-11-20T00:00:00.000Z",
+    adjustmentType: overrides.adjustmentType ?? "SPLIT",
+    payload: overrides.payload ?? { from: 5, to: 1 },
+    reason: overrides.reason ?? "test split",
+    evidenceRef: overrides.evidenceRef ?? null,
+    status: overrides.status ?? "ACTIVE",
+    reversedByAdjustmentId: overrides.reversedByAdjustmentId ?? null,
+  };
+}
+
+function execution(overrides: Partial<ExecutionRecord> = {}): ExecutionRecord {
+  return {
+    id: overrides.id ?? "exec-1",
+    accountId: overrides.accountId ?? "account-1",
+    broker: overrides.broker ?? "SCHWAB_THINKORSWIM",
+    symbol: overrides.symbol ?? "SDS",
+    tradeDate: overrides.tradeDate ?? "2025-11-01T00:00:00.000Z",
+    eventTimestamp: overrides.eventTimestamp ?? "2025-11-01T12:00:00.000Z",
+    eventType: overrides.eventType ?? "TRADE",
+    assetClass: overrides.assetClass ?? "EQUITY",
+    side: overrides.side ?? "BUY",
+    quantity: overrides.quantity ?? "200",
+    price: overrides.price ?? "14.87",
+    openingClosingEffect: overrides.openingClosingEffect ?? "TO_OPEN",
+    instrumentKey: overrides.instrumentKey ?? "SDS",
+    underlyingSymbol: overrides.underlyingSymbol ?? "SDS",
+    optionType: overrides.optionType ?? null,
+    strike: overrides.strike ?? null,
+    expirationDate: overrides.expirationDate ?? null,
+    spreadGroupId: overrides.spreadGroupId ?? null,
+    importId: overrides.importId ?? "import-1",
+  };
+}
+
+describe("applyExecutionSplitAdjustment", () => {
+  it("applies reverse split ratio to pre-effective-date executions", () => {
+    const scales = applyExecutionSplitAdjustment(execution(), [splitAdjustment()]);
+    expect(scales.quantityScale).toBeCloseTo(0.2, 6);
+    expect(scales.priceScale).toBeCloseTo(5, 6);
+  });
+
+  it("applies forward split ratio", () => {
+    const scales = applyExecutionSplitAdjustment(
+      execution({ symbol: "XLU", tradeDate: "2025-11-01T00:00:00.000Z" }),
+      [
+        splitAdjustment({
+          symbol: "XLU",
+          effectiveDate: "2025-12-05T00:00:00.000Z",
+          payload: { from: 1, to: 2 },
+        }),
+      ],
+    );
+    expect(scales.quantityScale).toBeCloseTo(2, 6);
+    expect(scales.priceScale).toBeCloseTo(0.5, 6);
+  });
+
+  it("ignores reversed split adjustments", () => {
+    const scales = applyExecutionSplitAdjustment(execution(), [splitAdjustment({ status: "REVERSED" })]);
+    expect(scales.quantityScale).toBe(1);
+    expect(scales.priceScale).toBe(1);
+  });
+});
+
+describe("applyPositionAdjustments", () => {
+  it("overrides qty and preserves per-share basis", () => {
+    const positions: OpenPosition[] = [
+      {
+        symbol: "SDS",
+        underlyingSymbol: "SDS",
+        assetClass: "EQUITY",
+        optionType: null,
+        strike: null,
+        expirationDate: null,
+        instrumentKey: "SDS",
+        netQty: 200,
+        costBasis: 2974,
+        accountId: "account-1",
+      },
+    ];
+
+    const result = applyPositionAdjustments(positions, [
+      splitAdjustment({
+        adjustmentType: "QTY_OVERRIDE",
+        payload: { instrumentKey: "SDS", overrideQty: 40 },
+      }),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.netQty).toBe(40);
+    expect(result[0]?.costBasis).toBeCloseTo(594.8, 4);
+  });
+
+  it("adds synthetic and removes by instrument key", () => {
+    const base: OpenPosition[] = [];
+    const result = applyPositionAdjustments(base, [
+      splitAdjustment({
+        id: "add",
+        adjustmentType: "ADD_POSITION",
+        payload: { instrumentKey: "XLU", assetClass: "EQUITY", netQty: 200, costBasis: 4589 },
+      }),
+      splitAdjustment({
+        id: "remove",
+        adjustmentType: "REMOVE_POSITION",
+        payload: { instrumentKey: "XLU" },
+        createdAt: "2026-01-02T00:00:00.000Z",
+      }),
+    ]);
+
+    expect(result).toHaveLength(0);
+  });
+});

--- a/src/lib/adjustments/apply-adjustments.ts
+++ b/src/lib/adjustments/apply-adjustments.ts
@@ -1,0 +1,141 @@
+import type { ExecutionRecord, ManualAdjustmentRecord, OpenPosition } from "@/types/api";
+import { parsePayloadByType } from "@/lib/adjustments/types";
+
+export function sortAdjustments(adjustments: ManualAdjustmentRecord[]): ManualAdjustmentRecord[] {
+  return [...adjustments].sort((left, right) => {
+    const leftEffective = new Date(left.effectiveDate).getTime();
+    const rightEffective = new Date(right.effectiveDate).getTime();
+
+    if (leftEffective !== rightEffective) {
+      return leftEffective - rightEffective;
+    }
+
+    const leftCreated = new Date(left.createdAt).getTime();
+    const rightCreated = new Date(right.createdAt).getTime();
+    return leftCreated - rightCreated;
+  });
+}
+
+export function applyExecutionSplitAdjustment(
+  execution: ExecutionRecord,
+  adjustments: ManualAdjustmentRecord[],
+): { quantityScale: number; priceScale: number } {
+  if (execution.assetClass !== "EQUITY") {
+    return { quantityScale: 1, priceScale: 1 };
+  }
+
+  const executionTradeDate = new Date(execution.tradeDate).getTime();
+  if (!Number.isFinite(executionTradeDate)) {
+    return { quantityScale: 1, priceScale: 1 };
+  }
+
+  let quantityScale = 1;
+  let priceScale = 1;
+
+  for (const adjustment of sortAdjustments(adjustments)) {
+    if (adjustment.status !== "ACTIVE" || adjustment.adjustmentType !== "SPLIT") {
+      continue;
+    }
+
+    if (adjustment.symbol.toUpperCase() !== execution.symbol.toUpperCase()) {
+      continue;
+    }
+
+    const effectiveDate = new Date(adjustment.effectiveDate).getTime();
+    if (!Number.isFinite(effectiveDate) || executionTradeDate >= effectiveDate) {
+      continue;
+    }
+
+    try {
+      const payload = parsePayloadByType("SPLIT", adjustment.payload);
+      quantityScale *= payload.to / payload.from;
+      priceScale *= payload.from / payload.to;
+    } catch {
+      continue;
+    }
+  }
+
+  return {
+    quantityScale,
+    priceScale,
+  };
+}
+
+function parseInstrumentSymbol(instrumentKey: string): string {
+  return instrumentKey.split("|")[0] ?? instrumentKey;
+}
+
+export function applyPositionAdjustments(positions: OpenPosition[], adjustments: ManualAdjustmentRecord[]): OpenPosition[] {
+  const activeAdjustments = sortAdjustments(adjustments.filter((adjustment) => adjustment.status === "ACTIVE"));
+  const grouped = new Map(positions.map((position) => [position.accountId + "::" + position.instrumentKey, { ...position }]));
+
+  for (const adjustment of activeAdjustments) {
+    const accountPrefix = adjustment.accountId + "::";
+
+    try {
+      if (adjustment.adjustmentType === "QTY_OVERRIDE") {
+        const payload = parsePayloadByType("QTY_OVERRIDE", adjustment.payload);
+        const target = grouped.get(accountPrefix + payload.instrumentKey);
+        if (target) {
+          const multiplier = target.assetClass === "OPTION" ? 100 : 1;
+          const costBasisPerShare = target.netQty !== 0 ? target.costBasis / (target.netQty * multiplier) : 0;
+          target.netQty = payload.overrideQty;
+          target.costBasis = payload.overrideQty * multiplier * costBasisPerShare;
+        }
+        continue;
+      }
+
+      if (adjustment.adjustmentType === "PRICE_OVERRIDE") {
+        const payload = parsePayloadByType("PRICE_OVERRIDE", adjustment.payload);
+        const target = grouped.get(accountPrefix + payload.instrumentKey);
+        if (target) {
+          const multiplier = target.assetClass === "OPTION" ? 100 : 1;
+          target.costBasis = target.netQty * multiplier * payload.overridePrice;
+        }
+        continue;
+      }
+
+      if (adjustment.adjustmentType === "REMOVE_POSITION") {
+        const payload = parsePayloadByType("REMOVE_POSITION", adjustment.payload);
+        grouped.delete(accountPrefix + payload.instrumentKey);
+        continue;
+      }
+
+      if (adjustment.adjustmentType === "ADD_POSITION") {
+        const payload = parsePayloadByType("ADD_POSITION", adjustment.payload);
+        const key = accountPrefix + payload.instrumentKey;
+        const existing = grouped.get(key);
+        if (existing) {
+          existing.netQty += payload.netQty;
+          existing.costBasis += payload.costBasis;
+        } else {
+          grouped.set(key, {
+            symbol: parseInstrumentSymbol(payload.instrumentKey),
+            underlyingSymbol: parseInstrumentSymbol(payload.instrumentKey),
+            assetClass: payload.assetClass,
+            optionType: payload.optionType ?? null,
+            strike: payload.strike ?? null,
+            expirationDate: payload.expirationDate ?? null,
+            instrumentKey: payload.instrumentKey,
+            netQty: payload.netQty,
+            costBasis: payload.costBasis,
+            accountId: adjustment.accountId,
+          });
+        }
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return Array.from(grouped.values())
+    .filter((position) => position.netQty !== 0)
+    .sort((left, right) => {
+      const symbolOrder = left.underlyingSymbol.localeCompare(right.underlyingSymbol);
+      if (symbolOrder !== 0) {
+        return symbolOrder;
+      }
+
+      return left.instrumentKey.localeCompare(right.instrumentKey);
+    });
+}

--- a/src/lib/adjustments/types.ts
+++ b/src/lib/adjustments/types.ts
@@ -1,0 +1,75 @@
+import { z } from "zod";
+import type {
+  AddPositionPayload,
+  AdjustmentType,
+  ManualAdjustmentPayload,
+  PriceOverridePayload,
+  QtyOverridePayload,
+  RemovePositionPayload,
+  SplitPayload,
+} from "@/types/api";
+
+const splitPayloadSchema = z.object({
+  from: z.number().positive(),
+  to: z.number().positive(),
+});
+
+const qtyOverridePayloadSchema = z.object({
+  instrumentKey: z.string().min(1),
+  overrideQty: z.number(),
+});
+
+const priceOverridePayloadSchema = z.object({
+  instrumentKey: z.string().min(1),
+  overridePrice: z.number().nonnegative(),
+});
+
+const addPositionPayloadSchema = z.object({
+  instrumentKey: z.string().min(1),
+  assetClass: z.enum(["EQUITY", "OPTION"]),
+  netQty: z.number(),
+  costBasis: z.number(),
+  optionType: z.enum(["CALL", "PUT"]).optional(),
+  strike: z.string().optional(),
+  expirationDate: z.string().optional(),
+});
+
+const removePositionPayloadSchema = z.object({
+  instrumentKey: z.string().min(1),
+});
+
+export const manualAdjustmentCreateSchema = z.object({
+  createdBy: z.string().trim().optional(),
+  accountId: z.string().trim().min(1),
+  symbol: z.string().trim().min(1),
+  effectiveDate: z.string().datetime(),
+  adjustmentType: z.enum(["SPLIT", "QTY_OVERRIDE", "PRICE_OVERRIDE", "ADD_POSITION", "REMOVE_POSITION"]),
+  payload: z.unknown(),
+  reason: z.string().trim().min(1),
+  evidenceRef: z.string().trim().optional(),
+});
+
+export type ManualAdjustmentCreateInput = z.infer<typeof manualAdjustmentCreateSchema>;
+
+export function parsePayloadByType(type: "SPLIT", payload: unknown): SplitPayload;
+export function parsePayloadByType(type: "QTY_OVERRIDE", payload: unknown): QtyOverridePayload;
+export function parsePayloadByType(type: "PRICE_OVERRIDE", payload: unknown): PriceOverridePayload;
+export function parsePayloadByType(type: "ADD_POSITION", payload: unknown): AddPositionPayload;
+export function parsePayloadByType(type: "REMOVE_POSITION", payload: unknown): RemovePositionPayload;
+export function parsePayloadByType(type: AdjustmentType, payload: unknown): ManualAdjustmentPayload;
+export function parsePayloadByType(type: AdjustmentType, payload: unknown): ManualAdjustmentPayload {
+  switch (type) {
+    case "SPLIT":
+      return splitPayloadSchema.parse(payload);
+    case "QTY_OVERRIDE":
+      return qtyOverridePayloadSchema.parse(payload);
+    case "PRICE_OVERRIDE":
+      return priceOverridePayloadSchema.parse(payload);
+    case "ADD_POSITION":
+      return addPositionPayloadSchema.parse(payload);
+    case "REMOVE_POSITION":
+      return removePositionPayloadSchema.parse(payload);
+    default:
+      throw new Error(`Unsupported adjustment type: ${String(type)}`);
+  }
+}

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -31,6 +31,7 @@ export const navGroups: NavGroup[] = [
     items: [
       { href: "/tts-evidence", label: "TTS Evidence" },
       { href: "/diagnostics", label: "Diagnostics" },
+      { href: "/adjustments", label: "Adjustments" },
     ],
   },
 ];
@@ -67,6 +68,10 @@ export function getTopbarContextTags(pathname: string): string[] {
 
   if (pathname.startsWith("/analytics")) {
     return ["Derived metrics"];
+  }
+
+  if (pathname.startsWith("/adjustments")) {
+    return ["Audit trail", "Overrides"];
   }
 
   return [];

--- a/src/lib/positions/compute-open-positions.test.ts
+++ b/src/lib/positions/compute-open-positions.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { ExecutionRecord, MatchedLotRecord } from "@/types/api";
+import type { ExecutionRecord, ManualAdjustmentRecord, MatchedLotRecord } from "@/types/api";
 import { computeOpenPositions } from "./compute-open-positions";
 
 function execution(overrides: Partial<ExecutionRecord> & Pick<ExecutionRecord, "id" | "symbol" | "accountId">): ExecutionRecord {
@@ -89,5 +89,43 @@ describe("computeOpenPositions", () => {
     expect(result).toHaveLength(1);
     expect(result[0]?.netQty).toBe(-1);
     expect(result[0]?.costBasis).toBeCloseTo(-198, 6);
+  });
+
+  it("applies split adjustments to quantity and price while preserving gross basis", () => {
+    const executions: ExecutionRecord[] = [
+      execution({
+        id: "open-sds",
+        accountId: "account-1",
+        symbol: "SDS",
+        quantity: "200",
+        price: "14.87",
+        instrumentKey: "SDS",
+        tradeDate: "2025-11-01T00:00:00.000Z",
+        eventTimestamp: "2025-11-01T14:00:00.000Z",
+      }),
+    ];
+
+    const adjustments: ManualAdjustmentRecord[] = [
+      {
+        id: "split-sds",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        createdBy: "tester",
+        accountId: "account-1",
+        accountExternalId: "D-68011053",
+        symbol: "SDS",
+        effectiveDate: "2025-11-20T00:00:00.000Z",
+        adjustmentType: "SPLIT",
+        payload: { from: 5, to: 1 },
+        reason: "reverse split",
+        evidenceRef: null,
+        status: "ACTIVE",
+        reversedByAdjustmentId: null,
+      },
+    ];
+
+    const result = computeOpenPositions(executions, [], adjustments);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.netQty).toBeCloseTo(40, 6);
+    expect(result[0]?.costBasis).toBeCloseTo(2974, 6);
   });
 });

--- a/src/lib/positions/compute-open-positions.ts
+++ b/src/lib/positions/compute-open-positions.ts
@@ -1,4 +1,5 @@
-import type { ExecutionRecord, MatchedLotRecord, OpenPosition } from "@/types/api";
+import { applyExecutionSplitAdjustment, applyPositionAdjustments } from "@/lib/adjustments/apply-adjustments";
+import type { ExecutionRecord, ManualAdjustmentRecord, MatchedLotRecord, OpenPosition } from "@/types/api";
 
 function signedQuantity(side: string | null, quantity: number): number {
   return side === "SELL" ? quantity * -1 : quantity;
@@ -16,7 +17,11 @@ function fallbackInstrumentKey(execution: ExecutionRecord): string {
   ].join("|");
 }
 
-export function computeOpenPositions(executions: ExecutionRecord[], matchedLots: MatchedLotRecord[]): OpenPosition[] {
+export function computeOpenPositions(
+  executions: ExecutionRecord[],
+  matchedLots: MatchedLotRecord[],
+  adjustments: ManualAdjustmentRecord[] = [],
+): OpenPosition[] {
   const matchedQtyByOpenExecutionId = new Map<string, number>();
   for (const lot of matchedLots) {
     const quantity = Number(lot.quantity);
@@ -50,13 +55,17 @@ export function computeOpenPositions(executions: ExecutionRecord[], matchedLots:
     const groupKey = execution.accountId + "::" + key;
 
     const price = Number(execution.price ?? 0);
-    const qtySigned = signedQuantity(execution.side, remainingQuantity);
+    const relevantAdjustments = adjustments.filter((adjustment) => adjustment.accountId === execution.accountId);
+    const splitScales = applyExecutionSplitAdjustment(execution, relevantAdjustments);
+    const adjustedQuantity = remainingQuantity * splitScales.quantityScale;
+    const adjustedPrice = price * splitScales.priceScale;
+    const qtySigned = signedQuantity(execution.side, adjustedQuantity);
     const multiplier = execution.assetClass === "OPTION" ? 100 : 1;
 
     const existing = grouped.get(groupKey);
     if (existing) {
       existing.netQty += qtySigned;
-      existing.costBasis += qtySigned * price * multiplier;
+      existing.costBasis += qtySigned * adjustedPrice * multiplier;
       continue;
     }
 
@@ -69,12 +78,12 @@ export function computeOpenPositions(executions: ExecutionRecord[], matchedLots:
       expirationDate: execution.expirationDate,
       instrumentKey: key,
       netQty: qtySigned,
-      costBasis: qtySigned * price * multiplier,
+      costBasis: qtySigned * adjustedPrice * multiplier,
       accountId: execution.accountId,
     });
   }
 
-  return Array.from(grouped.values())
+  const basePositions = Array.from(grouped.values())
     .filter((position) => position.netQty !== 0)
     .sort((left, right) => {
       const symbolOrder = left.underlyingSymbol.localeCompare(right.underlyingSymbol);
@@ -84,4 +93,6 @@ export function computeOpenPositions(executions: ExecutionRecord[], matchedLots:
 
       return left.instrumentKey.localeCompare(right.instrumentKey);
     });
+
+  return applyPositionAdjustments(basePositions, adjustments);
 }

--- a/types/api.ts
+++ b/types/api.ts
@@ -310,6 +310,89 @@ export interface NlvResult {
   loading: boolean;
 }
 
+export type AdjustmentType = "SPLIT" | "QTY_OVERRIDE" | "PRICE_OVERRIDE" | "ADD_POSITION" | "REMOVE_POSITION";
+export type AdjustmentStatus = "ACTIVE" | "REVERSED";
+
+export interface SplitPayload {
+  from: number;
+  to: number;
+}
+
+export interface QtyOverridePayload {
+  instrumentKey: string;
+  overrideQty: number;
+}
+
+export interface PriceOverridePayload {
+  instrumentKey: string;
+  overridePrice: number;
+}
+
+export interface AddPositionPayload {
+  instrumentKey: string;
+  assetClass: "EQUITY" | "OPTION";
+  netQty: number;
+  costBasis: number;
+  optionType?: "CALL" | "PUT";
+  strike?: string;
+  expirationDate?: string;
+}
+
+export interface RemovePositionPayload {
+  instrumentKey: string;
+}
+
+export type ManualAdjustmentPayload = SplitPayload | QtyOverridePayload | PriceOverridePayload | AddPositionPayload | RemovePositionPayload;
+
+export interface ManualAdjustmentRecord {
+  id: string;
+  createdAt: string;
+  createdBy: string;
+  accountId: string;
+  accountExternalId: string;
+  symbol: string;
+  effectiveDate: string;
+  adjustmentType: AdjustmentType;
+  payload: ManualAdjustmentPayload;
+  reason: string;
+  evidenceRef: string | null;
+  status: AdjustmentStatus;
+  reversedByAdjustmentId: string | null;
+}
+
+export interface CreateManualAdjustmentRequest {
+  createdBy?: string;
+  accountId: string;
+  symbol: string;
+  effectiveDate: string;
+  adjustmentType: AdjustmentType;
+  payload: ManualAdjustmentPayload;
+  reason: string;
+  evidenceRef?: string;
+}
+
+export interface ReverseManualAdjustmentResponse {
+  reversedId: string;
+  reversalId: string;
+}
+
+export interface AdjustmentPreviewResponse {
+  symbol: string;
+  adjustmentType: AdjustmentType;
+  before: {
+    openQty: number;
+    costBasisPerShare: number | null;
+    grossCost: number;
+  };
+  after: {
+    openQty: number;
+    costBasisPerShare: number | null;
+    grossCost: number;
+  };
+  affectedExecutionCount: number;
+  effectiveDate: string;
+}
+
 export interface StreakSummaryResponse {
   currentStreak: number;
   currentStreakType: "WIN" | "LOSS" | null;
@@ -329,3 +412,7 @@ export type TtsEvidenceApiResponse = ApiDetailResponse<TtsEvidenceResponse> | Ap
 export type DiagnosticsApiResponse = ApiDetailResponse<DiagnosticsResponse> | ApiErrorResponse;
 export type HealthApiResponse = HealthResponse;
 export type AdapterListApiResponse = ApiListResponse<AdapterSummaryRecord> | ApiErrorResponse;
+export type AdjustmentsListApiResponse = ApiListResponse<ManualAdjustmentRecord> | ApiErrorResponse;
+export type AdjustmentCreateApiResponse = ApiDetailResponse<ManualAdjustmentRecord> | ApiErrorResponse;
+export type AdjustmentReverseApiResponse = ApiDetailResponse<ReverseManualAdjustmentResponse> | ApiErrorResponse;
+export type AdjustmentPreviewApiResponse = ApiDetailResponse<AdjustmentPreviewResponse> | ApiErrorResponse;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,18 @@
+import { fileURLToPath } from 'node:url';
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: '@/types',
+        replacement: fileURLToPath(new URL('./types', import.meta.url)),
+      },
+      {
+        find: '@',
+        replacement: fileURLToPath(new URL('./src', import.meta.url)),
+      },
+    ],
+  },
+});


### PR DESCRIPTION
## Summary
- add `ManualAdjustment` Prisma model/enums and migration
- add additive adjustments API routes (list/create, reverse, preview) with payload validation
- add adjustment overlay engine and integrate into open-position computation
- add `/adjustments` page and sidebar navigation entry
- seed initial ACTIVE split adjustments for SDS (1:5 reverse) and XLU (2:1 forward) on account D-68011053
- add unit tests for adjustment math/order and open-position split integration
- add `vitest.config.ts` alias mapping for test path resolution

## Validation
- `npm run test`
- `npm run typecheck`
- `npm run lint`
- `npm run prisma:generate && npm run prisma:migrate && npm run db:seed`

## Notes
- raw execution/import/ledger records remain immutable; adjustments are overlay-only
- verified seeded ACTIVE adjustments exist for SDS and XLU in local DB
