### PR TITLE
Fix #47: normalize P&L and trading metrics to USD

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,3 +7,5 @@ Phase 5 complete — issues KM-005 through KM-030 done — typecheck clean — t
 Assumption: open positions are grouped by account + instrument key to avoid cross-account netting collisions.
 Assumption: dashboard edit controls are rendered within the dashboard content area (not topbar) while preserving required edit/add/remove/persist behavior.
 @modelcontextprotocol/sdk added to support MCP-backed market data tool calls without app-managed Schwab OAuth tokens.
+v7.2 bugfix exception: FIFO matched-lot realized P&L normalization updated for option contract multiplier (×100), with downstream rebuild support via `npm run rebuild:pnl`.
+v7.2 documentation added: `docs/kapman_build_spec_v7_2.md` (manual override features + P&L normalization/story fixes).

--- a/docs/kapman_build_spec_v7_2.md
+++ b/docs/kapman_build_spec_v7_2.md
@@ -1,0 +1,74 @@
+# KapMan Build Spec v7.2
+
+Status: Post-v7 bugfix + correctness patch set  
+Base: `docs/kapman_build_spec_v7.md`
+
+## Purpose
+v7.2 standardizes dollar semantics for realized P&L across T1/T2/T3, fixes pagination-sensitive T3 summaries, and clarifies metric units/formatting without changing parser behavior, schema, or open-position/NLV formulas.
+
+## Included Manual Override Features
+v7.2 preserves and documents manual overrides introduced in v7:
+- Manual adjustments route and UI (`/adjustments`)
+- Supported adjustment types:
+  - `SPLIT`
+  - `QTY_OVERRIDE`
+  - `PRICE_OVERRIDE`
+  - `ADD_POSITION`
+  - `REMOVE_POSITION`
+- Preview-before-commit behavior for adjustments
+- Reversal workflow for active adjustments
+- Position reconstruction integration through adjustment application layer
+
+No new adjustment types are added in v7.2.
+
+## v7.2 Fix Scope
+
+### 1) FIFO realized P&L normalization (options multiplier)
+- Fix location: FIFO matcher write-path feeding `MatchedLot.realizedPnl`
+- Canonical formulas:
+  - Equity: `(exitPrice - entryPrice) * quantity`
+  - Option: `(exitPrice - entryPrice) * quantity * 100`
+- Applies to standard closes, assignment/exercise closes, and synthetic expiration closes.
+
+### 2) Persisted data rebuild support
+- New command: `npm run rebuild:pnl`
+- Behavior:
+  - Rebuild matched lots from existing executions with corrected FIFO P&L
+  - Rebuild setup groups from corrected matched lots
+  - Print per-account before/after summary for matched-lot and setup P&L totals
+- Idempotent by design (safe to rerun).
+
+### 3) Win-rate canonicalization
+- Canonical definition: `WIN / (WIN + LOSS)`; FLAT excluded.
+- When denominator is zero (all flat), win rate is null/`N/A`.
+- Setup-group persistence now follows this rule during rebuilds.
+
+### 4) T3 summary card correctness
+- T3 summary cards now compute from the full filtered setup set (`pageSize=1000` fetch), not only the visible table page.
+- Summary values remain stable between paginated and show-all modes.
+
+### 5) Labeling + formatting normalization
+- T1 executions table header: `Unit Price`
+- T2/T3 realized P&L headers: `Realized P&L ($)`
+- Win-rate labels: `Win Rate (%)`
+- Expectancy labels: `Expectancy ($ / lot)`
+- Currency formatting applied to realized P&L displays across T2/T3 panels.
+- TTS Evidence `Gross Proceeds Proxy` now renders as compact currency with explanatory tooltip.
+
+## Explicit Non-Goals
+- No parser/adapter changes
+- No schema/migration changes
+- No changes to setup grouping/tag inference rules
+- No changes to open-position or NLV valuation formulas
+- No change to gross proceeds proxy formula (`sum(abs(quantity) * price)`)
+
+## Validation Requirements
+- `npm run test`
+- `npm run typecheck`
+- `npm run lint`
+
+## Rollout Notes
+1. Deploy code changes.
+2. Run `npm run rebuild:pnl` against the target environment database.
+3. Confirm per-account before/after output reflects option-P&L normalization impact.
+4. Verify dashboard/trade-records/analytics/tts-evidence surfaces for updated units and formatting.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "rebuild:pnl": "tsx scripts/rebuild-pnl.ts",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate deploy",
     "db:seed": "prisma db seed"

