### PR TITLE
docs: Account Value Curve & MFE/MAE spec set

### DIFF
--- a/docs/account-value-curve/00-overview.md
+++ b/docs/account-value-curve/00-overview.md
@@ -1,0 +1,152 @@
+# Account Value Curve & Excursion Analysis — Overview / Primer
+
+> **Read this first.** Every story file in this directory is self-contained, but this
+> document is the shared context primer. If you are an autonomous coding agent picking
+> up a single story, read this file plus that story's "Context primer" section before
+> writing code.
+
+## 1. Goal
+
+Add an **Analysis-page screen** that shows, for any selected accounts and date range, the
+**daily history** of account value broken into:
+
+- **Cash** value
+- **Stock/ETF** (equity) market value
+- **Options** market value
+- **Total** value (= the three above)
+
+…plus, where the broker reported it, the broker Net Liquidation Value (NLV) overlaid as a
+**reconciliation** check.
+
+Second deliverable: **MFE / MAE** (Maximum Favorable Excursion / Maximum Adverse
+Excursion) computed **per matched lot** (entry → exit), rolling up per setup and symbol.
+
+## 2. Locked product decisions
+
+These were decided with the product owner. Do not relitigate them in code.
+
+| Decision | Value |
+|---|---|
+| Time granularity | **Daily end-of-day** (one point per trading day). MFE/MAE use daily high/low. |
+| MFE/MAE level | **Per matched lot** (`MatchedLot`), rolled up per setup/symbol. |
+| Source of truth | **Reconstructed** value (executions + historical marks). Broker NLV is shown as a reconciliation delta where present, never as the primary number. |
+| Cash source | **`CashEvent`** ledger (cumulative), reconciled against `DailyAccountSnapshot.totalCash`. |
+| Backfill scope | **All history, all traded symbols.** |
+| Historical price source | **Massive/Polygon S3 flat files** (daily aggregates), ported to TypeScript. |
+| Reuse model | **Port to TypeScript** in this repo. `kapman-trader` (Python) is the reference implementation, not a runtime dependency. |
+
+## 3. What already exists (do not rebuild)
+
+Verified in the codebase as of this spec:
+
+- **`DailyAccountSnapshot`** (`prisma/schema.prisma`): per account/date `balance`, `totalCash`,
+  optional `brokerNetLiquidationValue`. Powers the *current* cash/balance curve only.
+- **`Execution`**: full trade ledger with `assetClass` (`EQUITY`/`OPTION`/`CASH`/`OTHER`),
+  `symbol`, `underlyingSymbol`, `optionType`, `strike`, `expirationDate`, `instrumentKey`,
+  `quantity`, `price`, `side`, `openingClosingEffect`, `tradeDate`, `eventTimestamp`.
+- **`MatchedLot`**: FIFO-matched open→close lots with `openExecutionId`, `closeExecutionId`,
+  `quantity`, `realizedPnl`, `holdingDays`, `outcome`. The open/close executions carry
+  `tradeDate` and `symbol`. **This is the anchor for MFE/MAE.**
+- **`CashEvent`**: dated cash ledger rows (`eventDate`, `rowType`, `amount`).
+- **`computeOpenPositions()`** (`src/lib/positions/compute-open-positions.ts`): nets
+  executions and subtracts matched-lot quantity to produce **current** open positions split
+  by asset class. **It has no date parameter** — it is point-in-time by construction.
+- **Snapshot compute** (`src/app/api/positions/snapshot/compute/route.ts`): already marks
+  equity vs option positions live and sums marked value by account. This is the math the new
+  daily engine reuses — it just needs to run *as-of each historical date* with *historical*
+  marks.
+- **Live quotes** (`src/lib/mcp/market-data.ts`): current quotes via MCP (`get_quotes`,
+  `get_option_chain`). **Current only — no historical marks anywhere.**
+- **API/UI conventions**: `detailResponse`/`errorResponse`/`listResponse`
+  (`src/lib/api/responses.ts`); account/date scope helpers in
+  `src/lib/api/account-scope.ts` (`parseAccountIds`, `parseDateRangeParams`,
+  `buildAccountScopeWhere`, `buildAccountIdWhere`, `toEndOfDayUtcIso`); charts use
+  `recharts`; the Analysis page is `src/app/analytics/page.tsx` and already consumes
+  `AccountFilterContext` + `RangeFilterContext`.
+
+## 4. The two real gaps this project fills
+
+1. **An as-of-date holdings engine** — reconstruct what was held on date `D`.
+2. **A historical mark store** — daily OHLC for every held equity and option contract.
+
+Everything else (charting, API scoping, asset-class split math) already exists in some form.
+
+## 5. New components (target state)
+
+| Component | Story | Kind |
+|---|---|---|
+| `HistoricalMark`, `AccountValueSnapshot`, `LotExcursion` models | 01 | Prisma + migration |
+| `computeHoldingsAsOf()` | 02 | Pure function + tests |
+| S3 flat-file equity ingestion (`HistoricalMark`) | 03 | TS port of `kapman-trader` |
+| Daily valuation backfill job → `AccountValueSnapshot` + reconciliation | 04 | `tsx` script |
+| `GET /api/analysis/account-value-series` | 05 | Next route |
+| Analysis-page stacked-area + total + broker overlay widget | 06 | React/recharts |
+| S3 flat-file **option** ingestion (OPRA prefix + OCC parser) | 07 | TS port + new parser |
+| `LotExcursion` compute + MFE/MAE UI | 08 | Engine + UI |
+
+## 6. Build order & dependency graph
+
+```
+01 ─┬─> 02 ─┐
+    ├─> 03 ─┼─> 04 ─> 05 ─> 06     (equity-only vertical slice ships here)
+    │       │
+    └────── 07 ───────┘            (adds option marks; re-run 04)
+02 + (03|07) ─> 08                  (MFE/MAE)
+```
+
+**Ship 01→06 first with equities only.** That is a usable screen (cash + stock/ETF + total,
+options shown as "unpriced" until 07 lands). Then 07 backfills option marks and 08 adds
+MFE/MAE.
+
+## 7. Canonical instrument keys (shared contract — read carefully)
+
+`HistoricalMark`, `computeHoldingsAsOf`, and the marking step must agree on one key per
+instrument. Use this canonical scheme:
+
+- **Equity/ETF:** `instrumentKey = SYMBOL.toUpperCase()` (e.g. `"AAPL"`).
+- **Option:** `instrumentKey = "{UNDERLYING}|{CALL|PUT}|{STRIKE}|{YYYY-MM-DD}"`
+  (e.g. `"SPY|CALL|500|2026-01-16"`). This matches
+  `buildOptionInstrumentKey` in `src/lib/mcp/market-data.ts` and the option branch of
+  `fallbackInstrumentKey` in `compute-open-positions.ts`.
+
+The OPRA flat files use the **OCC ticker** form `O:SPY260116C00500000`. Story 07 defines a
+bijective `occToCanonical()` / `canonicalToOcc()` converter so option marks land under the
+canonical key. **All joins between holdings and marks happen on the canonical key.**
+
+## 8. Glossary
+
+- **NLV** — Net Liquidation Value: total account worth if liquidated now.
+- **Mark** — the price used to value a held instrument on a given day (here: daily close).
+- **As-of holdings** — the set of open positions as they stood at the end of a past date.
+- **MFE** — Maximum Favorable Excursion: best unrealized gain reached during a lot's holding
+  window.
+- **MAE** — Maximum Adverse Excursion: worst unrealized loss reached during the window.
+- **OPRA** — Options Price Reporting Authority; the options flat-file dataset.
+- **OCC ticker** — standardized option symbol, e.g. `O:SPY260116C00500000`.
+
+## 9. Reference implementation (Python → TypeScript)
+
+`kapman-trader` (sibling repo) already solves the flat-file ingestion. Port, don't reinvent.
+Stories 03 and 07 cite exact files. Key ones:
+
+- `core/ingestion/ohlcv/s3_flatfiles.py` — S3 client, key layout
+  (`us_stocks_sip/day_aggs_v1/YYYY/MM/YYYY-MM-DD.csv.gz`), date listing, gzip streaming.
+- `core/ingestion/ohlcv/parser.py` — CSV columns (`ticker`, `open/o`, `high/h`, `low/l`,
+  `close/c`, `volume/v`, `window_start` ns timestamp), dedup, missing-symbol handling.
+- `core/providers/market_data/polygon_s3.py` — provider-class variant of the same.
+- `core/providers/market_data/polygon_options.py` — **live snapshot only**, NOT historical;
+  do not copy for historical option marks. Use the OPRA flat-file prefix instead (story 07).
+
+## 10. Conventions every story must follow
+
+- **Tests:** `vitest` (`npm test`). Co-locate `*.test.ts` next to source, matching existing
+  files (e.g. `compute-open-positions` has no test yet — add one if you touch it).
+- **Money:** `Prisma.Decimal` at the DB boundary; convert to `number` only for arithmetic, as
+  existing code does. Persist with `.toFixed(6)`.
+- **Migrations:** `npx prisma migrate dev --name <snake_case>`; do not hand-write timestamps.
+- **Jobs:** `tsx scripts/<name>.ts`, registered in `package.json` scripts, following
+  `scripts/rebuild-pnl.ts` style (instantiate `PrismaClient`, `main()`, structured logs).
+- **API:** use `detailResponse`/`errorResponse`; parse scope with `account-scope.ts` helpers.
+- **Validation:** `zod` for request/response shapes (already a dependency).
+- **No secrets in code.** New env vars go in `.env.example` with comments (story 03).
+- **Typecheck + lint must pass:** `npm run typecheck && npm run lint && npm test`.

