### PR TITLE
KM-146 Rebuild Ledger button and warning refresh

### DIFF
--- a/src/app/adjustments/page.tsx
+++ b/src/app/adjustments/page.tsx
@@ -4,7 +4,8 @@ import { useEffect, useState } from "react";
 import { AdjustmentForm } from "@/components/adjustments/adjustment-form";
 import { AdjustmentList } from "@/components/adjustments/adjustment-list";
 import { AdjustmentPreview } from "@/components/adjustments/adjustment-preview";
-import type { AdjustmentPreviewResponse, ManualAdjustmentRecord } from "@/types/api";
+import { useAccountFilterContext } from "@/contexts/AccountFilterContext";
+import type { AccountLedgerRebuildApiResponse, AdjustmentPreviewResponse, ApiErrorResponse, ManualAdjustmentRecord } from "@/types/api";
 
 interface AdjustmentListPayload {
   data: ManualAdjustmentRecord[];
@@ -16,11 +17,16 @@ interface AdjustmentListPayload {
 }
 
 export default function Page() {
+  const { selectedAccounts } = useAccountFilterContext();
   const [adjustments, setAdjustments] = useState<ManualAdjustmentRecord[]>([]);
   const [preview, setPreview] = useState<AdjustmentPreviewResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [reversingId, setReversingId] = useState<string | null>(null);
+  const [rebuildMessage, setRebuildMessage] = useState<string | null>(null);
+  const [rebuilding, setRebuilding] = useState(false);
+
+  const activeAccountId = selectedAccounts.length === 1 ? selectedAccounts[0] : null;
 
   async function loadAdjustments() {
     setLoading(true);
@@ -47,6 +53,7 @@ export default function Page() {
   async function handleReverse(adjustmentId: string) {
     setReversingId(adjustmentId);
     setError(null);
+    setRebuildMessage(null);
     try {
       const response = await fetch(`/api/adjustments/${adjustmentId}/reverse`, { method: "POST" });
       const payload = await response.json();
@@ -61,16 +68,63 @@ export default function Page() {
     }
   }
 
+  async function handleRebuildLedger() {
+    if (!activeAccountId) {
+      setError("Select a single account to rebuild.");
+      setRebuildMessage(null);
+      return;
+    }
+
+    setRebuilding(true);
+    setError(null);
+    setRebuildMessage(null);
+    try {
+      const response = await fetch(`/api/accounts/${activeAccountId}/rebuild-ledger`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+      const payload = (await response.json()) as AccountLedgerRebuildApiResponse;
+      if (!response.ok || !("data" in payload)) {
+        const errorPayload = payload as ApiErrorResponse;
+        throw new Error(errorPayload.error?.message ?? "Ledger rebuild failed.");
+      }
+
+      setRebuildMessage(
+        `Rebuild complete - ${payload.data.matchedLotsPersisted} matched lots, ${payload.data.warningsCleared} warnings cleared.`,
+      );
+    } catch (rebuildError) {
+      setError(rebuildError instanceof Error ? rebuildError.message : "Ledger rebuild failed.");
+    } finally {
+      setRebuilding(false);
+    }
+  }
+
   return (
     <section className="space-y-4">
       <header className="rounded-xl border border-border bg-panel p-4">
-        <p className="text-sm font-semibold text-text">Manual Adjustments</p>
-        <p className="mt-1 text-xs text-muted">
-          Add auditable reconciliation overlays for corporate actions and exceptional corrections without mutating raw executions.
-        </p>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <p className="text-sm font-semibold text-text">Manual Adjustments</p>
+            <p className="mt-1 text-xs text-muted">
+              Add auditable reconciliation overlays for corporate actions and exceptional corrections without mutating raw executions.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => void handleRebuildLedger()}
+            disabled={!activeAccountId || rebuilding}
+            title={!activeAccountId ? "Select a single account to rebuild." : undefined}
+            className="rounded border border-border bg-panel-2 px-3 py-2 text-xs font-medium text-text disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {rebuilding ? "Rebuilding..." : "Rebuild Ledger"}
+          </button>
+        </div>
       </header>
 
       {error ? <p className="rounded border border-red-400/60 bg-red-400/10 px-3 py-2 text-xs text-red-200">{error}</p> : null}
+      {rebuildMessage ? <p className="rounded border border-accent/40 bg-accent/10 px-3 py-2 text-xs text-accent">{rebuildMessage}</p> : null}
 
       <div className="grid gap-4 lg:grid-cols-2">
         <AdjustmentForm

--- a/src/app/api/accounts/[id]/rebuild-ledger/route.test.ts
+++ b/src/app/api/accounts/[id]/rebuild-ledger/route.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const rebuildLedgerRouteMocks = vi.hoisted(() => {
+  const tx = {};
+
+  return {
+    prisma: {
+      account: {
+        findFirst: vi.fn(),
+      },
+      $transaction: vi.fn(),
+    },
+    tx,
+    rebuildAccountLedger: vi.fn(),
+    rebuildAccountSetups: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/db/prisma", () => {
+  return {
+    prisma: rebuildLedgerRouteMocks.prisma,
+  };
+});
+
+vi.mock("@/lib/ledger/rebuild-account-ledger", () => {
+  return {
+    rebuildAccountLedger: rebuildLedgerRouteMocks.rebuildAccountLedger,
+  };
+});
+
+vi.mock("@/lib/analytics/rebuild-account-setups", () => {
+  return {
+    rebuildAccountSetups: rebuildLedgerRouteMocks.rebuildAccountSetups,
+  };
+});
+
+describe("POST /api/accounts/[id]/rebuild-ledger", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    rebuildLedgerRouteMocks.prisma.$transaction.mockImplementation(async (callback: (tx: typeof rebuildLedgerRouteMocks.tx) => unknown) => {
+      return callback(rebuildLedgerRouteMocks.tx);
+    });
+  });
+
+  it("rebuilds one account and returns the summary payload", async () => {
+    rebuildLedgerRouteMocks.prisma.account.findFirst.mockResolvedValueOnce({
+      id: "acct-internal-1",
+      accountId: "D-68011053",
+    });
+    rebuildLedgerRouteMocks.rebuildAccountLedger.mockResolvedValueOnce({
+      matchedLotsPersisted: 263,
+      syntheticExecutionsPersisted: 2,
+      warningsCleared: 2,
+      warnings: [],
+    });
+    rebuildLedgerRouteMocks.rebuildAccountSetups.mockResolvedValueOnce({
+      setupGroupsPersisted: 17,
+      uncategorizedCount: 1,
+    });
+
+    const { POST } = await import("./route");
+    const response = await POST(new Request("http://localhost/api/accounts/acct-internal-1/rebuild-ledger", { method: "POST" }), {
+      params: { id: "acct-internal-1" },
+    });
+    const payload = (await response.json()) as {
+      data: {
+        matchedLotsPersisted: number;
+        syntheticExecutionsPersisted: number;
+        warningsCleared: number;
+        setupGroupsPersisted: number;
+      };
+    };
+
+    expect(rebuildLedgerRouteMocks.prisma.account.findFirst).toHaveBeenCalledWith({
+      where: {
+        OR: [{ id: "acct-internal-1" }, { accountId: "acct-internal-1" }],
+      },
+      select: {
+        id: true,
+        accountId: true,
+      },
+    });
+    expect(rebuildLedgerRouteMocks.rebuildAccountLedger).toHaveBeenCalledWith(
+      rebuildLedgerRouteMocks.tx,
+      "acct-internal-1",
+      expect.any(Date),
+    );
+    expect(rebuildLedgerRouteMocks.rebuildAccountSetups).toHaveBeenCalledWith(rebuildLedgerRouteMocks.tx, "acct-internal-1");
+    expect(payload.data).toEqual({
+      matchedLotsPersisted: 263,
+      syntheticExecutionsPersisted: 2,
+      warningsCleared: 2,
+      setupGroupsPersisted: 17,
+    });
+  });
+
+  it("returns 404 when the account is missing", async () => {
+    rebuildLedgerRouteMocks.prisma.account.findFirst.mockResolvedValueOnce(null);
+
+    const { POST } = await import("./route");
+    const response = await POST(new Request("http://localhost/api/accounts/missing/rebuild-ledger", { method: "POST" }), {
+      params: { id: "missing" },
+    });
+
+    expect(response.status).toBe(404);
+    expect(rebuildLedgerRouteMocks.prisma.$transaction).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/accounts/[id]/rebuild-ledger/route.ts
+++ b/src/app/api/accounts/[id]/rebuild-ledger/route.ts
@@ -1,0 +1,38 @@
+import { detailResponse, errorResponse } from "@/lib/api/responses";
+import { rebuildAccountSetups } from "@/lib/analytics/rebuild-account-setups";
+import { prisma } from "@/lib/db/prisma";
+import { rebuildAccountLedger } from "@/lib/ledger/rebuild-account-ledger";
+import type { AccountLedgerRebuildResponse } from "@/types/api";
+
+export async function POST(_request: Request, context: { params: { id: string } }) {
+  const accountParam = context.params.id;
+  const account = await prisma.account.findFirst({
+    where: {
+      OR: [{ id: accountParam }, { accountId: accountParam }],
+    },
+    select: {
+      id: true,
+      accountId: true,
+    },
+  });
+
+  if (!account) {
+    return errorResponse("ACCOUNT_NOT_FOUND", "Account not found.", [`No account exists for id ${accountParam}.`], 404);
+  }
+
+  const rebuiltAt = new Date();
+  const rebuilt = await prisma.$transaction(async (tx) => {
+    const ledger = await rebuildAccountLedger(tx, account.id, rebuiltAt);
+    const setups = await rebuildAccountSetups(tx, account.id);
+    return { ledger, setups };
+  });
+
+  const payload: AccountLedgerRebuildResponse = {
+    matchedLotsPersisted: rebuilt.ledger.matchedLotsPersisted,
+    syntheticExecutionsPersisted: rebuilt.ledger.syntheticExecutionsPersisted,
+    warningsCleared: rebuilt.ledger.warningsCleared,
+    setupGroupsPersisted: rebuilt.setups.setupGroupsPersisted,
+  };
+
+  return detailResponse(payload);
+}

--- a/src/lib/ledger/rebuild-account-ledger.test.ts
+++ b/src/lib/ledger/rebuild-account-ledger.test.ts
@@ -72,6 +72,10 @@ describe("rebuildAccountLedger execution qty overrides", () => {
       manualAdjustment: {
         findMany: vi.fn().mockResolvedValue([]),
       },
+      import: {
+        findMany: vi.fn().mockResolvedValue([]),
+        update: vi.fn().mockResolvedValue({}),
+      },
     };
 
     const result = await rebuildAccountLedger(
@@ -160,6 +164,10 @@ describe("rebuildAccountLedger execution price overrides", () => {
           },
         ]),
       },
+      import: {
+        findMany: vi.fn().mockResolvedValue([]),
+        update: vi.fn().mockResolvedValue({}),
+      },
     };
 
     const result = await rebuildAccountLedger(
@@ -179,5 +187,195 @@ describe("rebuildAccountLedger execution price overrides", () => {
       quantity: 100,
     });
     expect(createManyArg.data[0]?.realizedPnl).toBeCloseTo(1292, 6);
+  });
+});
+
+describe("rebuildAccountLedger import warning rewrite", () => {
+  it("clears stale ledger warnings while preserving parse-class warnings", async () => {
+    const open = tradeExecution({
+      id: "open-1",
+      quantity: new Prisma.Decimal(2),
+      price: new Prisma.Decimal(100),
+      openingClosingEffect: "TO_OPEN",
+    });
+    const close = tradeExecution({
+      id: "close-1",
+      side: "SELL",
+      quantity: new Prisma.Decimal(3),
+      price: new Prisma.Decimal(110),
+      openingClosingEffect: "TO_CLOSE",
+      eventTimestamp: new Date("2026-04-02T14:30:00.000Z"),
+      tradeDate: new Date("2026-04-02T00:00:00.000Z"),
+    });
+
+    const tx = {
+      matchedLot: {
+        deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+        createMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+      execution: {
+        deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+        findMany: vi.fn().mockResolvedValue([open, close]),
+        update: vi.fn().mockResolvedValue({}),
+        createMany: vi.fn().mockResolvedValue({ count: 0 }),
+      },
+      manualAdjustment: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            id: "qty-override",
+            createdAt: new Date("2026-04-03T00:00:00.000Z"),
+            createdBy: "tester",
+            accountId: "account-1",
+            symbol: "GOOG",
+            effectiveDate: new Date("2026-04-02T00:00:00.000Z"),
+            adjustmentType: "EXECUTION_QTY_OVERRIDE",
+            payloadJson: { executionId: "close-1", overrideQty: 2 },
+            reason: "fix stale unmatched close",
+            evidenceRef: null,
+            status: "ACTIVE",
+            reversedByAdjustmentId: null,
+            account: { accountId: "D-1" },
+          },
+        ]),
+      },
+      import: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            id: "import-1",
+            warnings: [
+              {
+                code: "UNMATCHED_CLOSE_QUANTITY",
+                message: "Unmatched close quantity 1 for instrument GOOG.",
+                rowRef: "close-1",
+              },
+              {
+                code: "EXECUTION_QTY_OVERRIDE_TARGET_MISSING",
+                message: "Execution qty override references missing execution missing-close.",
+                rowRef: "missing-close",
+              },
+              {
+                code: "LIMITED_SPREAD_INTERPRETATION",
+                message: "Preserve parse warning.",
+              },
+              {
+                code: "SYNTHETIC_EXPIRATION_INFERRED",
+                message: "Preserve synthetic expiration warning.",
+                rowRef: "synthetic-1",
+              },
+            ],
+          },
+        ]),
+        update: vi.fn().mockResolvedValue({}),
+      },
+    };
+
+    const result = await rebuildAccountLedger(
+      tx as unknown as Prisma.TransactionClient,
+      "account-1",
+      new Date("2026-04-10T00:00:00.000Z"),
+    );
+
+    expect(result.warnings).toEqual([]);
+    expect(result.warningsCleared).toBe(2);
+    expect(tx.import.update).toHaveBeenCalledWith({
+      where: { id: "import-1" },
+      data: {
+        warnings: [
+          {
+            code: "LIMITED_SPREAD_INTERPRETATION",
+            message: "Preserve parse warning.",
+          },
+          {
+            code: "SYNTHETIC_EXPIRATION_INFERRED",
+            message: "Preserve synthetic expiration warning.",
+            rowRef: "synthetic-1",
+          },
+        ],
+      },
+    });
+  });
+
+  it("rewrites current ledger warnings back onto the owning import", async () => {
+    const open = tradeExecution({
+      id: "open-1",
+      quantity: new Prisma.Decimal(1),
+      price: new Prisma.Decimal(100),
+      openingClosingEffect: "TO_OPEN",
+    });
+    const close = tradeExecution({
+      id: "close-1",
+      side: "SELL",
+      quantity: new Prisma.Decimal(2),
+      price: new Prisma.Decimal(110),
+      openingClosingEffect: "TO_CLOSE",
+      eventTimestamp: new Date("2026-04-02T14:30:00.000Z"),
+      tradeDate: new Date("2026-04-02T00:00:00.000Z"),
+    });
+
+    const tx = {
+      matchedLot: {
+        deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+        createMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+      execution: {
+        deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+        findMany: vi.fn().mockResolvedValue([open, close]),
+        update: vi.fn().mockResolvedValue({}),
+        createMany: vi.fn().mockResolvedValue({ count: 0 }),
+      },
+      manualAdjustment: {
+        findMany: vi.fn().mockResolvedValue([]),
+      },
+      import: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            id: "import-1",
+            warnings: [
+              {
+                code: "UNMATCHED_CLOSE_QUANTITY",
+                message: "Outdated unmatched close quantity warning.",
+                rowRef: "close-1",
+              },
+              {
+                code: "LIMITED_SPREAD_INTERPRETATION",
+                message: "Preserve parse warning.",
+              },
+            ],
+          },
+        ]),
+        update: vi.fn().mockResolvedValue({}),
+      },
+    };
+
+    const result = await rebuildAccountLedger(
+      tx as unknown as Prisma.TransactionClient,
+      "account-1",
+      new Date("2026-04-10T00:00:00.000Z"),
+    );
+
+    expect(result.warnings).toEqual([
+      {
+        code: "UNMATCHED_CLOSE_QUANTITY",
+        message: "Unmatched close quantity 1 for instrument GOOG.",
+        rowRef: "close-1",
+      },
+    ]);
+    expect(result.warningsCleared).toBe(1);
+    expect(tx.import.update).toHaveBeenCalledWith({
+      where: { id: "import-1" },
+      data: {
+        warnings: [
+          {
+            code: "LIMITED_SPREAD_INTERPRETATION",
+            message: "Preserve parse warning.",
+          },
+          {
+            code: "UNMATCHED_CLOSE_QUANTITY",
+            message: "Unmatched close quantity 1 for instrument GOOG.",
+            rowRef: "close-1",
+          },
+        ],
+      },
+    });
   });
 });

