### PR TITLE
Fix CSP color token in expectancy scatter widget

### DIFF
--- a/src/components/widgets/ExpectancyScatterWidget.tsx
+++ b/src/components/widgets/ExpectancyScatterWidget.tsx
@@ -31,7 +31,7 @@ const tagColors: Record<string, string> = {
   stock: "var(--pos)",
   bull_vertical: "var(--warn)",
   diagonal: "var(--neg)",
-  cash_secured_put: "var(--accent-2)",
+  cash_secured_put: "var(--warn)",
 };
 
 const INFO_LEGEND = [


### PR DESCRIPTION
Closes #244