### PR TITLE
Safe-deploy minimum for Fly.io: auth gate, production image, deploy config, .env hygiene

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,0 @@
-DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:55432/kapman
-NODE_ENV=development
-NEXT_TELEMETRY_DISABLED=1

--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,10 @@ NEXT_TELEMETRY_DISABLED=1
 MCP_SERVER_URL=
 # Optional bearer auth for MCP endpoint; app remains functional for non-quote features when unset
 MCP_BEARER_TOKEN=
+
+# Optional HTTP Basic Auth gate (src/middleware.ts). Set BOTH in production
+# (e.g. `fly secrets set BASIC_AUTH_USER=... BASIC_AUTH_PASSWORD=...`) to require
+# a login on every request. When either is unset the gate is bypassed, so local
+# dev, docker compose, and tests run without authentication.
+BASIC_AUTH_USER=
+BASIC_AUTH_PASSWORD=

--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,9 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
+.env
 .env*.local
+!.env.example
 
 # local account statement exports
 /fixtures/*AccountStatement*.csv

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,17 @@ RUN npm ci
 
 COPY . .
 
+# A throwaway URL so `prisma generate` and `next build` never need a live
+# database. Real values are injected at runtime via Fly secrets.
+ENV DATABASE_URL="postgresql://build:build@localhost:5432/build"
+ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN npx prisma generate && npm run build
+
+ENV NODE_ENV=production
+
 EXPOSE 3000
 
-CMD ["npm", "run", "dev:container"]
+# Production server. Database migrations run separately via the fly.toml
+# release_command. docker compose overrides this command for local dev.
+CMD ["npm", "run", "start"]

--- a/fly.toml
+++ b/fly.toml
@@ -1,7 +1,11 @@
-app = "kapman-tradelog-APP_NAME_PLACEHOLDER"
+app = "kapman-tradelog"
 primary_region = "iad"
 
 [build]
+  dockerfile = "Dockerfile"
+
+[deploy]
+  release_command = "npx prisma migrate deploy"
 
 [http_service]
   internal_port = 3000

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,83 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+// Minimal HTTP Basic Auth gate for the whole app.
+//
+// Credentials come from environment variables and are never committed:
+//   BASIC_AUTH_USER, BASIC_AUTH_PASSWORD
+//
+// When either variable is unset the gate is bypassed, so local development,
+// docker compose, and tests run without authentication. In production (Fly)
+// set both via `fly secrets set` to require a login on every request.
+//
+// `/api/health` is intentionally exempt so the Fly health check can reach the
+// app, and Next.js static assets are excluded via the matcher below.
+
+const HEALTH_PATH = "/api/health";
+
+function unauthorized(): NextResponse {
+  return new NextResponse("Authentication required", {
+    status: 401,
+    headers: {
+      "WWW-Authenticate": 'Basic realm="KapMan Trading Journal", charset="UTF-8"',
+    },
+  });
+}
+
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  let mismatch = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return mismatch === 0;
+}
+
+export function middleware(request: NextRequest): NextResponse {
+  const expectedUser = process.env.BASIC_AUTH_USER?.trim();
+  const expectedPassword = process.env.BASIC_AUTH_PASSWORD;
+
+  // Auth not configured -> allow through (local dev / tests / compose).
+  if (!expectedUser || !expectedPassword) {
+    return NextResponse.next();
+  }
+
+  // Let Fly's health check through without credentials.
+  if (request.nextUrl.pathname === HEALTH_PATH) {
+    return NextResponse.next();
+  }
+
+  const header = request.headers.get("authorization");
+  if (!header?.startsWith("Basic ")) {
+    return unauthorized();
+  }
+
+  let decoded = "";
+  try {
+    decoded = atob(header.slice("Basic ".length));
+  } catch {
+    return unauthorized();
+  }
+
+  const separatorIndex = decoded.indexOf(":");
+  if (separatorIndex === -1) {
+    return unauthorized();
+  }
+
+  const user = decoded.slice(0, separatorIndex);
+  const password = decoded.slice(separatorIndex + 1);
+
+  const userOk = timingSafeEqual(user, expectedUser);
+  const passwordOk = timingSafeEqual(password, expectedPassword);
+  if (!userOk || !passwordOk) {
+    return unauthorized();
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  // Run on everything except Next.js internals and common static asset files.
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+};


### PR DESCRIPTION
Closes #248

## What
Minimum changes to deploy this app to Fly.io safely.

### Security
- **`src/middleware.ts`** — HTTP Basic Auth gate over every page and API route.
  - Credentials from `BASIC_AUTH_USER` / `BASIC_AUTH_PASSWORD` (Fly secrets; never committed).
  - Bypassed when either var is unset → local dev, docker compose, and tests are unaffected.
  - `/api/health` and Next static assets are exempt so Fly health checks and assets load.
  - Constant-time credential comparison.
- Untracked the committed **`.env`**, added it to `.gitignore` (kept `.env.example`), and documented the new optional `BASIC_AUTH_*` vars.

### Deploy
- **`Dockerfile`** — production build: `prisma generate` + `next build`, runs `next start`. A throwaway `DATABASE_URL` is set at build time so the build never needs a live DB. `docker compose` still overrides the command for local dev.
- **`fly.toml`** — real app name, `[build]` dockerfile, and `release_command = "npx prisma migrate deploy"` to run migrations on deploy.

## Validation
- `npm run typecheck` ✓
- `npm run lint` ✓ (no warnings/errors)
- `npm test` ✓ (56 files, 396 tests)
- `docker compose up` health + summary smoke tests (see PR check / comment)

## Operator steps (not in this PR)
- `fly secrets set BASIC_AUTH_USER=... BASIC_AUTH_PASSWORD=...`
- Provision/attach Fly Postgres so `DATABASE_URL` is injected.

## Out of scope
- UI account-number masking (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)