--- a/docs/account-value-curve/01-data-model.md
+++ b/docs/account-value-curve/01-data-model.md
@@ -1,0 +1,162 @@
+# Story 01 — Data Model: HistoricalMark, AccountValueSnapshot, LotExcursion
+
+## Context primer
+
+Read `00-overview.md` §3, §5, §7, §10 first. This repo is Next.js + Prisma 5.14 +
+PostgreSQL. Models live in `prisma/schema.prisma` using the existing conventions: `cuid()`
+ids, `@map`/`@@map` snake_case, `Decimal(20, 6)` for money/quantities, explicit `@@unique`
+and `@@index`. This story only adds schema + a migration. No business logic.
+
+## Goal
+
+Add three tables that the rest of the project reads/writes:
+
+1. `HistoricalMark` — daily OHLC per instrument (equities and option contracts).
+2. `AccountValueSnapshot` — the materialized daily value series the screen reads.
+3. `LotExcursion` — per-`MatchedLot` MFE/MAE (populated in story 08).
+
+## Out of scope
+
+- Any ingestion, compute, API, or UI. Other stories own those.
+- Backfilling data. This story only defines structure + migration.
+
+## Files to modify/create
+
+- `prisma/schema.prisma` (add models below).
+- New migration via `npx prisma migrate dev --name add_value_curve_models`.
+
+## Schema to add
+
+```prisma
+enum MarkAssetClass {
+  EQUITY
+  OPTION
+}
+
+enum MarkSource {
+  MASSIVE_S3
+  POLYGON_REST
+  MANUAL
+}
+
+enum ValueSnapshotSource {
+  RECONSTRUCTED
+  BROKER_NLV
+  MIXED
+}
+
+/// Daily OHLC for one instrument (equity symbol or option contract).
+/// instrumentKey is the canonical key defined in 00-overview §7.
+model HistoricalMark {
+  id            String         @id @default(cuid())
+  instrumentKey String         @map("instrument_key")
+  assetClass    MarkAssetClass @map("asset_class")
+  /// Equity: symbol. Option: underlying symbol. Useful for filtering/backfill.
+  symbol        String
+  markDate      DateTime       @map("mark_date") @db.Date
+  open          Decimal        @db.Decimal(20, 6)
+  high          Decimal        @db.Decimal(20, 6)
+  low           Decimal        @db.Decimal(20, 6)
+  close         Decimal        @db.Decimal(20, 6)
+  volume        Decimal?       @db.Decimal(28, 6)
+  source        MarkSource     @default(MASSIVE_S3)
+  createdAt     DateTime       @default(now()) @map("created_at")
+  updatedAt     DateTime       @updatedAt @map("updated_at")
+
+  @@unique([instrumentKey, markDate])
+  @@index([symbol, markDate])
+  @@index([markDate])
+  @@map("historical_marks")
+}
+
+/// Materialized daily account value, split by asset class. One row per account/date.
+/// This is what GET /api/analysis/account-value-series reads.
+model AccountValueSnapshot {
+  id                        String              @id @default(cuid())
+  snapshotDate              DateTime            @map("snapshot_date") @db.Date
+  cashValue                 Decimal             @map("cash_value") @db.Decimal(20, 6)
+  equityValue               Decimal             @map("equity_value") @db.Decimal(20, 6)
+  optionValue               Decimal             @map("option_value") @db.Decimal(20, 6)
+  totalValue                Decimal             @map("total_value") @db.Decimal(20, 6)
+  /// Broker-reported NLV for this date if available (for reconciliation only).
+  brokerNlv                 Decimal?            @map("broker_nlv") @db.Decimal(20, 6)
+  /// brokerNlv - totalValue when both present; null otherwise.
+  reconcileDelta            Decimal?            @map("reconcile_delta") @db.Decimal(20, 6)
+  /// Count of held instruments with no mark on this date (data-quality signal).
+  unpricedPositionCount     Int                 @default(0) @map("unpriced_position_count")
+  source                    ValueSnapshotSource @default(RECONSTRUCTED)
+  createdAt                 DateTime            @default(now()) @map("created_at")
+  updatedAt                 DateTime            @updatedAt @map("updated_at")
+
+  accountId String  @map("account_id")
+  account   Account @relation(fields: [accountId], references: [id], onDelete: Cascade)
+
+  @@unique([accountId, snapshotDate])
+  @@index([snapshotDate])
+  @@map("account_value_snapshots")
+}
+
+/// Per matched-lot maximum favorable / adverse excursion. Populated by story 08.
+model LotExcursion {
+  id              String   @id @default(cuid())
+  /// $ best unrealized gain during the holding window (>= 0 expected, but store raw).
+  mfe             Decimal  @db.Decimal(20, 6)
+  /// $ worst unrealized loss during the holding window (<= 0 expected, but store raw).
+  mae             Decimal  @db.Decimal(20, 6)
+  /// As a fraction of cost basis (e.g. 0.25 = +25%). Null if cost basis is 0.
+  mfePct          Decimal? @map("mfe_pct") @db.Decimal(12, 6)
+  maePct          Decimal? @map("mae_pct") @db.Decimal(12, 6)
+  mfeDate         DateTime? @map("mfe_date") @db.Date
+  maeDate         DateTime? @map("mae_date") @db.Date
+  /// Number of trading days in the window that had a usable mark.
+  pricedDays      Int      @default(0) @map("priced_days")
+  /// Number of trading days in the window with NO mark (data-quality signal).
+  unpricedDays    Int      @default(0) @map("unpriced_days")
+  computedAt      DateTime @default(now()) @map("computed_at")
+
+  matchedLotId String     @unique @map("matched_lot_id")
+  matchedLot   MatchedLot @relation(fields: [matchedLotId], references: [id], onDelete: Cascade)
+
+  @@map("lot_excursions")
+}
+```
+
+## Required relation edits on existing models
+
+Add the back-relations so Prisma validates:
+
+- On `model Account`: add `valueSnapshots AccountValueSnapshot[]`.
+- On `model MatchedLot`: add `excursion LotExcursion?`.
+
+## Design notes (why these choices)
+
+- `@db.Date` (not `DateTime`) for `markDate`/`snapshotDate`: these are calendar days, no
+  time component. Avoids timezone drift when joining holdings (as-of a date) to marks.
+- `HistoricalMark` unique on `(instrumentKey, markDate)`: enables idempotent upsert during
+  backfill (story 03/07 re-runs must not duplicate).
+- `AccountValueSnapshot` unique on `(accountId, snapshotDate)`: one materialized row per
+  account/day; the backfill job (story 04) upserts.
+- `reconcileDelta` and `unpricedPositionCount` are persisted (not computed on read) so the UI
+  can show data-quality without recomputation.
+- `LotExcursion` 1:1 with `MatchedLot` via `@unique` FK; cascade delete keeps it consistent
+  when lots are rebuilt by `rebuild-pnl`.
+
+## Acceptance criteria
+
+- [ ] Three models + three enums added to `prisma/schema.prisma`.
+- [ ] Back-relations added to `Account` and `MatchedLot`.
+- [ ] `npx prisma migrate dev --name add_value_curve_models` generates a migration and applies
+      cleanly to a fresh DB.
+- [ ] `npx prisma generate` succeeds; `npm run typecheck` passes.
+- [ ] No changes to existing columns/tables (additive only).
+
+## Test plan
+
+- `npm run typecheck` — Prisma client types compile.
+- Manual: `npx prisma migrate reset --force` then confirm the three tables exist
+  (`npx prisma studio` or `psql \dt`).
+- No unit tests required for a pure schema story.
+
+## Dependencies
+
+None. This is the first story; everything else depends on it.

