### PR TITLE
Fix execution deep links

### DIFF
--- a/src/components/diagnostic-case-file-panel.tsx
+++ b/src/components/diagnostic-case-file-panel.tsx
@@ -174,7 +174,7 @@ export function DiagnosticCaseFilePanel({ query, closeHref }: { query: Diagnosti
                 <ul className="mt-2 space-y-2 text-xs text-text">
                   {data.executions.map((execution) => (
                     <li key={execution.id}>
-                      <Link href={`/executions?execution=${execution.id}`} className="text-blue-300 underline">
+                      <Link href={`/trade-records?tab=executions&execution=${execution.id}`} className="text-blue-300 underline">
                         {execution.id.slice(0, 8)}...
                       </Link>{" "}
                       {execution.underlyingSymbol ?? execution.symbol} {execution.eventType} {execution.openingClosingEffect ?? "UNKNOWN"}

--- a/src/components/matched-lots-table-panel.tsx
+++ b/src/components/matched-lots-table-panel.tsx
@@ -59,13 +59,13 @@ const MatchedLotsTableBody = memo(function MatchedLotsTableBody({
             {row.outcome === "WIN" ? <Badge variant="win">WIN</Badge> : row.outcome === "LOSS" ? <Badge variant="loss">LOSS</Badge> : <Badge variant="flat">FLAT</Badge>}
           </td>
           <td className="px-2 py-2 font-mono">
-            <Link href={`/executions?execution=${row.openExecutionId}&account=${row.accountId}`} className="text-accent underline">
+            <Link href={`/trade-records?tab=executions&execution=${row.openExecutionId}&account=${row.accountId}`} className="text-accent underline">
               {shortId(row.openExecutionId)}
             </Link>
           </td>
           <td className="px-2 py-2 font-mono">
             {row.closeExecutionId ? (
-              <Link href={`/executions?execution=${row.closeExecutionId}&account=${row.accountId}`} className="text-accent underline">
+              <Link href={`/trade-records?tab=executions&execution=${row.closeExecutionId}&account=${row.accountId}`} className="text-accent underline">
                 {shortId(row.closeExecutionId)}
               </Link>
             ) : (

--- a/src/components/setups-analytics-panel.tsx
+++ b/src/components/setups-analytics-panel.tsx
@@ -513,13 +513,13 @@ export function SetupsAnalyticsPanel() {
                         <td className="px-2 py-2 text-right">{lot.holdingDays}</td>
                         <td className="px-2 py-2">{lot.outcome}</td>
                         <td className="px-2 py-2">
-                          <Link href={`/executions?execution=${lot.openExecutionId}&account=${lot.accountId}`} className="text-accent underline">
+                          <Link href={`/trade-records?tab=executions&execution=${lot.openExecutionId}&account=${lot.accountId}`} className="text-accent underline">
                             {lot.openExecutionId.slice(0, 8)}...
                           </Link>
                         </td>
                         <td className="px-2 py-2">
                           {lot.closeExecutionId ? (
-                            <Link href={`/executions?execution=${lot.closeExecutionId}&account=${lot.accountId}`} className="text-accent underline">
+                            <Link href={`/trade-records?tab=executions&execution=${lot.closeExecutionId}&account=${lot.accountId}`} className="text-accent underline">
                               {lot.closeExecutionId.slice(0, 8)}...
                             </Link>
                           ) : (


### PR DESCRIPTION
Closes #210

## Summary
- Route matched-lot open and close execution links directly to T1 executions tab with query params preserved.
- Route setup detail drawer execution links directly to T1 executions tab with query params preserved.
- Updated the diagnostic case file execution drill-through to avoid the query-dropping /executions redirect.

## Validation
- npm run typecheck
- npm run lint
- npm test -- --passWithNoTests