--- a/src/lib/ledger/rebuild-account-ledger.ts
+++ b/src/lib/ledger/rebuild-account-ledger.ts
@@ -11,6 +11,7 @@ import { runFifoMatcher, type LedgerExecution, type LedgerWarning } from "./fifo
 export interface RebuildAccountLedgerResult {
   matchedLotsPersisted: number;
   syntheticExecutionsPersisted: number;
+  warningsCleared: number;
   warnings: LedgerWarning[];
 }
 
@@ -22,6 +23,97 @@ export interface RebuildAccountLedgerOptions {
 }
 
 const FIDELITY_COMPACT_OPTION_SYMBOL_REGEX = /^-([A-Z]{1,6})(\d{2})(\d{2})(\d{2})([CP])(\d+(?:\.\d+)?)$/;
+const LEDGER_WARNING_CODES = new Set([
+  "UNMATCHED_CLOSE_QUANTITY",
+  "EXECUTION_QTY_OVERRIDE_TARGET_MISSING",
+  "EXECUTION_PRICE_OVERRIDE_TARGET_MISSING",
+]);
+
+function isWarningObject(value: unknown): value is LedgerWarning {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const candidate = value as { code?: unknown; message?: unknown; rowRef?: unknown };
+  return (
+    typeof candidate.code === "string" &&
+    typeof candidate.message === "string" &&
+    (candidate.rowRef === undefined || typeof candidate.rowRef === "string")
+  );
+}
+
+function warningKey(warning: Pick<LedgerWarning, "code" | "message" | "rowRef">): string {
+  return `${warning.code}::${warning.rowRef ?? ""}::${warning.message}`;
+}
+
+async function rewriteLedgerWarningsOnImports(
+  tx: Prisma.TransactionClient,
+  accountId: string,
+  sourceExecutions: Array<{ id: string; importId: string }>,
+  warnings: LedgerWarning[],
+): Promise<number> {
+  const importRows = await tx.import.findMany({
+    where: { accountId },
+    select: { id: true, warnings: true },
+  });
+
+  const importIdByExecutionId = new Map(sourceExecutions.map((execution) => [execution.id, execution.importId]));
+  const newWarningsByImportId = new Map<string, LedgerWarning[]>();
+  for (const warning of warnings) {
+    if (!warning.rowRef) {
+      continue;
+    }
+
+    const importId = importIdByExecutionId.get(warning.rowRef);
+    if (!importId) {
+      continue;
+    }
+
+    const existing = newWarningsByImportId.get(importId) ?? [];
+    existing.push(warning);
+    newWarningsByImportId.set(importId, existing);
+  }
+
+  let warningsCleared = 0;
+  for (const importRow of importRows) {
+    const existingWarnings: unknown[] = Array.isArray(importRow.warnings) ? importRow.warnings : [];
+    const existingLedgerWarnings = existingWarnings.filter(
+      (warning): warning is LedgerWarning => isWarningObject(warning) && LEDGER_WARNING_CODES.has(warning.code),
+    );
+    const freshWarnings = newWarningsByImportId.get(importRow.id) ?? [];
+
+    if (existingLedgerWarnings.length === 0 && freshWarnings.length === 0) {
+      continue;
+    }
+
+    const freshWarningCounts = new Map<string, number>();
+    for (const warning of freshWarnings) {
+      const key = warningKey(warning);
+      freshWarningCounts.set(key, (freshWarningCounts.get(key) ?? 0) + 1);
+    }
+
+    for (const warning of existingLedgerWarnings) {
+      const key = warningKey(warning);
+      const remaining = freshWarningCounts.get(key) ?? 0;
+      if (remaining > 0) {
+        freshWarningCounts.set(key, remaining - 1);
+        continue;
+      }
+
+      warningsCleared += 1;
+    }
+
+    const preservedWarnings = existingWarnings.filter((warning) => !isWarningObject(warning) || !LEDGER_WARNING_CODES.has(warning.code));
+    await tx.import.update({
+      where: { id: importRow.id },
+      data: {
+        warnings: [...preservedWarnings, ...freshWarnings] as Prisma.InputJsonValue,
+      },
+    });
+  }
+
+  return warningsCleared;
+}
 
 function toNumber(value: Prisma.Decimal | null): number | null {
   return value === null ? null : Number(value);
@@ -371,9 +463,12 @@ export async function rebuildAccountLedger(
     });
   }
 