--- a/scripts/rebuild-pnl.ts
+++ b/scripts/rebuild-pnl.ts
@@ -1,0 +1,92 @@
+import { PrismaClient, type Prisma } from "@prisma/client";
+import { rebuildAccountSetups } from "../src/lib/analytics/rebuild-account-setups";
+import { rebuildAccountLedger } from "../src/lib/ledger/rebuild-account-ledger";
+
+interface AccountStats {
+  matchedLotCount: number;
+  matchedLotPnl: number;
+  setupCount: number;
+  setupPnl: number;
+}
+
+function decimalToNumber(value: Prisma.Decimal | null | undefined): number {
+  return value ? Number(value) : 0;
+}
+
+async function loadAccountStats(prisma: PrismaClient, accountId: string): Promise<AccountStats> {
+  const [matchedLotAgg, setupAgg] = await Promise.all([
+    prisma.matchedLot.aggregate({
+      where: { accountId },
+      _count: { _all: true },
+      _sum: { realizedPnl: true },
+    }),
+    prisma.setupGroup.aggregate({
+      where: { accountId },
+      _count: { _all: true },
+      _sum: { realizedPnl: true },
+    }),
+  ]);
+
+  return {
+    matchedLotCount: matchedLotAgg._count._all,
+    matchedLotPnl: decimalToNumber(matchedLotAgg._sum.realizedPnl),
+    setupCount: setupAgg._count._all,
+    setupPnl: decimalToNumber(setupAgg._sum.realizedPnl),
+  };
+}
+
+function formatSigned(value: number): string {
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 2 }).format(value);
+}
+
+async function main() {
+  const prisma = new PrismaClient();
+
+  try {
+    const accounts = await prisma.account.findMany({
+      select: {
+        id: true,
+        accountId: true,
+      },
+      orderBy: { accountId: "asc" },
+    });
+
+    if (accounts.length === 0) {
+      console.log("[rebuild:pnl] no accounts found; nothing to rebuild.");
+      return;
+    }
+
+    console.log(`[rebuild:pnl] rebuilding ${accounts.length} account(s)...`);
+
+    for (const account of accounts) {
+      const before = await loadAccountStats(prisma, account.id);
+      const rebuilt = await prisma.$transaction(async (tx) => {
+        const ledger = await rebuildAccountLedger(tx, account.id, new Date());
+        const setups = await rebuildAccountSetups(tx, account.id);
+        return { ledger, setups };
+      });
+      const after = await loadAccountStats(prisma, account.id);
+
+      console.log(`\n[rebuild:pnl] account=${account.accountId}`);
+      console.log(
+        `  matched_lots: ${before.matchedLotCount} -> ${after.matchedLotCount} | realized_pnl: ${formatSigned(before.matchedLotPnl)} -> ${formatSigned(after.matchedLotPnl)}`,
+      );
+      console.log(
+        `  setup_groups: ${before.setupCount} -> ${after.setupCount} | realized_pnl: ${formatSigned(before.setupPnl)} -> ${formatSigned(after.setupPnl)}`,
+      );
+      console.log(
+        `  ledger: matched_persisted=${rebuilt.ledger.matchedLotsPersisted}, synthetic_persisted=${rebuilt.ledger.syntheticExecutionsPersisted}, warnings=${rebuilt.ledger.warnings.length}`,
+      );
+      console.log(
+        `  setups: persisted=${rebuilt.setups.setupGroupsPersisted}, uncategorized=${rebuilt.setups.uncategorizedCount}`,
+      );
+    }
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((error) => {
+  console.error("[rebuild:pnl] failed", error);
+  process.exit(1);
+});

--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Bar, BarChart, Cell, Pie, PieChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import { KpiCard } from "@/components/KpiCard";
 import { useAccountFilterContext } from "@/contexts/AccountFilterContext";
-import { formatCurrency, safeNumber } from "@/components/widgets/utils";
+import { formatCurrency, formatNullablePercent, safeNumber } from "@/components/widgets/utils";
 import type { DiagnosticsResponse, MatchedLotRecord, SetupSummaryRecord } from "@/types/api";
 
 const SHOW_ALL_KEY = "kapman_table_setups_showAll";
@@ -139,7 +139,7 @@ export default function Page() {
 
     return {
       totalPnl,
-      winRate: wins + losses === 0 ? 0 : (wins / (wins + losses)) * 100,
+      winRate: wins + losses === 0 ? null : (wins / (wins + losses)) * 100,
       avgHold,
       pairAmbiguities: diagnostics?.setupInference.setupInferencePairAmbiguousTotal ?? 0,
       shortCallPaired: diagnostics?.setupInference.setupInferenceShortCallPairedTotal ?? 0,
@@ -214,7 +214,7 @@ export default function Page() {
     <section className="space-y-5">
       <div className="grid gap-3 md:grid-cols-3 xl:grid-cols-6">
         <KpiCard label="Total P&L" value={formatCurrency(kpis.totalPnl)} colorVariant={kpis.totalPnl >= 0 ? "pos" : "neg"} />
-        <KpiCard label="Win Rate" value={kpis.winRate.toFixed(1) + "%"} colorVariant="accent" />
+        <KpiCard label="Win Rate (%)" value={formatNullablePercent(kpis.winRate, 1)} colorVariant="accent" />
         <KpiCard label="Avg Hold" value={kpis.avgHold.toFixed(2) + "d"} colorVariant="accent" />
         <KpiCard label="Pair Ambiguities" value={kpis.pairAmbiguities} colorVariant="neutral" />
         <KpiCard label="Short Call Paired" value={kpis.shortCallPaired} colorVariant="neutral" />
@@ -271,13 +271,17 @@ export default function Page() {
                   <button type="button" onClick={() => toggleSort("underlyingSymbol")}>Underlying</button>
                 </th>
                 <th className="px-2 py-2 text-right">
-                  <button type="button" onClick={() => toggleSort("realizedPnl")}>Realized P&L</button>
+                  <button type="button" onClick={() => toggleSort("realizedPnl")}>Realized P&L ($)</button>
                 </th>
                 <th className="px-2 py-2 text-right">
-                  <button type="button" onClick={() => toggleSort("winRate")}>Win Rate</button>
+                  <button type="button" onClick={() => toggleSort("winRate")} title="Percent of closed lots with positive outcome. Flat lots excluded.">
+                    Win Rate (%)
+                  </button>
                 </th>
                 <th className="px-2 py-2 text-right">
-                  <button type="button" onClick={() => toggleSort("expectancy")}>Expectancy</button>
+                  <button type="button" onClick={() => toggleSort("expectancy")} title="Average realized P&L per matched lot in this setup.">
+                    Expectancy ($ / lot)
+                  </button>
                 </th>
                 <th className="px-2 py-2 text-right">
                   <button type="button" onClick={() => toggleSort("averageHoldDays")}>Avg Hold</button>
@@ -290,8 +294,8 @@ export default function Page() {
                   <td className="px-2 py-2">{row.overrideTag ?? row.tag}</td>
                   <td className="px-2 py-2">{row.underlyingSymbol}</td>
                   <td className="px-2 py-2 text-right">{formatCurrency(safeNumber(row.realizedPnl))}</td>
-                  <td className="px-2 py-2 text-right">{safeNumber(row.winRate).toFixed(2)}</td>
-                  <td className="px-2 py-2 text-right">{safeNumber(row.expectancy).toFixed(2)}</td>
+                  <td className="px-2 py-2 text-right">{formatNullablePercent(row.winRate === null ? null : safeNumber(row.winRate) * 100, 1)}</td>
+                  <td className="px-2 py-2 text-right">{formatCurrency(safeNumber(row.expectancy)) + " / lot"}</td>
                   <td className="px-2 py-2 text-right">{safeNumber(row.averageHoldDays).toFixed(2)}</td>
                 </tr>
               ))}

--- a/src/components/executions-table-panel.tsx
+++ b/src/components/executions-table-panel.tsx
@@ -344,8 +344,13 @@ export function ExecutionsTablePanel() {
                     </button>
                   </th>
                   <th className="px-2 py-2 text-right">
-                    <button type="button" onClick={() => toggleSort("price")} className="font-medium">
-                      Price
+                    <button
+                      type="button"
+                      onClick={() => toggleSort("price")}
+                      className="font-medium"
+                      title="Execution price per share (equity) or per contract share (option). Multiply options by 100 for dollar value."
+                    >
+                      Unit Price
                     </button>
                   </th>
                   <th className="px-2 py-2 text-left">Event</th>

--- a/src/components/matched-lots-table-panel.tsx
+++ b/src/components/matched-lots-table-panel.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { Badge } from "@/components/Badge";
 import { LoadingSkeleton } from "@/components/loading-skeleton";
+import { formatCurrency, safeNumber } from "@/components/widgets/utils";
 import type { ImportRecord, MatchedLotRecord } from "@/types/api";
 
 interface MatchedLotsPayload {
@@ -319,7 +320,7 @@ export function MatchedLotsTablePanel() {
                   <th className="px-2 py-2 text-right">Qty</th>
                   <th className="px-2 py-2 text-right">
                     <button type="button" onClick={() => toggleSort("realizedPnl")} className="font-medium">
-                      Realized P&L
+                      Realized P&L ($)
                     </button>
                   </th>
                   <th className="px-2 py-2 text-right">
@@ -339,7 +340,7 @@ export function MatchedLotsTablePanel() {
                     <td className="px-2 py-2">{row.symbol}</td>
                     <td className="px-2 py-2 text-right">{row.quantity}</td>
                     <td className={`px-2 py-2 text-right ${Number(row.realizedPnl) >= 0 ? "text-emerald-300" : "text-red-300"}`}>
-                      {row.realizedPnl}
+                      {formatCurrency(safeNumber(row.realizedPnl))}
                     </td>
                     <td className="px-2 py-2 text-right">{row.holdingDays}</td>
                     <td className="px-2 py-2">

--- a/src/components/setups-analytics-panel.tsx
+++ b/src/components/setups-analytics-panel.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { LoadingSkeleton } from "@/components/loading-skeleton";
+import { formatCurrency, formatNullablePercent, safeNumber } from "@/components/widgets/utils";
 import type { ImportRecord, SetupDetailResponse, SetupSummaryRecord } from "@/types/api";
 
 interface SetupsPayload {
@@ -61,6 +62,7 @@ export function SetupsAnalyticsPanel() {
   const searchParams = useSearchParams();
   const [imports, setImports] = useState<ImportRecord[]>([]);
   const [rows, setRows] = useState<SetupSummaryRecord[]>([]);
+  const [summaryRows, setSummaryRows] = useState<SetupSummaryRecord[]>([]);
   const [meta, setMeta] = useState({ total: 0, page: 1, pageSize: 25 });
   const [page, setPage] = useState(1);
   const [showAll, setShowAll] = useState(false);
@@ -136,6 +138,32 @@ export function SetupsAnalyticsPanel() {
   }, [appliedFilters, page, showAll]);
 
   useEffect(() => {
+    async function loadSummaryRows() {
+      const query = new URLSearchParams({
+        page: "1",
+        pageSize: "1000",
+      });
+
+      if (appliedFilters.account.trim()) {
+        query.set("account", appliedFilters.account.trim());
+      }
+      if (appliedFilters.tag.trim()) {
+        query.set("tag", appliedFilters.tag.trim());
+      }
+
+      const response = await fetch(`/api/setups?${query.toString()}`, { cache: "no-store" });
+      if (!response.ok) {
+        return;
+      }
+
+      const payload = (await response.json()) as SetupsPayload;
+      setSummaryRows(payload.data);
+    }
+
+    void loadSummaryRows();
+  }, [appliedFilters]);
+
+  useEffect(() => {
     async function loadSetupDetail() {
       if (!selectedSetupId) {
         setDetail(null);
@@ -173,27 +201,35 @@ export function SetupsAnalyticsPanel() {
   }, [imports]);
 
   const summary = useMemo(() => {
-    if (rows.length === 0) {
+    if (summaryRows.length === 0) {
       return {
-        totalPnl: "0.00",
-        averageWinRate: "0.00",
-        averageExpectancy: "0.00",
-        averageHoldDays: "0.00",
+        totalPnl: 0,
+        averageWinRate: null as number | null,
+        averageExpectancy: 0,
+        averageHoldDays: 0,
       };
     }
 
-    const totalPnl = rows.reduce((sum, row) => sum + Number(row.realizedPnl ?? 0), 0);
-    const averageWinRate = rows.reduce((sum, row) => sum + Number(row.winRate ?? 0), 0) / rows.length;
-    const averageExpectancy = rows.reduce((sum, row) => sum + Number(row.expectancy ?? 0), 0) / rows.length;
-    const averageHoldDays = rows.reduce((sum, row) => sum + Number(row.averageHoldDays ?? 0), 0) / rows.length;
+    const totalPnl = summaryRows.reduce((sum, row) => sum + safeNumber(row.realizedPnl), 0);
+
+    const winRates = summaryRows
+      .map((row) => (row.winRate === null ? null : safeNumber(row.winRate)))
+      .filter((value): value is number => value !== null);
+    const averageWinRateRatio = winRates.length > 0 ? winRates.reduce((sum, value) => sum + value, 0) / winRates.length : null;
+
+    const expectancies = summaryRows.map((row) => safeNumber(row.expectancy));
+    const averageExpectancy = expectancies.length > 0 ? expectancies.reduce((sum, value) => sum + value, 0) / expectancies.length : 0;
+
+    const holdDays = summaryRows.map((row) => safeNumber(row.averageHoldDays));
+    const averageHoldDays = holdDays.length > 0 ? holdDays.reduce((sum, value) => sum + value, 0) / holdDays.length : 0;
 
     return {
-      totalPnl: totalPnl.toFixed(2),
-      averageWinRate: averageWinRate.toFixed(2),
-      averageExpectancy: averageExpectancy.toFixed(2),
-      averageHoldDays: averageHoldDays.toFixed(2),
+      totalPnl,
+      averageWinRate: averageWinRateRatio === null ? null : averageWinRateRatio * 100,
+      averageExpectancy,
+      averageHoldDays,
     };
-  }, [rows]);
+  }, [summaryRows]);
 
   const hasRows = rows.length > 0;
   const canGoBack = meta.page > 1;
@@ -230,20 +266,24 @@ export function SetupsAnalyticsPanel() {
 
       <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
         <div className="rounded-lg border border-slate-700 bg-slate-950/50 p-3">
-          <p className="text-xs text-slate-400">Performance Summary</p>
-          <p className={`text-lg font-semibold ${Number(summary.totalPnl) >= 0 ? "text-emerald-300" : "text-red-300"}`}>{summary.totalPnl}</p>
+          <p className="text-xs text-slate-400">Performance Summary ($)</p>
+          <p className={`text-lg font-semibold ${summary.totalPnl >= 0 ? "text-emerald-300" : "text-red-300"}`}>{formatCurrency(summary.totalPnl)}</p>
         </div>
         <div className="rounded-lg border border-slate-700 bg-slate-950/50 p-3">
-          <p className="text-xs text-slate-400">Win Rate</p>
-          <p className="text-lg font-semibold text-slate-100">{summary.averageWinRate}</p>
+          <p className="text-xs text-slate-400" title="Percent of closed lots with positive outcome. Flat lots excluded.">
+            Win Rate (%)
+          </p>
+          <p className="text-lg font-semibold text-slate-100">{formatNullablePercent(summary.averageWinRate, 1)}</p>
         </div>
         <div className="rounded-lg border border-slate-700 bg-slate-950/50 p-3">
-          <p className="text-xs text-slate-400">Expectancy</p>
-          <p className="text-lg font-semibold text-slate-100">{summary.averageExpectancy}</p>
+          <p className="text-xs text-slate-400" title="Average realized P&L per matched lot in this setup.">
+            Expectancy ($ / lot)
+          </p>
+          <p className="text-lg font-semibold text-slate-100">{formatCurrency(summary.averageExpectancy)} / lot</p>
         </div>
         <div className="rounded-lg border border-slate-700 bg-slate-950/50 p-3">
           <p className="text-xs text-slate-400">Average Hold (Days)</p>
-          <p className="text-lg font-semibold text-slate-100">{summary.averageHoldDays}</p>
+          <p className="text-lg font-semibold text-slate-100">{summary.averageHoldDays.toFixed(2)}</p>
         </div>
       </div>
 
@@ -319,9 +359,16 @@ export function SetupsAnalyticsPanel() {
                 <tr>
                   <th className="px-2 py-2 text-left">Tag</th>
                   <th className="px-2 py-2 text-left">Underlying</th>
-                  <th className="px-2 py-2 text-right">Realized P&L</th>
-                  <th className="px-2 py-2 text-right">Win Rate</th>
-                  <th className="px-2 py-2 text-right">Expectancy</th>
+                  <th className="px-2 py-2 text-right">Realized P&L ($)</th>
+                  <th
+                    className="px-2 py-2 text-right"
+                    title="Percent of closed lots with positive outcome. Flat lots excluded."
+                  >
+                    Win Rate (%)
+                  </th>
+                  <th className="px-2 py-2 text-right" title="Average realized P&L per matched lot in this setup.">
+                    Expectancy ($ / lot)
+                  </th>
                   <th className="px-2 py-2 text-right">Avg Hold</th>
                   <th className="px-2 py-2 text-left">Detail</th>
                 </tr>
@@ -331,12 +378,12 @@ export function SetupsAnalyticsPanel() {
                   <tr key={row.id} className="border-t border-slate-800 text-slate-200">
                     <td className="px-2 py-2">{row.overrideTag ?? row.tag}</td>
                     <td className="px-2 py-2">{row.underlyingSymbol}</td>
-                    <td className={`px-2 py-2 text-right ${Number(row.realizedPnl ?? 0) >= 0 ? "text-emerald-300" : "text-red-300"}`}>
-                      {row.realizedPnl ?? "0.00"}
+                    <td className={`px-2 py-2 text-right ${safeNumber(row.realizedPnl) >= 0 ? "text-emerald-300" : "text-red-300"}`}>
+                      {formatCurrency(safeNumber(row.realizedPnl))}
                     </td>
-                    <td className="px-2 py-2 text-right">{row.winRate ?? "0.00"}</td>
-                    <td className="px-2 py-2 text-right">{row.expectancy ?? "0.00"}</td>
-                    <td className="px-2 py-2 text-right">{row.averageHoldDays ?? "0.00"}</td>
+                    <td className="px-2 py-2 text-right">{formatNullablePercent(row.winRate === null ? null : safeNumber(row.winRate) * 100, 1)}</td>
+                    <td className="px-2 py-2 text-right">{`${formatCurrency(safeNumber(row.expectancy))} / lot`}</td>
+                    <td className="px-2 py-2 text-right">{safeNumber(row.averageHoldDays).toFixed(2)}</td>
                     <td className="px-2 py-2">
                       <Link href={`${pathname}?setup=${row.id}#setup-detail`} className="text-blue-300 underline">
                         View detail
@@ -411,7 +458,7 @@ export function SetupsAnalyticsPanel() {
                     <tr>
                       <th className="px-2 py-2 text-left">Symbol</th>
                       <th className="px-2 py-2 text-right">Qty</th>
-                      <th className="px-2 py-2 text-right">Realized P&L</th>
+                      <th className="px-2 py-2 text-right">Realized P&L ($)</th>
                       <th className="px-2 py-2 text-right">Hold Days</th>
                       <th className="px-2 py-2 text-left">Outcome</th>
                       <th className="px-2 py-2 text-left">Open Execution</th>
@@ -423,8 +470,8 @@ export function SetupsAnalyticsPanel() {
                       <tr key={lot.id} className="border-t border-slate-800 text-slate-200">
                         <td className="px-2 py-2">{lot.symbol}</td>
                         <td className="px-2 py-2 text-right">{lot.quantity}</td>
-                        <td className={`px-2 py-2 text-right ${Number(lot.realizedPnl) >= 0 ? "text-emerald-300" : "text-red-300"}`}>
-                          {lot.realizedPnl}
+                        <td className={`px-2 py-2 text-right ${safeNumber(lot.realizedPnl) >= 0 ? "text-emerald-300" : "text-red-300"}`}>
+                          {formatCurrency(safeNumber(lot.realizedPnl))}
                         </td>
                         <td className="px-2 py-2 text-right">{lot.holdingDays}</td>
                         <td className="px-2 py-2">{lot.outcome}</td>

--- a/src/components/tts-evidence-panel.tsx
+++ b/src/components/tts-evidence-panel.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { LoadingSkeleton } from "@/components/loading-skeleton";
+import { formatCompactCurrency, safeNumber } from "@/components/widgets/utils";
 import type { TtsEvidenceResponse } from "@/types/api";
 
 interface TtsPayload {
@@ -81,8 +82,13 @@ export function TtsEvidencePanel() {
               <p className="text-lg font-semibold text-slate-100">{data.medianHoldingPeriodDays}</p>
             </div>
             <div className="rounded-lg border border-slate-700 bg-slate-950/50 p-3">
-              <p className="text-xs text-slate-400">Gross Proceeds Proxy</p>
-              <p className="text-lg font-semibold text-slate-100">{data.grossProceedsProxy}</p>
+              <p
+                className="text-xs text-slate-400"
+                title="Approximate trading notional — premium × contracts for options (excludes ×100 notional multiplier). Used as a trading-activity scale signal, not a tax determination."
+              >
+                Gross Proceeds Proxy
+              </p>
+              <p className="text-lg font-semibold text-slate-100">{formatCompactCurrency(safeNumber(data.grossProceedsProxy))}</p>
             </div>
           </div>
 

--- a/src/components/widgets/ExpectancyScatterWidget.tsx
+++ b/src/components/widgets/ExpectancyScatterWidget.tsx
@@ -71,15 +71,15 @@ export function ExpectancyScatterWidget() {
       <div className="h-56">
         <ResponsiveContainer width="100%" height="100%">
           <ScatterChart>
-            <XAxis dataKey="x" name="Average Hold" tick={{ fill: "var(--muted)", fontSize: 10 }} />
-            <YAxis dataKey="y" name="Expectancy" tick={{ fill: "var(--muted)", fontSize: 10 }} />
+            <XAxis dataKey="x" name="Average Hold (days)" tick={{ fill: "var(--muted)", fontSize: 10 }} />
+            <YAxis dataKey="y" name="Expectancy ($ / lot)" tick={{ fill: "var(--muted)", fontSize: 10 }} />
             <ZAxis dataKey="z" range={[40, 260]} />
             <Tooltip
               cursor={{ strokeDasharray: "3 3" }}
               contentStyle={{ background: "var(--panel-2)", borderColor: "var(--border)", color: "var(--text)" }}
               formatter={(_value, _name, item) => {
                 const row = item.payload.row as SetupSummaryRecord;
-                return [formatCurrency(safeNumber(row.realizedPnl)), row.overrideTag ?? row.tag];
+                return [`${formatCurrency(safeNumber(row.expectancy))} / lot`, `Expectancy · ${row.overrideTag ?? row.tag}`];
               }}
             />
             {Array.from(grouped.entries()).map(([tag, points]) => (

--- a/src/components/widgets/WinLossFlatWidget.tsx
+++ b/src/components/widgets/WinLossFlatWidget.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
 import { WidgetCard } from "@/components/widgets/WidgetCard";
 import { useAccountFilterContext } from "@/contexts/AccountFilterContext";
+import { formatNullablePercent } from "@/components/widgets/utils";
 import type { MatchedLotRecord } from "@/types/api";
 
 interface MatchedLotsPayload {
@@ -61,7 +62,7 @@ export function WinLossFlatWidget() {
     { name: "FLAT", value: counts.FLAT, color: "var(--muted)" },
   ];
 
-  const winRate = counts.WIN + counts.LOSS === 0 ? 0 : (counts.WIN / (counts.WIN + counts.LOSS)) * 100;
+  const winRate = counts.WIN + counts.LOSS === 0 ? null : (counts.WIN / (counts.WIN + counts.LOSS)) * 100;
 
   return (
     <WidgetCard title="Win / Loss / Flat">
@@ -79,7 +80,9 @@ export function WinLossFlatWidget() {
           </ResponsiveContainer>
         </div>
         <div className="space-y-1 text-xs text-muted">
-          <p className="text-base font-semibold text-text">Win rate: {winRate.toFixed(1)}%</p>
+          <p className="text-base font-semibold text-text" title="Percent of closed lots with positive outcome. Flat lots excluded.">
+            Win Rate (%): {formatNullablePercent(winRate, 1)}
+          </p>
           {chartData.map((entry) => (
             <p key={entry.name}>
               {entry.name}: {entry.value}

--- a/src/components/widgets/utils.ts
+++ b/src/components/widgets/utils.ts
@@ -15,3 +15,15 @@ export function safeNumber(value: string | number | null | undefined): number {
   const parsed = Number(value ?? 0);
   return Number.isFinite(parsed) ? parsed : 0;
 }
+
+export function formatPercent(value: number, digits = 1): string {
+  return `${value.toFixed(digits)}%`;
+}
+
+export function formatNullablePercent(value: number | null, digits = 1): string {
+  if (value === null || !Number.isFinite(value)) {
+    return "N/A";
+  }
+
+  return formatPercent(value, digits);
+}

--- a/src/lib/analytics/rebuild-account-setups.ts
+++ b/src/lib/analytics/rebuild-account-setups.ts
@@ -39,18 +39,54 @@ export async function rebuildAccountSetups(
   }));
 
   const inferred = inferSetupGroups(inferenceLots);
+  const lotMetricsById = new Map(
+    inferenceLots.map((lot) => [
+      lot.id,
+      {
+        realizedPnl: lot.realizedPnl,
+        holdingDays: lot.holdingDays,
+      },
+    ]),
+  );
 
   for (const group of inferred.groups) {
+    const groupMetrics = group.lotIds.reduce(
+      (acc, lotId) => {
+        const lot = lotMetricsById.get(lotId);
+        if (!lot) {
+          return acc;
+        }
+
+        acc.realizedPnl += lot.realizedPnl;
+        acc.holdingDays += lot.holdingDays;
+        acc.lotCount += 1;
+
+        if (lot.realizedPnl > 0) {
+          acc.wins += 1;
+        } else if (lot.realizedPnl < 0) {
+          acc.losses += 1;
+        }
+
+        return acc;
+      },
+      { realizedPnl: 0, holdingDays: 0, lotCount: 0, wins: 0, losses: 0 },
+    );
+
+    const denominator = groupMetrics.wins + groupMetrics.losses;
+    const winRate = denominator > 0 ? groupMetrics.wins / denominator : null;
+    const expectancy = groupMetrics.lotCount > 0 ? groupMetrics.realizedPnl / groupMetrics.lotCount : null;
+    const averageHoldDays = groupMetrics.lotCount > 0 ? groupMetrics.holdingDays / groupMetrics.lotCount : null;
+
     const created = await tx.setupGroup.create({
       data: {
         accountId,
         tag: group.tag,
         overrideTag: null,
         underlyingSymbol: group.underlyingSymbol,
-        realizedPnl: group.realizedPnl,
-        winRate: group.winRate,
-        expectancy: group.expectancy,
-        averageHoldDays: group.averageHoldDays,
+        realizedPnl: groupMetrics.realizedPnl,
+        winRate,
+        expectancy,
+        averageHoldDays,
       },
     });
 

--- a/src/lib/ledger/fifo-matcher-pnl-normalization.test.ts
+++ b/src/lib/ledger/fifo-matcher-pnl-normalization.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+import { runFifoMatcher, type LedgerExecution } from "./fifo-matcher";
+
+function date(value: string): Date {
+  return new Date(value);
+}
+
+function makeExecution(overrides: Partial<LedgerExecution>): LedgerExecution {
+  const base: LedgerExecution = {
+    id: "exec-base",
+    importId: "import-1",
+    accountId: "account-1",
+    broker: "SCHWAB_THINKORSWIM",
+    eventTimestamp: date("2026-01-01T14:30:00.000Z"),
+    tradeDate: date("2026-01-01T00:00:00.000Z"),
+    eventType: "TRADE",
+    assetClass: "OPTION",
+    symbol: "SPY",
+    instrumentKey: "SPY|CALL|500|2026-03-20",
+    side: "BUY",
+    quantity: 1,
+    price: 1,
+    openingClosingEffect: "TO_OPEN",
+    expirationDate: date("2026-03-20T00:00:00.000Z"),
+    optionType: "CALL",
+    strike: 500,
+  };
+
+  return { ...base, ...overrides };
+}
+
+describe("runFifoMatcher P&L normalization", () => {
+  it("applies 100x multiplier for long option realized P&L", () => {
+    const open = makeExecution({
+      id: "opt-long-open",
+      side: "BUY",
+      quantity: 5,
+      price: 1,
+      openingClosingEffect: "TO_OPEN",
+    });
+    const close = makeExecution({
+      id: "opt-long-close",
+      eventTimestamp: date("2026-01-05T14:30:00.000Z"),
+      tradeDate: date("2026-01-05T00:00:00.000Z"),
+      side: "SELL",
+      quantity: 5,
+      price: 2.5,
+      openingClosingEffect: "TO_CLOSE",
+    });
+
+    const result = runFifoMatcher([open, close], date("2026-02-01T00:00:00.000Z"));
+    expect(result.matchedLots).toHaveLength(1);
+    expect(result.matchedLots[0]?.realizedPnl).toBe(750);
+  });
+
+  it("applies 100x multiplier for short option realized P&L", () => {
+    const open = makeExecution({
+      id: "opt-short-open",
+      side: "SELL",
+      quantity: 3,
+      price: 3,
+      openingClosingEffect: "TO_OPEN",
+    });
+    const close = makeExecution({
+      id: "opt-short-close",
+      eventTimestamp: date("2026-01-05T14:30:00.000Z"),
+      tradeDate: date("2026-01-05T00:00:00.000Z"),
+      side: "BUY",
+      quantity: 3,
+      price: 1.5,
+      openingClosingEffect: "TO_CLOSE",
+    });
+
+    const result = runFifoMatcher([open, close], date("2026-02-01T00:00:00.000Z"));
+    expect(result.matchedLots).toHaveLength(1);
+    expect(result.matchedLots[0]?.realizedPnl).toBe(450);
+  });
+
+  it("does not apply multiplier for equity realized P&L", () => {
+    const open = makeExecution({
+      id: "eq-open",
+      assetClass: "EQUITY",
+      symbol: "AAPL",
+      instrumentKey: "AAPL",
+      optionType: null,
+      strike: null,
+      expirationDate: null,
+      side: "BUY",
+      quantity: 100,
+      price: 79,
+      openingClosingEffect: "TO_OPEN",
+    });
+    const close = makeExecution({
+      id: "eq-close",
+      assetClass: "EQUITY",
+      symbol: "AAPL",
+      instrumentKey: "AAPL",
+      optionType: null,
+      strike: null,
+      expirationDate: null,
+      eventTimestamp: date("2026-01-05T14:30:00.000Z"),
+      tradeDate: date("2026-01-05T00:00:00.000Z"),
+      side: "SELL",
+      quantity: 100,
+      price: 82,
+      openingClosingEffect: "TO_CLOSE",
+    });
+
+    const result = runFifoMatcher([open, close], date("2026-02-01T00:00:00.000Z"));
+    expect(result.matchedLots).toHaveLength(1);
+    expect(result.matchedLots[0]?.realizedPnl).toBe(300);
+  });
+
+  it("applies multiplier to synthetic expiration closes for long options", () => {
+    const open = makeExecution({
+      id: "opt-exp-long-open",
+      side: "BUY",
+      quantity: 4,
+      price: 1.5,
+      openingClosingEffect: "TO_OPEN",
+      expirationDate: date("2026-01-17T00:00:00.000Z"),
+      instrumentKey: "SPY|CALL|500|2026-01-17",
+    });
+
+    const result = runFifoMatcher([open], date("2026-01-25T00:00:00.000Z"));
+    expect(result.matchedLots).toHaveLength(1);
+    expect(result.matchedLots[0]?.realizedPnl).toBe(-600);
+  });
+
+  it("applies multiplier to synthetic expiration closes for short options", () => {
+    const open = makeExecution({
+      id: "opt-exp-short-open",
+      side: "SELL",
+      quantity: 2,
+      price: 1.5,
+      openingClosingEffect: "TO_OPEN",
+      expirationDate: date("2026-01-17T00:00:00.000Z"),
+      instrumentKey: "SPY|PUT|400|2026-01-17",
+      optionType: "PUT",
+      strike: 400,
+    });
+
+    const result = runFifoMatcher([open], date("2026-01-25T00:00:00.000Z"));
+    expect(result.matchedLots).toHaveLength(1);
+    expect(result.matchedLots[0]?.realizedPnl).toBe(300);
+  });
+
+  it("applies multiplier when assignment uses strike as effective close price", () => {
+    const open = makeExecution({
+      id: "opt-assignment-open",
+      side: "SELL",
+      quantity: 1,
+      price: 2,
+      strike: 100,
+      openingClosingEffect: "TO_OPEN",
+      instrumentKey: "XYZ|CALL|100|2026-03-20",
+      symbol: "XYZ",
+    });
+    const close = makeExecution({
+      id: "opt-assignment-close",
+      eventTimestamp: date("2026-01-05T16:00:00.000Z"),
+      tradeDate: date("2026-01-05T00:00:00.000Z"),
+      eventType: "ASSIGNMENT",
+      side: "BUY",
+      quantity: 1,
+      price: null,
+      strike: 100,
+      openingClosingEffect: "TO_CLOSE",
+      instrumentKey: "XYZ|CALL|100|2026-03-20",
+      symbol: "XYZ",
+    });
+
+    const result = runFifoMatcher([open, close], date("2026-02-01T00:00:00.000Z"));
+    expect(result.matchedLots).toHaveLength(1);
+    expect(result.matchedLots[0]?.realizedPnl).toBe(-9800);
+  });
+});

--- a/src/lib/ledger/fifo-matcher.test.ts
+++ b/src/lib/ledger/fifo-matcher.test.ts
@@ -153,7 +153,7 @@ describe("runFifoMatcher", () => {
     const result = runFifoMatcher([openShort, closeShort], date("2026-02-01T00:00:00.000Z"));
 
     expect(result.matchedLots).toHaveLength(1);
-    expect(result.matchedLots[0]?.realizedPnl).toBe(4);
+    expect(result.matchedLots[0]?.realizedPnl).toBe(400);
     expect(result.matchedLots[0]?.outcome).toBe("WIN");
   });
 
@@ -174,7 +174,7 @@ describe("runFifoMatcher", () => {
     expect(result.syntheticExecutions[0]?.eventType).toBe("EXPIRATION_INFERRED");
     expect(result.syntheticExecutions[0]?.price).toBe(0);
     expect(result.matchedLots).toHaveLength(1);
-    expect(result.matchedLots[0]?.realizedPnl).toBe(-2);
+    expect(result.matchedLots[0]?.realizedPnl).toBe(-200);
     expect(result.warnings.some((warning) => warning.code === "SYNTHETIC_EXPIRATION_INFERRED")).toBe(true);
   });
 
@@ -205,7 +205,7 @@ describe("runFifoMatcher", () => {
     const result = runFifoMatcher([openShort, assignmentClose], date("2026-02-01T00:00:00.000Z"));
 
     expect(result.matchedLots).toHaveLength(1);
-    expect(result.matchedLots[0]?.realizedPnl).toBe(-98);
+    expect(result.matchedLots[0]?.realizedPnl).toBe(-9800);
   });
 
   it("matches multiple opens to one close in FIFO order", () => {

--- a/src/lib/ledger/fifo-matcher.ts
+++ b/src/lib/ledger/fifo-matcher.ts
@@ -72,13 +72,14 @@ interface OpenLot {
 function computePnl(open: LedgerExecution, close: { side: "BUY" | "SELL"; price: number | null }, quantity: number): number {
   const openPrice = open.price ?? 0;
   const closePrice = close.price ?? 0;
+  const multiplier = open.assetClass === "OPTION" ? 100 : 1;
 
   if (open.side === "BUY" && close.side === "SELL") {
-    return (closePrice - openPrice) * quantity;
+    return (closePrice - openPrice) * quantity * multiplier;
   }
 
   if (open.side === "SELL" && close.side === "BUY") {
-    return (openPrice - closePrice) * quantity;
+    return (openPrice - closePrice) * quantity * multiplier;
   }
 
   return 0;


### PR DESCRIPTION
## Summary
- Fix FIFO realized P&L normalization by applying the options contract multiplier (`×100`) when writing matched-lot realized P&L.
- Add a rebuild workflow (`npm run rebuild:pnl`) to regenerate matched lots and setup aggregates from existing executions, with before/after per-account summary output.
- Standardize win-rate semantics for persisted setup aggregates to `WIN / (WIN + LOSS)` (flat excluded, `null` when denominator is zero).
- Make T3 summary cards in `SetupsAnalyticsPanel` compute from the full filtered dataset so values are stable between paginated/show-all modes.
- Normalize T1/T2/T3 labels/units and formatting (currency, percent, expectancy units), plus TTS gross-proceeds proxy display tooltip/format improvements.
- Add `docs/kapman_build_spec_v7_2.md` documenting manual override capabilities and this v7.2 fix package.

## Issue
Closes #47

## Validation
- `npm run test -- src/lib/ledger/fifo-matcher-pnl-normalization.test.ts`
- `npm run test`
- `npm run typecheck`
- `npm run lint`
- `npm run rebuild:pnl`
