### PR TITLE
feat: add Period Return widget (closes #226)

### DIFF
--- a/src/app/api/overview/period-return/route.ts
+++ b/src/app/api/overview/period-return/route.ts
@@ -1,0 +1,85 @@
+import type { PeriodReturnResponse } from "@/types/api";
+import {
+  buildAccountScopeWhere,
+  parseAccountIds,
+  parseDateRangeParams,
+  toEndOfDayUtcIso,
+} from "@/lib/api/account-scope";
+import { detailResponse, errorResponse } from "@/lib/api/responses";
+import { prisma } from "@/lib/db/prisma";
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const { startDate, endDate } = parseDateRangeParams(url.searchParams);
+
+  if (!startDate || !endDate) {
+    return errorResponse("MISSING_PARAMS", "startDate and endDate are required", []);
+  }
+
+  const accountIds = parseAccountIds(url.searchParams.get("accountIds"));
+  const accountScope = buildAccountScopeWhere(accountIds);
+
+  const startDateBound = new Date(startDate);
+  const endDateBound = toEndOfDayUtcIso(endDate);
+
+  const internalAccountIds =
+    accountIds.length > 0
+      ? (
+          await prisma.account.findMany({
+            where: accountScope,
+            select: { id: true },
+          })
+        ).map((a) => a.id)
+      : (await prisma.account.findMany({ select: { id: true } })).map((a) => a.id);
+
+  const [startingSnapshots, endingSnapshots, cashAggregate] = await Promise.all([
+    prisma.dailyAccountSnapshot.findMany({
+      where: {
+        accountId: { in: internalAccountIds },
+        snapshotDate: { lte: startDateBound },
+      },
+      orderBy: { snapshotDate: "desc" },
+      distinct: ["accountId"],
+    }),
+    prisma.dailyAccountSnapshot.findMany({
+      where: {
+        accountId: { in: internalAccountIds },
+        snapshotDate: { lte: endDateBound },
+      },
+      orderBy: { snapshotDate: "desc" },
+      distinct: ["accountId"],
+    }),
+    prisma.cashEvent.aggregate({
+      where: {
+        accountId: { in: internalAccountIds },
+        eventDate: { gte: startDateBound, lte: endDateBound },
+      },
+      _sum: { amount: true },
+    }),
+  ]);
+
+  function sumNlv(snapshots: typeof startingSnapshots): number {
+    return snapshots.reduce((acc, row) => {
+      const nlv = row.brokerNetLiquidationValue ?? row.balance;
+      return acc + Number(nlv);
+    }, 0);
+  }
+
+  const startingNlv = sumNlv(startingSnapshots);
+  const endingNlv = sumNlv(endingSnapshots);
+  const netFlows = Number(cashAggregate._sum.amount ?? 0);
+
+  const profit = endingNlv - startingNlv - netFlows;
+  const denominator = startingNlv + netFlows;
+  const returnPercentage = denominator > 0 ? profit / denominator : null;
+
+  const payload: PeriodReturnResponse = {
+    profit,
+    returnPercentage,
+    startingNlv,
+    endingNlv,
+    netFlows,
+  };
+
+  return detailResponse(payload);
+}