+  const warningsCleared = await rewriteLedgerWarningsOnImports(tx, accountId, sourceExecutions, matchResult.warnings);
+
   return {
     matchedLotsPersisted: matchResult.matchedLots.length,
     syntheticExecutionsPersisted: matchResult.syntheticExecutions.length,
+    warningsCleared,
     warnings: matchResult.warnings,
   };
 }

--- a/types/api.ts
+++ b/types/api.ts
@@ -647,6 +647,13 @@ export interface ReverseManualAdjustmentResponse {
   reversalId: string;
 }
 
+export interface AccountLedgerRebuildResponse {
+  matchedLotsPersisted: number;
+  syntheticExecutionsPersisted: number;
+  warningsCleared: number;
+  setupGroupsPersisted: number;
+}
+
 export interface AdjustmentPreviewResponse {
   symbol: string;
   adjustmentType: AdjustmentType;
@@ -716,6 +723,7 @@ export type AdjustmentsListApiResponse = ApiListResponse<ManualAdjustmentRecord>
 export type AdjustmentCreateApiResponse = ApiDetailResponse<ManualAdjustmentRecord> | ApiErrorResponse;
 export type AdjustmentReverseApiResponse = ApiDetailResponse<ReverseManualAdjustmentResponse> | ApiErrorResponse;
 export type AdjustmentPreviewApiResponse = ApiDetailResponse<AdjustmentPreviewResponse> | ApiErrorResponse;
+export type AccountLedgerRebuildApiResponse = ApiDetailResponse<AccountLedgerRebuildResponse> | ApiErrorResponse;
 export type OptionQuotesApiResponse = ApiDetailResponse<OptionQuotesMap> | ApiErrorResponse;
 export type PositionSnapshotComputeApiResponse = ApiDetailResponse<PositionSnapshotComputeResponse> | ApiErrorResponse;
 export type PositionSnapshotApiResponse = PositionSnapshotResponse | ApiErrorResponse;


### PR DESCRIPTION
Closes #189

## Summary
- add an account-scoped rebuild-ledger POST route under /api/accounts/[id]/rebuild-ledger
- rewrite ledger-owned import warnings during account rebuilds while preserving parse-class warnings
- add a Rebuild Ledger action to the Adjustments page with loading, success, and error states

## Validation
- npm run typecheck
- npm run lint
- npm test -- --passWithNoTests
- docker compose up -d
- curl -sf http://localhost:3002/api/health | grep ok
- curl -sf http://localhost:3002/api/overview/summary | grep netPnl
- curl -sf -X POST http://localhost:3002/api/accounts/D-68011053/rebuild-ledger