--- a/docs/account-value-curve/02-asof-holdings.md
+++ b/docs/account-value-curve/02-asof-holdings.md
@@ -1,0 +1,103 @@
+# Story 02 — As-of-Date Holdings Engine
+
+## Context primer
+
+Read `00-overview.md` §3, §4, §7. The existing `computeOpenPositions()`
+(`src/lib/positions/compute-open-positions.ts`) produces **current** open positions by
+netting all executions and subtracting **all** matched-lot quantity. It has no date
+parameter and cannot answer "what was held on date D". This story adds that capability as a
+**new pure function** without modifying the existing one.
+
+## Goal
+
+Add `computeHoldingsAsOf(executions, matchedLots, adjustments, asOfDate)` returning the set
+of open positions (split EQUITY vs OPTION) **as they stood at end of `asOfDate`**, each
+carrying `instrumentKey` (canonical, per §7), `netQty`, `costBasis`, `accountId`, and the
+option metadata needed to value it.
+
+## Out of scope
+
+- Pricing/marks (story 03/04 join marks to these holdings).
+- Cash (story 04 computes cash from `CashEvent`).
+- Modifying `computeOpenPositions()` (leave it as the "current" path).
+
+## Files to create
+
+- `src/lib/positions/compute-holdings-asof.ts`
+- `src/lib/positions/compute-holdings-asof.test.ts`
+
+## Algorithm
+
+Mirror `compute-open-positions.ts`, but make every quantity **date-aware**:
+
+1. **Opens:** include an execution as an opener only if its `tradeDate <= asOfDate` AND it
+   qualifies as an open (same predicate the existing engine uses: `openingClosingEffect ===
+   "TO_OPEN"`, or the "plain equity buy" special case — copy that predicate exactly so
+   behavior matches).
+2. **Closes:** instead of subtracting *all* matched-lot quantity for an open execution,
+   subtract only matched lots whose **close execution `tradeDate <= asOfDate`**. A lot that
+   closes *after* `asOfDate` was still open on `asOfDate`, so its quantity must NOT be
+   subtracted.
+   - `MatchedLotRecord` carries `closeTradeDate` (string ISO) and `openExecutionId`. Build
+     `matchedQtyByOpenExecutionId` from only the lots with `closeTradeDate != null &&
+     closeTradeDate <= endOfDay(asOfDate)`.
+   - Open lots (`closeTradeDate == null`) are never subtracted — they are still held.
+3. **Adjustments:** apply only adjustments with `effectiveDate <= asOfDate`. Reuse
+   `applyExecutionSplitAdjustment` and `applyPositionAdjustmentsWithWarnings`, but filter the
+   adjustment list by date first. (Splits effective after `asOfDate` must not retroactively
+   rescale historical holdings.)
+4. **Grouping, netting, cost basis:** identical to the existing engine — group by
+   `accountId + "::" + instrumentKey`, sum signed qty and `qtySigned * adjustedPrice *
+   multiplier` (multiplier 100 for options). Drop positions with `netQty === 0`.
+
+Return type: reuse `OpenPosition` from `@/types/api` (same shape the current engine returns)
+so downstream marking code is shared.
+
+```ts
+export function computeHoldingsAsOf(
+  executions: ExecutionRecord[],
+  matchedLots: MatchedLotRecord[],
+  adjustments: ManualAdjustmentRecord[],
+  asOfDate: Date,
+): OpenPosition[];
+```
+
+## Edge cases to handle (and test)
+
+- **Date boundary:** compare against **end-of-day UTC** of `asOfDate` (reuse
+  `toEndOfDayUtcIso` from `src/lib/api/account-scope.ts`). A trade on `asOfDate` counts as
+  held that day.
+- **Lot closes after asOf:** quantity stays open. (Core regression risk — test explicitly.)
+- **Partial closes:** an open execution partially matched by lots, some closing before and
+  some after `asOfDate` → only the before-closes reduce the held quantity.
+- **Asof before any trade:** returns `[]`.
+- **Split effective after asOf:** holdings on `asOfDate` use pre-split qty/price.
+- **Plain equity buy** (the `openingClosingEffect === "UNKNOWN"` special case): preserve the
+  exact predicate from the current engine.
+
+## Acceptance criteria
+
+- [ ] `computeHoldingsAsOf` exported with the signature above.
+- [ ] `computeOpenPositions()` is unchanged.
+- [ ] For an `asOfDate` >= the latest trade/close date, output **equals**
+      `computeOpenPositions()` for the same inputs (parity test — guards against divergence).
+- [ ] All edge cases above covered by unit tests.
+- [ ] `npm run typecheck && npm run lint && npm test` pass.
+
+## Test plan
+
+`src/lib/positions/compute-holdings-asof.test.ts` (vitest), using hand-built
+`ExecutionRecord`/`MatchedLotRecord` fixtures (mirror the style of existing ledger tests in
+`src/lib/ledger/__tests__`). Minimum cases:
+
+1. Single equity buy, no closes → held at and after buy date; not held before.
+2. Lot opened day 1, closed day 5 → held on days 1–4, flat from day 5.
+3. Partial close: open 100 on day 1, close 40 on day 3 → 100 held days 1–2, 60 from day 3.
+4. Option position with multiplier 100 → cost basis includes ×100.
+5. **Parity:** `asOfDate = far future` equals `computeOpenPositions()`.
+6. Split adjustment effective day 10 → holdings on day 5 use unsplit basis.
+
+## Dependencies
+
+Story 01 (types only; no new tables used here, but `OpenPosition` and the record types must
+exist — they already do in `@/types/api`).