--- a/src/components/widgets/PeriodReturnWidget.tsx
+++ b/src/components/widgets/PeriodReturnWidget.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useContext, useEffect, useState } from "react";
+import { useAccountFilterContext } from "@/contexts/AccountFilterContext";
+import { RangeFilterContext } from "@/contexts/RangeFilterContext";
+import { applyAccountIdsToSearchParams } from "@/lib/api/account-scope";
+import { KpiCard } from "@/components/KpiCard";
+import { LoadingSkeleton } from "@/components/loading-skeleton";
+import type { PeriodReturnResponse } from "@/types/api";
+
+function formatPercent(value: number): string {
+  const sign = value >= 0 ? "+" : "";
+  return `${sign}${(value * 100).toFixed(2)}%`;
+}
+
+function formatCurrency(value: number): string {
+  const sign = value >= 0 ? "+" : "-";
+  return `${sign}$${Math.abs(value).toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+export function PeriodReturnWidget() {
+  const { selectedAccounts } = useAccountFilterContext();
+  const { range, applyRangeToSearchParams } = useContext(RangeFilterContext);
+  const [data, setData] = useState<PeriodReturnResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadData() {
+      setLoading(true);
+      const query = new URLSearchParams();
+      applyAccountIdsToSearchParams(query, selectedAccounts);
+      applyRangeToSearchParams(query);
+
+      const response = await fetch(`/api/overview/period-return?${query.toString()}`, { cache: "no-store" });
+      if (!response.ok || cancelled) {
+        return;
+      }
+
+      const payload = (await response.json()) as { data?: PeriodReturnResponse };
+      if (!cancelled) {
+        setData(payload.data ?? null);
+        setLoading(false);
+      }
+    }
+
+    void loadData();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedAccounts, range.startDate, range.endDate, applyRangeToSearchParams]);
+
+  if (loading || data === null) {
+    return <LoadingSkeleton lines={2} />;
+  }
+
+  const returnDisplay = data.returnPercentage !== null ? formatPercent(data.returnPercentage) : "N/A";
+  const profitDisplay = formatCurrency(data.profit);
+  const colorVariant = data.returnPercentage === null ? "neutral" : data.returnPercentage >= 0 ? "pos" : "neg";
+
+  return (
+    <KpiCard
+      label="Period Return"
+      value={returnDisplay}
+      sub={`Profit: ${profitDisplay}`}
+      colorVariant={colorVariant}
+    />
+  );
+}

--- a/src/lib/widget-registry.ts
+++ b/src/lib/widget-registry.ts
@@ -13,6 +13,7 @@ import { ReconciliationWidget } from "@/components/widgets/ReconciliationWidget"
 import { RecentExecutionsWidget } from "@/components/widgets/RecentExecutionsWidget";
 import { SetupExpectancyWidget } from "@/components/widgets/SetupExpectancyWidget";
 import { SetupTagRollupWidget } from "@/components/widgets/SetupTagRollupWidget";
+import { PeriodReturnWidget } from "@/components/widgets/PeriodReturnWidget";
 import { StreakWidget } from "@/components/widgets/StreakWidget";
 import { SymbolPnlWidget } from "@/components/widgets/SymbolPnlWidget";
 import { TopSetupsWidget } from "@/components/widgets/TopSetupsWidget";
@@ -77,6 +78,13 @@ export const WIDGET_REGISTRY: WidgetDefinition[] = [
   },
   { id: "setup-expectancy", name: "Setup Expectancy", description: "Expectancy rollup by setup tag.", defaultColSpan: 1, component: SetupExpectancyWidget },
   { id: "streaks", name: "Win / Loss Streak", description: "Current and longest streak statistics.", defaultColSpan: 1, component: StreakWidget },
+  {
+    id: "period-return",
+    name: "Period Return",
+    description: "Net-contribution-adjusted return for the selected date range.",
+    defaultColSpan: 1,
+    component: PeriodReturnWidget,
+  },
 ];
 
 export const DEFAULT_DASHBOARD_LAYOUT = [

--- a/types/api.ts
+++ b/types/api.ts
@@ -728,3 +728,13 @@ export type AccountLedgerRebuildApiResponse = ApiDetailResponse<AccountLedgerReb
 export type OptionQuotesApiResponse = ApiDetailResponse<OptionQuotesMap> | ApiErrorResponse;
 export type PositionSnapshotComputeApiResponse = ApiDetailResponse<PositionSnapshotComputeResponse> | ApiErrorResponse;
 export type PositionSnapshotApiResponse = PositionSnapshotResponse | ApiErrorResponse;
+
+export interface PeriodReturnResponse {
+  profit: number;
+  returnPercentage: number | null;
+  startingNlv: number;
+  endingNlv: number;
+  netFlows: number;
+}
+
+export type PeriodReturnApiResponse = ApiDetailResponse<PeriodReturnResponse> | ApiErrorResponse;


### PR DESCRIPTION
Closes #226

## Changes
- `types/api.ts` — adds `PeriodReturnResponse` and `PeriodReturnApiResponse`
- `src/app/api/overview/period-return/route.ts` — new GET endpoint; queries `DailyAccountSnapshot` for Starting/Ending NLV using `distinct: ['accountId']` + `orderBy: desc` lookups and aggregates `CashEvent.amount` for net flows; returns Modified Dietz profit and returnPercentage (null on divide-by-zero)
- `src/components/widgets/PeriodReturnWidget.tsx` — client widget; follows StreakWidget pattern; shows `LoadingSkeleton` while fetching, then renders `KpiCard` with return % as headline and absolute profit in sub-label
- `src/lib/widget-registry.ts` — registers `period-return` widget with `defaultColSpan: 1`

## Validation
- `npm run typecheck` ✓
- `npm run lint` ✓ (pre-existing font warning only)
- `npm test -- --passWithNoTests` ✓ (62 files, 231 tests)