### PR TITLE
Fix production next build (force-dynamic) — regression from #249

### DIFF
--- a/src/app/api/accounts/route.ts
+++ b/src/app/api/accounts/route.ts
@@ -4,6 +4,10 @@ import { warnDeprecatedStartingCapitalEnvVar } from "@/lib/accounts/env";
 import { ensureAccountDefaults } from "@/lib/accounts/ensure-defaults";
 import { prisma } from "@/lib/db/prisma";
 
+// Always query the live database at request time; never statically prerender
+// this handler at build (no DB is available then).
+export const dynamic = "force-dynamic";
+
 export async function GET() {
   warnDeprecatedStartingCapitalEnvVar();
   await ensureAccountDefaults();

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,11 @@ export const metadata: Metadata = {
   description: "Containerized trading journal for imports, FIFO lots, and setup analytics.",
 };
 
+// This is a runtime, database-backed dashboard rendered per request; opt the
+// whole route tree out of build-time static generation so `next build` does not
+// try to prerender pages that depend on live data.
+export const dynamic = "force-dynamic";
+
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="en">


### PR DESCRIPTION
Closes #250

Re-lands the build fix that was lost when #249 auto-merged before the commit was pushed.

## Changes
- `src/app/layout.tsx` — `export const dynamic = "force-dynamic"` so the DB-backed dashboard route tree is rendered per request, not statically prerendered at build.
- `src/app/api/accounts/route.ts` — `export const dynamic = "force-dynamic"` so the no-arg GET handler isn't statically evaluated (and DB-queried) at build.

## Verified
- `npm run build` → exit 0, 0 prerender errors, 0 export errors
- `docker build .` → exit 0 (the Fly production artifact)
- `npm run typecheck` / `lint` / `test` → all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)