--- a/docs/account-value-curve/03-polygon-ingest.md
+++ b/docs/account-value-curve/03-polygon-ingest.md
@@ -1,0 +1,123 @@
+# Story 03 — Equity Historical Marks: Massive S3 Flat-File Ingestion (TS port)
+
+## Context primer
+
+Read `00-overview.md` §7 (keys) and §9 (reference impl). We need daily OHLC for every
+equity/ETF the accounts ever traded, written into `HistoricalMark` (story 01). The robust,
+proven approach is **Massive/Polygon S3 flat files**: one gzipped CSV per trading day
+containing *all* US equities. `kapman-trader` (Python sibling repo) already implements this;
+this story **ports that logic to TypeScript** using `@aws-sdk/client-s3`. We are NOT using
+the live MCP for history.
+
+## Reference implementation (port these, do not reinvent)
+
+Absolute paths in the sibling repo `kapman-trader`:
+
+- `core/ingestion/ohlcv/s3_flatfiles.py`
+  - Key layout: `{prefix}/{YYYY}/{MM}/{YYYY-MM-DD}.csv.gz`, default prefix
+    `us_stocks_sip/day_aggs_v1`.
+  - `list_available_dates_in_range()` — lists by `YYYY/MM/` prefix to avoid full-bucket
+    scans. Port this paginated listing.
+  - `get_s3_client()` — endpoint `S3_ENDPOINT_URL` (`https://files.massive.com`), bucket
+    `flatfiles`, **path-style addressing**, signature v4. The AWS SDK v3 equivalent is
+    `forcePathStyle: true` + `endpoint`.
+- `core/ingestion/ohlcv/parser.py`
+  - CSV columns: `ticker`, `open`/`o`, `high`/`h`, `low`/`l`, `close`/`c`, `volume`/`v`,
+    `window_start` (nanosecond epoch). Port the column-fallback and dedup logic.
+  - Filtering: `include_symbols` set restricts parsing to symbols we care about.
+
+## Goal
+
+A TypeScript module + CLI job that, given a set of equity symbols and a date range,
+downloads each day's flat file once, parses rows for the requested symbols, and **upserts**
+`HistoricalMark` rows (`assetClass = EQUITY`, `source = MASSIVE_S3`).
+
+## Out of scope
+
+- Options (story 07).
+- Computing account values (story 04).
+
+## Files to create
+
+- `src/lib/marketdata/s3-flatfiles.ts` — S3 client, key building, date listing, gzip fetch.
+- `src/lib/marketdata/equity-day-aggs-parser.ts` — CSV → parsed rows for requested symbols.
+- `src/lib/marketdata/ingest-equity-marks.ts` — orchestration: range → upsert
+  `HistoricalMark`.
+- `scripts/ingest-equity-marks.ts` — `tsx` CLI wrapper (mirror `scripts/rebuild-pnl.ts`).
+- Tests: `s3-flatfiles.test.ts`, `equity-day-aggs-parser.test.ts`.
+- `.env.example` additions (below).
+- `package.json`: add `@aws-sdk/client-s3` dependency and an `ingest:equity-marks` script.
+
+## New env vars (add to `.env.example` with comments)
+
+```
+# Massive/Polygon S3 flat files (historical marks). Required only for the
+# account-value-curve backfill; the rest of the app works without them.
+S3_ENDPOINT_URL=https://files.massive.com
+S3_BUCKET=flatfiles
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+POLYGON_S3_EQUITY_PREFIX=us_stocks_sip/day_aggs_v1
+```
+
+## Implementation notes
+
+- **AWS SDK v3 client:**
+  ```ts
+  new S3Client({
+    endpoint: process.env.S3_ENDPOINT_URL,
+    region: "us-east-1",
+    forcePathStyle: true,
+    credentials: { accessKeyId: ..., secretAccessKey: ... },
+  });
+  ```
+- **Gzip:** stream `GetObjectCommand` body → `zlib.gunzipSync` (node built-in) → parse CSV.
+  Use a small CSV parser; avoid heavy deps. A streaming line reader is fine — files are one
+  day of US equities (manageable).
+- **Date → close:** the flat file's bar is the daily aggregate; `close` is the EOD mark we
+  store. Persist O/H/L/C/V all (H/L feed MFE/MAE in story 08).
+- **markDate:** use the file's calendar date (from the S3 key), stored as `@db.Date`. Do not
+  derive from `window_start` to avoid TZ drift.
+- **Idempotent upsert:** `prisma.historicalMark.upsert({ where: { instrumentKey_markDate: {
+  instrumentKey, markDate } }, ... })`. `instrumentKey = symbol.toUpperCase()` for equities.
+- **Missing files:** a non-trading day (weekend/holiday) has no key → skip silently. A
+  missing key for a trading day → log a warning and continue (do not abort the whole range).
+- **Symbol filter:** pass the traded-symbol set as `include_symbols` so we don't store the
+  entire market. Source set = distinct `Execution.symbol` where `assetClass = 'EQUITY'`
+  (the CLI computes this when no explicit list is given).
+- **Resumability:** because upsert is idempotent, re-running a range is safe. Log per-day row
+  counts and a final summary (dates processed, rows upserted, symbols missing).
+
+## CLI contract
+
+```
+npm run ingest:equity-marks -- --start 2023-01-01 --end 2024-12-31 [--symbols AAPL,MSFT]
+# no --symbols  => all distinct equity symbols ever traded
+# no --start    => earliest equity Execution.tradeDate
+# no --end      => yesterday (UTC)
+```
+
+## Acceptance criteria
+
+- [ ] `@aws-sdk/client-s3` added; `npm install` clean.
+- [ ] Module downloads a day file, gunzips, parses, and filters to requested symbols.
+- [ ] Upserts `HistoricalMark` rows idempotently (re-run produces no duplicates).
+- [ ] Non-trading days and missing keys are skipped with a warning, not a crash.
+- [ ] CLI defaults: all traded equity symbols, earliest trade date → yesterday.
+- [ ] `.env.example` documents the new vars; missing vars produce a clear error (mirror
+      `default_s3_flatfiles_config`'s "Missing required S3 env vars" message).
+- [ ] `npm run typecheck && npm run lint && npm test` pass.
+
+## Test plan
+
+- `equity-day-aggs-parser.test.ts`: feed a small gzipped CSV fixture (build in-test with
+  `zlib.gzipSync`), assert parsed rows for included symbols, column fallbacks (`o` vs
+  `open`), invalid-row skipping, and dedup.
+- `s3-flatfiles.test.ts`: unit-test pure helpers (`buildDayAggsKey`,
+  `listAvailableDatesInRange` against a mocked paginator). Mock `S3Client.send`; no network.
+- Manual smoke (documented, not CI): run the CLI for one symbol over one week against real
+  credentials; confirm rows in `historical_marks`.
+
+## Dependencies
+
+Story 01 (the `HistoricalMark` table).

--- a/docs/account-value-curve/04-backfill-job.md
+++ b/docs/account-value-curve/04-backfill-job.md
@@ -1,0 +1,136 @@
+# Story 04 — Daily Valuation Backfill: AccountValueSnapshot + Reconciliation
+
+## Context primer
+
+Read `00-overview.md` §2 (locked decisions — note **cash from `CashEvent`**, **reconstructed
+source of truth**), §3, §7. With story 02 (`computeHoldingsAsOf`) and story 03
+(`HistoricalMark` for equities), we can now value each account on each trading day and
+materialize it into `AccountValueSnapshot` (story 01). This story is the engine + the CLI job.
+
+## Goal
+
+For each account in scope and each trading day in range:
+
+1. Reconstruct holdings as-of the day (`computeHoldingsAsOf`).
+2. Mark each holding using `HistoricalMark` for that `instrumentKey` + date.
+3. Compute `equityValue`, `optionValue`, `cashValue`, `totalValue`,
+   `unpricedPositionCount`.
+4. Attach `brokerNlv` + `reconcileDelta` from `DailyAccountSnapshot` when present.
+5. **Upsert** one `AccountValueSnapshot` row per account/day.
+
+## Out of scope
+
+- MFE/MAE (story 08).
+- The read API (story 05) and UI (story 06).
+- Option *ingestion* (story 07) — but this engine must already handle option holdings: if an
+  option's mark is missing, count it in `unpricedPositionCount` and value it at 0. Once story
+  07 backfills option marks, re-running this job fills in `optionValue`.
+
+## Cash computation (decision: from `CashEvent`)
+
+`cashValue(account, D)` = `startingCapital(account)` + Σ `CashEvent.amount` where
+`eventDate <= endOfDay(D)`.
+
+- Get `startingCapital` via the existing `getStartingCapitalSummary` /
+  `Account.startingCapital` path used elsewhere (see
+  `src/lib/accounts/starting-capital.ts`).
+- **Sub-task — verify CashEvent semantics before trusting the sum.** Enumerate the distinct
+  `CashEvent.rowType` values in the DB and confirm which represent real cash movements
+  (deposits, withdrawals, fees, trade cash flows). If trade proceeds are *already* implied by
+  reconstructed positions, including them in cash would double-count. Document the rowType
+  treatment in a comment and a short note in this folder (`04-cash-rowtypes.md`) so reviewers
+  can validate. If unclear, prefer the interpretation that makes `totalValue` reconcile most
+  closely to `DailyAccountSnapshot.totalCash`/`brokerNlv` and log the delta.
+
+> ⚠️ This reconciliation is expected to be imperfect (assignments, expirations, dividends,
+> fees not in cost basis). That is why `reconcileDelta` is a first-class, visible column — do
+> not hide discrepancies.
+
+## Marking
+
+For each holding from `computeHoldingsAsOf`:
+
+- Look up `HistoricalMark` by `(instrumentKey, markDate = D)`.
+  - If no mark on exactly `D` (e.g. thin option, holiday mismatch), fall back to the most
+    recent mark with `markDate <= D` within a small window (e.g. 5 trading days). If still
+    none → unpriced.
+- `marketValue = close * netQty * (assetClass === "OPTION" ? 100 : 1)`.
+- `equityValue` = Σ market value of EQUITY holdings; `optionValue` = Σ for OPTION.
+- `unpricedPositionCount` = count of holdings with no usable mark.
+
+`totalValue = cashValue + equityValue + optionValue`.
+
+`source`:
+- `RECONSTRUCTED` always (reconstructed is source of truth).
+- Set `brokerNlv` from `DailyAccountSnapshot.brokerNetLiquidationValue` for that account/date
+  if present; `reconcileDelta = brokerNlv - totalValue` (else null).
+
+## Files to create
+
+- `src/lib/analysis/value-snapshot-engine.ts` — pure-ish function:
+  `computeAccountValueForDate(holdings, marksByKey, cashValue, brokerNlv?) => {...}`.
+- `src/lib/analysis/backfill-value-snapshots.ts` — orchestration over accounts × trading days.
+- `scripts/backfill-value-snapshots.ts` — `tsx` CLI (mirror `scripts/rebuild-pnl.ts`).
+- Tests: `value-snapshot-engine.test.ts`.
+- `package.json`: add `backfill:value-snapshots` script.
+- `04-cash-rowtypes.md` — short note documenting the `CashEvent.rowType` treatment (output of
+  the sub-task above).
+
+## Trading-day calendar
+
+Use the set of `markDate`s present in `HistoricalMark` as the trading-day calendar (the flat
+files only exist for trading days). Iterate those dates within range rather than all calendar
+days — this avoids producing snapshots for weekends/holidays and keeps the series aligned to
+real market days. Restrict to dates `>= ` the account's first `Execution.tradeDate`.
+
+## Performance
+
+- Batch-load `HistoricalMark` for the full range + symbol universe once into an in-memory
+  `Map<instrumentKey, Map<markDateISO, close/high/low>>`, rather than querying per day.
+- Batch-load executions, matched lots, adjustments, and cash events per account once; pass
+  slices to the engine. Don't re-query inside the day loop.
+- Upsert snapshots in chunks (e.g. `Promise.all` over batches) to keep the DB busy without
+  exhausting the pool.
+
+## CLI contract
+
+```
+npm run backfill:value-snapshots -- [--accountIds id1,id2] [--start YYYY-MM-DD] [--end YYYY-MM-DD]
+# no --accountIds => all accounts
+# no --start      => earliest Execution.tradeDate across scope
+# no --end        => latest HistoricalMark.markDate (or yesterday)
+```
+
+Idempotent: re-running upserts (unique `(accountId, snapshotDate)`), so it can run after
+story 07 lands to fill option values.
+
+## Acceptance criteria
+
+- [ ] Engine splits value into cash/equity/option/total and counts unpriced positions.
+- [ ] `cashValue` uses `startingCapital + cumulative CashEvent` with documented rowType
+      treatment (`04-cash-rowtypes.md`).
+- [ ] `brokerNlv` + `reconcileDelta` populated when a `DailyAccountSnapshot` exists for the
+      day; null otherwise.
+- [ ] Iterates only real trading days (from `HistoricalMark`), from first trade date forward.
+- [ ] Upserts are idempotent; re-run after option ingest fills `optionValue`.
+- [ ] Engine is unit-tested (mark hit, mark miss → unpriced, option ×100, reconcile delta,
+      missing broker NLV).
+- [ ] `npm run typecheck && npm run lint && npm test` pass.
+
+## Test plan
+
+`value-snapshot-engine.test.ts` (vitest), fixture holdings + a marks map:
+
+1. Equity + option both priced → correct split, total, source.
+2. Option mark missing → counted in `unpricedPositionCount`, valued 0, equity still correct.
+3. Broker NLV present → `reconcileDelta = brokerNlv - total`.
+4. Broker NLV absent → `brokerNlv` and `reconcileDelta` null.
+5. Cash-only account (no holdings) → `totalValue == cashValue`.
+
+(The orchestrator/CLI is validated by manual smoke against a seeded DB; the engine carries
+the unit coverage.)
+
+## Dependencies
+
+Stories 01, 02, 03. (07 optional — engine handles missing option marks gracefully until
+then.)

--- a/docs/account-value-curve/05-value-series-api.md
+++ b/docs/account-value-curve/05-value-series-api.md
@@ -1,0 +1,103 @@
+# Story 05 — API: GET /api/analysis/account-value-series
+
+## Context primer
+
+Read `00-overview.md` §3 (API conventions). With `AccountValueSnapshot` materialized by story
+04, this story exposes it as a JSON series the Analysis page consumes. Follow the exact
+patterns in `src/app/api/overview/summary/route.ts`: scope parsing via
+`src/lib/api/account-scope.ts`, response via `detailResponse`/`errorResponse`, types in
+`src/types/api.ts`.
+
+## Goal
+
+`GET /api/analysis/account-value-series?accountIds=<csv>&startDate=<YYYY-MM-DD>&endDate=<YYYY-MM-DD>`
+returns the daily, **account-summed** value series for the scope, plus per-day data-quality
+fields and a small summary.
+
+## Out of scope
+
+- Computing values (story 04 owns that; this route only reads `AccountValueSnapshot`).
+- MFE/MAE (story 08 adds its own endpoint).
+
+## Files to create/modify
+
+- `src/app/api/analysis/account-value-series/route.ts`
+- `src/app/api/analysis/account-value-series/route.test.ts`
+- `src/types/api.ts` — add the response type.
+
+## Behavior
+
+1. Parse `accountIds` (`parseAccountIds`), `startDate`/`endDate` (`parseDateRangeParams`,
+   `toEndOfDayUtcIso`). No scope = all accounts (match `summary/route.ts` semantics).
+2. Resolve internal account ids (`buildAccountIdWhere`) like `summary/route.ts` does.
+3. Query `AccountValueSnapshot` for those accounts within the date range, ordered by
+   `snapshotDate asc`.
+4. **Aggregate across accounts per date** (the screen shows the combined portfolio):
+   - `cash`, `stockEtf` (= equityValue), `options` (= optionValue), `total` summed.
+   - `brokerNlv`: sum only when **every** in-scope account has a `brokerNlv` for that date;
+     otherwise null (so the overlay doesn't show a misleading partial total). Track an
+     `brokerNlvComplete` boolean per point.
+   - `unpricedPositionCount`: sum.
+   - `reconcileDelta`: `brokerNlv - total` when `brokerNlvComplete`, else null.
+5. Return the series + a summary (first/last total, min/max, count of unpriced days).
+
+## Response shape (add to `src/types/api.ts`)
+
+```ts
+export interface AccountValueSeriesPoint {
+  date: string;                 // YYYY-MM-DD
+  cash: string;                 // Decimal as string, 2dp
+  stockEtf: string;
+  options: string;
+  total: string;
+  brokerNlv: string | null;     // null unless all in-scope accounts have it that day
+  reconcileDelta: string | null;
+  unpricedPositionCount: number;
+}
+
+export interface AccountValueSeriesResponse {
+  points: AccountValueSeriesPoint[];
+  meta: {
+    accountCount: number;
+    startDate: string | null;
+    endDate: string | null;
+    daysWithUnpriced: number;
+    firstTotal: string | null;
+    lastTotal: string | null;
+  };
+}
+```
+
+Wrap in `detailResponse(payload)`.
+
+## Notes
+
+- Format money with `.toFixed(2)` for display fields, mirroring `summary/route.ts`'s
+  `snapshotSeries` formatting (the curve doesn't need 6dp precision in the wire format).
+- Empty result (no snapshots in range) → `points: []` with a populated `meta` (not a 404).
+- This route is read-only and cheap; no MCP/S3 calls.
+
+## Acceptance criteria
+
+- [ ] Route returns the aggregated daily series for the scope + range.
+- [ ] `brokerNlv`/`reconcileDelta` null unless all in-scope accounts have broker NLV that day.
+- [ ] `unpricedPositionCount` summed per day; `meta.daysWithUnpriced` correct.
+- [ ] Account + date scoping matches `summary/route.ts` semantics (no scope = all).
+- [ ] Response typed in `src/types/api.ts`; `detailResponse` used.
+- [ ] `npm run typecheck && npm run lint && npm test` pass.
+
+## Test plan
+
+`route.test.ts` (vitest), following `summary/route.test.ts` style (seed via Prisma test
+helpers or mock). Cases:
+
+1. Two accounts, overlapping dates → values summed per date.
+2. One account missing broker NLV on a date → `brokerNlv` null that day even if the other has
+   it.
+3. Date-range filter excludes out-of-range snapshots.
+4. Unpriced counts aggregate and surface in `meta.daysWithUnpriced`.
+5. Empty range → `points: []`, valid `meta`.
+
+## Dependencies
+
+Stories 01, 04 (needs materialized `AccountValueSnapshot` rows).

--- a/docs/account-value-curve/06-analysis-ui.md
+++ b/docs/account-value-curve/06-analysis-ui.md
@@ -1,0 +1,78 @@
+# Story 06 — Analysis-Page UI: Account Value Curve Widget
+
+## Context primer
+
+Read `00-overview.md` §3. The Analysis page is `src/app/analytics/page.tsx` (a client
+component) and already consumes `useAccountFilterContext()` (selected accounts) and
+`RangeFilterContext` (date range), and uses `applyAccountIdsToSearchParams` +
+`applyRangeToSearchParams` to build query strings — copy that fetch pattern exactly. Charts
+use `recharts` (already a dependency). Money formatting helpers live in
+`src/components/widgets/utils` (`formatCurrency`, `safeNumber`).
+
+## Goal
+
+Add a widget that fetches `GET /api/analysis/account-value-series` (story 05) and renders:
+
+- A **stacked area** of `cash` + `stockEtf` + `options` (the composition).
+- A **total** line on top.
+- An optional **broker NLV** overlay line (dashed) where present.
+- A **data-quality caveat** when any day has `unpricedPositionCount > 0` or broker NLV is
+  incomplete.
+
+## Out of scope
+
+- MFE/MAE visuals (story 08).
+- Changing global layout/navigation beyond mounting the widget on the Analysis page.
+
+## Files to create/modify
+
+- `src/components/widgets/AccountValueCurveWidget.tsx` (new)
+- `src/app/analytics/page.tsx` (mount the widget, wired to account + range context)
+- Optional: `src/components/widgets/AccountValueCurveWidget.test.tsx` (render smoke test if
+  the repo tests components; otherwise rely on typecheck/lint).
+
+## Behavior
+
+- Re-fetch when `selectedAccounts`, `range.startDate`, or `range.endDate` change (same
+  dependency pattern as the existing `loadSetups` effect in `analytics/page.tsx`). Use
+  `cache: "no-store"`.
+- Build query with `applyAccountIdsToSearchParams(query, selectedAccounts)` and
+  `applyRangeToSearchParams(query)`.
+- Map `AccountValueSeriesPoint[]` to recharts data. Stacked `Area`s: `cash`, `stockEtf`,
+  `options` (consistent colors; cash bottom). A `Line` for `total`. A dashed `Line` for
+  `brokerNlv` (recharts skips null points).
+- **Empty state:** if `points` is empty, show "No value history yet — run the value-snapshot
+  backfill" (mirror existing empty-state copy tone).
+- **Caveat banner:** if `meta.daysWithUnpriced > 0`, show a small inline note: "N days have
+  positions without historical marks; those are valued at 0 and the total may be understated."
+  If broker NLV is incomplete on shown days, note "broker NLV shown only on days where all
+  selected accounts reported it."
+
+## UI/format notes
+
+- Tooltip: show date + cash/stock-ETF/options/total formatted via `formatCurrency`, plus
+  `reconcileDelta` when present ("Broker vs reconstructed: ±$X").
+- Use `ResponsiveContainer` like the existing analytics bar chart.
+- Keep the KPI/section styling consistent with `KpiCard` and the surrounding page.
+- No new chart library — recharts only.
+
+## Acceptance criteria
+
+- [ ] Widget fetches the series scoped to current accounts + range and re-fetches on change.
+- [ ] Stacked area (cash/stock-ETF/options) + total line render; broker NLV overlay appears
+      only where present.
+- [ ] Empty and caveat states implemented.
+- [ ] Mounted on the Analysis page without breaking existing widgets.
+- [ ] `npm run typecheck && npm run lint && npm test` pass.
+
+## Test plan
+
+- Typecheck/lint are the primary gate (matches how the page is currently covered).
+- If adding a render test, mock `fetch` to return a small `AccountValueSeriesResponse` and
+  assert the chart container + caveat render. Otherwise document a manual check: select
+  accounts/range, confirm the curve and tooltip.
+
+## Dependencies
+
+Story 05 (the API). Visually complete with equities only; option areas fill in after story 07
++ re-running the story-04 backfill.

--- a/docs/account-value-curve/07-options-history.md
+++ b/docs/account-value-curve/07-options-history.md
@@ -1,0 +1,120 @@
+# Story 07 — Option Historical Marks: OPRA Flat Files + OCC Parser
+
+## Context primer
+
+Read `00-overview.md` §7 (keys) and §9. This is the **riskiest** story — historical option
+marks. The existing `kapman-trader` options code
+(`core/providers/market_data/polygon_options.py`, `core/ingestion/options/`) uses the
+**live snapshot** endpoint (`/v3/snapshot/options/{underlying}`) and is **not** a source of
+historical OHLC — do not copy it for this. Instead, reuse the **same S3 flat-file machinery
+from story 03** pointed at the **OPRA options** dataset.
+
+## Goal
+
+Daily OHLC for every option **contract** the accounts ever held, written into
+`HistoricalMark` (`assetClass = OPTION`, `source = MASSIVE_S3`), keyed by the canonical option
+`instrumentKey` (§7) so the story-04 engine can value option holdings.
+
+## Recommended approach: spike first
+
+Before committing to a full backfill, **spike against 5–10 real closed option lots**:
+
+1. Pick lots from `MatchedLot` joined to their option `Execution`s.
+2. Confirm the OPRA flat-file prefix and key layout in the Massive bucket (likely
+   `us_options_opra/day_aggs_v1/{YYYY}/{MM}/{YYYY-MM-DD}.csv.gz`; verify by listing).
+3. Confirm the CSV's contract identifier column (an OCC ticker like `O:SPY260116C00500000`)
+   and OHLC columns.
+4. Verify a known contract's close on a known date is plausible vs the executed price.
+
+Write the spike findings into `07-opra-findings.md` (prefix, columns, coverage gaps observed)
+before building the full ingester. If OPRA flat files are unavailable on the plan, fall back
+to Polygon REST `/v2/aggs/ticker/{occTicker}/range/1/day/{from}/{to}` per held contract
+(document the switch; it's more calls but bounded by the number of distinct contracts held).
+
+## OCC ↔ canonical conversion (shared contract — must be correct)
+
+OCC ticker format: `O:` + underlying (padded) + `YYMMDD` + `C`/`P` + strike×1000 as 8 digits.
+
+```
+O:SPY260116C00500000
+   └─SPY  └26 01 16  └C  └00500000  => strike 500.000
+```
+
+Implement and unit-test both directions:
+
+```ts
+// "SPY|CALL|500|2026-01-16"  <->  "O:SPY260116C00500000"
+export function occToCanonical(occ: string): { instrumentKey: string; underlying: string; ... };
+export function canonicalToOcc(instrumentKey: string): string;
+```
+
+- Strike: OCC integer = strike × 1000 (8 digits). Format canonical strike to match how
+  holdings store it (`buildOptionInstrumentKey` uses the numeric strike, e.g. `500`, not
+  `500.0`) — normalize to avoid join misses (e.g. trailing-zero/decimal mismatches). Add tests
+  for fractional strikes (e.g. `7.5`).
+- Expiration: OCC `YYMMDD` ↔ canonical `YYYY-MM-DD`.
+
+> Join correctness lives or dies here. A mismatch between the strike formatting used by
+> `compute-holdings-asof` (`instrumentKey`) and by this converter means option holdings will
+> silently show as **unpriced**. Add a test that round-trips a holding's `instrumentKey`
+> through `canonicalToOcc(occToCanonical(...))`.
+
+## Files to create
+
+- `src/lib/marketdata/occ-ticker.ts` + `occ-ticker.test.ts` — the converters above.
+- `src/lib/marketdata/option-day-aggs-parser.ts` + test — parse OPRA day file rows; map OCC →
+  canonical; filter to the held-contract set.
+- `src/lib/marketdata/ingest-option-marks.ts` — orchestration → upsert `HistoricalMark`.
+- `scripts/ingest-option-marks.ts` — `tsx` CLI.
+- `.env.example`: add `POLYGON_S3_OPTIONS_PREFIX=us_options_opra/day_aggs_v1` (verify in
+  spike) and, if using the REST fallback, `POLYGON_API_KEY`.
+- `package.json`: `ingest:option-marks` script.
+- `07-opra-findings.md` — spike output.
+
+## Implementation notes
+
+- **Reuse** `src/lib/marketdata/s3-flatfiles.ts` from story 03 (parameterize the prefix); do
+  not duplicate the S3 client/listing logic.
+- Held-contract set = distinct option `instrumentKey`s from
+  `computeHoldingsAsOf` across the full history (or distinct option `Execution`s). Convert each
+  to OCC and filter the day file to those, so we don't store the entire OPRA universe (it is
+  enormous — filtering is mandatory, not optional).
+- `markDate` from the S3 key (calendar day). Upsert on `(instrumentKey, markDate)`.
+- A contract with no row on a day (illiquid / no trades) → no mark; story 04 handles the gap
+  via its lookback window / unpriced count.
+
+## CLI contract
+
+```
+npm run ingest:option-marks -- [--start YYYY-MM-DD] [--end YYYY-MM-DD] [--contracts <canonicalKey,...>]
+# defaults: all held option contracts, earliest option trade date -> yesterday
+```
+
+## After this story
+
+Re-run story 04 (`npm run backfill:value-snapshots`) — it is idempotent and will now populate
+`optionValue`. The story-06 chart's options area fills in with no UI change.
+
+## Acceptance criteria
+
+- [ ] `occToCanonical`/`canonicalToOcc` correct and round-trip-tested, incl. fractional
+      strikes; round-trips a real holding `instrumentKey`.
+- [ ] Reuses story-03 S3 module (no duplicated S3 client).
+- [ ] Filters OPRA day files to held contracts; upserts `HistoricalMark` (`OPTION`)
+      idempotently.
+- [ ] Spike findings recorded in `07-opra-findings.md` (prefix, columns, coverage); REST
+      fallback documented if used.
+- [ ] `npm run typecheck && npm run lint && npm test` pass.
+
+## Test plan
+
+- `occ-ticker.test.ts`: known conversions both directions; fractional strike (`7.5`);
+  round-trip property; underlying with non-3-letter symbol.
+- `option-day-aggs-parser.test.ts`: gzipped CSV fixture with a couple of OCC rows → parsed,
+  mapped to canonical keys, filtered to the held set.
+- Manual smoke: ingest one real held contract over its holding window; confirm marks land and
+  re-running story 04 produces non-zero `optionValue`.
+
+## Dependencies
+
+Stories 01, 03 (S3 module). Consumed by 04 (re-run) and 08.

--- a/docs/account-value-curve/08-mfe-mae.md
+++ b/docs/account-value-curve/08-mfe-mae.md
@@ -1,0 +1,97 @@
+# Story 08 — MFE / MAE per Matched Lot + UI
+
+## Context primer
+
+Read `00-overview.md` §1, §8 (definitions). MFE = Maximum Favorable Excursion (best
+unrealized gain during a lot's holding window); MAE = Maximum Adverse Excursion (worst
+unrealized loss). Computed **per `MatchedLot`** using daily **high/low** from `HistoricalMark`
+(stories 03 + 07). Results persist to `LotExcursion` (story 01) and surface on the Analysis
+page.
+
+## Goal
+
+1. A compute engine that, for each closed `MatchedLot`, walks its holding window day-by-day
+   and finds the favorable/adverse extremes, writing `LotExcursion`.
+2. A CLI job to (re)compute excursions for all lots.
+3. UI: per-lot MFE/MAE columns + a small distribution visual on the Analysis page.
+
+## Out of scope
+
+- Open (unclosed) lots may optionally be included (window end = today); make it a CLI flag,
+  default closed-only.
+- Intraday excursion (decision: daily high/low only).
+
+## Excursion math
+
+For a lot with open execution price `entry`, signed direction (long if net long, short if net
+short), quantity `qty`, multiplier `mult` (100 for options, 1 equity), over trading days `d`
+in `[openTradeDate, closeTradeDate]` (inclusive) with marks `high_d`, `low_d`:
+
+- **Long:**
+  - favorable extreme price = `max over d of high_d`; `MFE$ = (favHigh - entry) * qty * mult`
+  - adverse extreme price = `min over d of low_d`; `MAE$ = (advLow - entry) * qty * mult`
+- **Short:** signs invert:
+  - `MFE$ = (entry - min low_d) * qty * mult`
+  - `MAE$ = (entry - max high_d) * qty * mult`
+- `MFE$ >= 0` and `MAE$ <= 0` in the normal case; store raw computed values regardless.
+- `mfePct = MFE$ / |costBasis|`, `maePct = MAE$ / |costBasis|` (null if cost basis 0).
+- `mfeDate` / `maeDate` = the day the extreme occurred.
+- `pricedDays` / `unpricedDays` = window days with / without a usable mark. If
+  `pricedDays == 0`, write the row with zeros and `unpricedDays` set (so the UI can flag "no
+  marks").
+
+Instrument: a lot's `instrumentKey` comes from its open execution (equity symbol or canonical
+option key per §7). Use the same lookback/window rules story 04 uses for missing days.
+
+## Files to create/modify
+
+- `src/lib/analysis/compute-lot-excursion.ts` + `compute-lot-excursion.test.ts` — pure engine
+  given (lot, entry, direction, marks-by-date).
+- `src/lib/analysis/backfill-lot-excursions.ts` — orchestration over `MatchedLot`s.
+- `scripts/backfill-lot-excursions.ts` — `tsx` CLI; `package.json` script
+  `backfill:lot-excursions`.
+- `src/app/api/analysis/excursions/route.ts` (+ test) — read endpoint, OR extend
+  `/api/matched-lots` to include `excursion` (prefer a dedicated route to avoid disturbing the
+  existing matched-lots contract). Add response type to `src/types/api.ts`.
+- UI: `src/components/widgets/ExcursionWidget.tsx` mounted on `src/app/analytics/page.tsx`,
+  plus MFE/MAE columns in the matched-lots table if one is shown there.
+
+## UI
+
+- Per-lot: MFE$, MAE$, MFE%, MAE% columns (sortable, consistent with the existing analytics
+  table sorting in `analytics/page.tsx`).
+- Distribution visual (recharts): e.g. a scatter of MFE% (y) vs realized return, or paired
+  bars of MFE/MAE per symbol/setup. Keep it simple; reuse the page's chart styling.
+- Flag lots with `unpricedDays > 0` (excursion may be understated).
+
+## Performance
+
+Batch-load all `MatchedLot`s (with open/close execution dates, price, qty, instrument) and all
+relevant `HistoricalMark` rows once; build an in-memory marks map keyed by
+`instrumentKey → date → {high, low}`. Compute in memory; bulk upsert `LotExcursion`.
+
+## Acceptance criteria
+
+- [ ] Engine computes MFE/MAE ($ and %), extreme dates, priced/unpriced day counts, for long
+      and short, equity and option (×100).
+- [ ] Excursions persist to `LotExcursion` (1:1 with `MatchedLot`); CLI is idempotent.
+- [ ] Read endpoint returns per-lot excursions scoped by account/date/setup like sibling
+      analytics routes.
+- [ ] Analysis page shows per-lot MFE/MAE + a distribution visual; flags unpriced windows.
+- [ ] `npm run typecheck && npm run lint && npm test` pass.
+
+## Test plan
+
+`compute-lot-excursion.test.ts` (vitest):
+
+1. Long equity, marks rising then falling → MFE at the peak high, MAE at the trough low;
+   correct dates.
+2. Short option (×100) → signs invert; MFE from the lowest low.
+3. Window with a missing mark day → counted in `unpricedDays`, not crashing.
+4. Zero-cost-basis edge → `mfePct`/`maePct` null.
+5. `pricedDays == 0` → zeros + unpriced flag.
+
+## Dependencies
+
+Stories 01, 02, and marks from 03 (equity) and 07 (option). Equity-only MFE/MAE can ship
+before 07; option lots will show `unpricedDays` until option marks exist.

--- a/docs/account-value-curve/README.md
+++ b/docs/account-value-curve/README.md
@@ -1,0 +1,165 @@
+# Account Value Curve & Excursion Analysis — Spec Index
+
+This folder is a **Codex/Windsurf-ready specification** for adding two features to the
+Analysis page:
+
+1. A **daily account-value curve** over any selected accounts/range, split into
+   **cash / stock-ETF / options / total**, with broker NLV shown as a reconciliation overlay.
+2. **MFE / MAE** (max favorable / adverse excursion) **per matched lot**.
+
+> **Start with [`00-overview.md`](./00-overview.md).** It is the shared context primer —
+> locked decisions, what already exists, the canonical instrument-key contract, and the
+> conventions every story must follow. Then work the stories in dependency order below.
+
+## Stories
+
+| # | File | Output | Depends on |
+|---|---|---|---|
+| 00 | [`00-overview.md`](./00-overview.md) | Primer / shared context | — |
+| 01 | [`01-data-model.md`](./01-data-model.md) | Prisma models + migration | — |
+| 02 | [`02-asof-holdings.md`](./02-asof-holdings.md) | `computeHoldingsAsOf()` | 01 |
+| 03 | [`03-polygon-ingest.md`](./03-polygon-ingest.md) | Equity marks (S3 flat-file, TS port) | 01 |
+| 04 | [`04-backfill-job.md`](./04-backfill-job.md) | Daily valuation → `AccountValueSnapshot` | 01,02,03 |
+| 05 | [`05-value-series-api.md`](./05-value-series-api.md) | `GET /api/analysis/account-value-series` | 01,04 |
+| 06 | [`06-analysis-ui.md`](./06-analysis-ui.md) | Stacked-area value-curve widget | 05 |
+| 07 | [`07-options-history.md`](./07-options-history.md) | Option marks (OPRA + OCC parser) | 01,03 |
+| 08 | [`08-mfe-mae.md`](./08-mfe-mae.md) | `LotExcursion` engine + MFE/MAE UI | 01,02,03,07 |
+
+## Build order
+
+```
+01 ─┬─> 02 ─┐
+    ├─> 03 ─┼─> 04 ─> 05 ─> 06     ← equity-only screen ships here (usable)
+    │       │
+    └────── 07 ───────┘            ← adds option marks; then re-run 04
+02 + (03|07) ─> 08                  ← MFE/MAE
+```
+
+**Ship 01→06 with equities first** (cash + stock/ETF + total; options show as "unpriced"
+until 07). Then 07 + re-run the story-04 backfill fills option values with no UI change;
+08 adds MFE/MAE.
+
+## How to feed this to Codex (Windsurf)
+
+- Hand Codex **one story at a time**, in the order above. Each file is self-contained:
+  *Context primer → Goal → Out-of-scope → Files → inline schema/algorithm → Acceptance
+  criteria → Test plan → Dependencies*.
+- Every story's gate is the same: `npm run typecheck && npm run lint && npm test`.
+- Stories 03 and 07 cite exact reference files in the sibling **`kapman-trader`** repo — point
+  Codex at those so it ports proven S3 flat-file logic instead of inventing it.
+- Two empirical sub-tasks are intentionally deferred to in-repo notes (do them with the live
+  DB/bucket in hand): `CashEvent.rowType` treatment → `04-cash-rowtypes.md`; OPRA
+  prefix/columns → `07-opra-findings.md`.
+
+---
+
+## Deployment & migrations (local-first → Fly.io)
+
+> **Short answer to "won't migrations need to occur?":** Yes — but the mechanism is already
+> wired. The new tables migrate automatically. The *data backfill* is the part that is **not**
+> automatic and must be run as a separate job.
+
+### What changes across the stories (deploy-relevant)
+
+| Change | Introduced in | Deploy impact |
+|---|---|---|
+| New tables (`HistoricalMark`, `AccountValueSnapshot`, `LotExcursion`) | 01 | A Prisma **migration** — applied automatically (see below) |
+| New npm dep `@aws-sdk/client-s3` | 03 | Baked into the Docker image at build (`npm ci`) — no action |
+| New env vars (S3/Polygon creds + prefixes) | 03, 07 | **Must be set as Fly secrets** before the backfill jobs can run |
+| Ingestion + backfill CLI scripts (`tsx`) | 03, 04, 07, 08 | **Run manually** — not part of the web deploy |
+
+### How migrations run here (already configured)
+
+- **Local:** `scripts`/`dev:container` and the local flow use `prisma migrate dev` (creates
+  the migration file) and `prisma migrate deploy` (applies committed migrations). `docker
+  compose` runs `prisma migrate deploy` on app start.
+- **Fly.io:** `fly.toml` has `release_command = "npx prisma migrate deploy"`. Fly runs this in
+  a **release step on every `fly deploy`, before the new version goes live**, against the
+  production `DATABASE_URL`. So committing the story-01 migration and deploying is enough to
+  create the tables in prod — no manual prod migration step.
+
+### Recommended sequence: validate locally, then promote
+
+**1 — Create + apply the migration locally (story 01)**
+```bash
+docker compose up -d db                 # local Postgres on :55432 (or your existing local DB)
+npx prisma migrate dev --name add_value_curve_models
+npm run typecheck && npm run test
+```
+This writes a migration file under `prisma/migrations/` — **commit it**. (`migrate dev` is
+local-only; never run it against prod. Prod uses `migrate deploy`.)
+
+**2 — Set credentials locally, run a SMALL ingest + backfill (stories 03/04)**
+```bash
+# put S3_ENDPOINT_URL / S3_BUCKET / AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
+# and the *_PREFIX vars in your local .env (see .env.example after story 03)
+npm run ingest:equity-marks  -- --symbols AAPL,MSFT --start 2024-01-01 --end 2024-01-31
+npm run backfill:value-snapshots -- --start 2024-01-01 --end 2024-01-31
+npm run dev                              # open the Analysis page, confirm the curve renders
+```
+Keep the first run tiny (a couple symbols, one month) to validate end-to-end before a
+full-history pull.
+
+**3 — Set the same secrets on Fly (one-time, before deploy)**
+```bash
+fly secrets set \
+  S3_ENDPOINT_URL='https://files.massive.com' \
+  S3_BUCKET='flatfiles' \
+  AWS_ACCESS_KEY_ID='...' \
+  AWS_SECRET_ACCESS_KEY='...' \
+  POLYGON_S3_EQUITY_PREFIX='us_stocks_sip/day_aggs_v1' \
+  POLYGON_S3_OPTIONS_PREFIX='us_options_opra/day_aggs_v1' \
+  -a kapman-tradelog
+```
+(Add `POLYGON_API_KEY` only if story 07 uses the REST fallback.)
+
+**4 — Deploy (migration runs automatically)**
+```bash
+fly deploy -a kapman-tradelog
+# Fly runs `npx prisma migrate deploy` as the release_command → tables created in prod.
+```
+
+**5 — Run the backfill against prod data (separate, deliberate step)**
+
+The tables exist after step 4, but they are **empty** — the curve/MFE-MAE screens will show
+their empty state until a backfill populates them. Two safe ways to run the one-time historical
+backfill:
+
+- **Option A (recommended for the one-time full backfill): run locally, pointed at prod DB.**
+  You control concurrency and don't load the web machine.
+  ```bash
+  DATABASE_URL='<prod-connection-string>' npm run ingest:equity-marks
+  DATABASE_URL='<prod-connection-string>' npm run ingest:option-marks      # after story 07
+  DATABASE_URL='<prod-connection-string>' npm run backfill:value-snapshots
+  DATABASE_URL='<prod-connection-string>' npm run backfill:lot-excursions  # after story 08
+  ```
+  Use the prod DB's direct/external connection string; double-check you're pointed at the
+  right DB before running.
+
+- **Option B: run inside Fly.** `tsx` is present in the image (it's installed by `npm ci`), so:
+  ```bash
+  fly ssh console -a kapman-tradelog
+  # then, inside the machine:
+  npm run ingest:equity-marks && npm run backfill:value-snapshots
+  ```
+  Fine for incremental/daily runs; for the heavy first backfill prefer Option A or a one-off
+  machine so you don't disrupt the running web service.
+
+**6 — Keep it current (later).** The same jobs are idempotent; schedule a daily incremental
+(yesterday's marks + a one-day valuation/excursion update). Wire it via a Fly scheduled
+machine / cron once the one-time backfill looks right. Re-running story 04 after story 07 lands
+is the mechanism that fills option values in.
+
+### Gotchas to remember
+
+- **Migration order:** the story-01 migration must be committed and deployed **before** any
+  job that writes the new tables runs in prod. Step 1 + 4 cover this.
+- **Empty ≠ broken:** after deploy, an empty Analysis curve means "no backfill yet," not a bug
+  (story 06 ships an explicit empty state for exactly this).
+- **Secrets before jobs:** the S3/Polygon secrets (step 3) gate the ingestion jobs — the web
+  app and migrations work without them; only the marks pull needs them.
+- **Don't `migrate dev` on prod:** prod only ever runs `migrate deploy` (via the
+  release_command). `migrate dev` can reset/rewrite history and is local-only.
+- **Reconciliation will show deltas:** `reconcileDelta`/`unpricedPositionCount` are surfaced
+  on purpose. Non-zero values are expected (dividends, assignments, fees) — investigate, don't
+  panic.


### PR DESCRIPTION
Closes #262

## What

Adds a Codex/Windsurf-ready specification set under `docs/account-value-curve/` for two Analysis-page features:

1. **Daily account-value curve** — cash / stock-ETF / options / total over selected accounts/range, with broker NLV as a reconciliation overlay.
2. **MFE / MAE per matched lot** — max favorable / adverse excursion from daily high/low.

## Scope

**Documentation only.** No application code, Prisma schema, or dependency changes. Implementation is decomposed into per-story files to be executed separately.

## Contents

- `README.md` — index, dependency graph, and a local-first → Fly.io deploy/migration runbook
- `00-overview.md` — primer: locked decisions, existing-vs-gaps, canonical instrument-key contract, conventions
- `01`–`08` — self-contained story specs (data model, as-of holdings engine, equity S3 ingest, valuation backfill, read API, UI, options history, MFE/MAE), each with inline schema, acceptance criteria, and test plans
- Stories 03/07 cite the sibling `kapman-trader` repo's S3 flat-file ingestion as reference impl

## Validation

- `npm run typecheck` → 0
- `npm run lint` → 0
- `npm test` → 262 passed (68 files)

Docs-only change; introduces no runtime behavior.