### PR TITLE
fix: reconstruct account value cash from trade flows

### DIFF
--- a/docs/account-value-curve/04-cash-rowtypes.md
+++ b/docs/account-value-curve/04-cash-rowtypes.md
@@ -11,18 +11,20 @@ Local DB row types observed before implementing the backfill:
 | MONEY_MARKET_REDEEM | 9 | 27626.68 |
 | TRANSFER_IN | 1 | 52973.60 |
 
-Treatment for Story 04:
+Treatment for Story 04 after cash-reconstruction correction:
 
-- Include all persisted `CashEvent.amount` rows in the cumulative cash ledger:
-  `startingCapital + sum(CashEvent.amount where eventDate <= D)`.
+- Include trade cash flows derived from executions in the cumulative cash ledger:
+  buys reduce cash, sells increase cash, and options use a 100x multiplier.
+- Include external persisted `CashEvent.amount` rows in the cumulative cash ledger:
+  `startingCapital + trade cash + external CashEvent.amount where date <= D`.
 - Do not include `TRD` cash-balance rows here. The thinkorswim parser uses `TRD` rows as trade
   references/fee enrichment, not persisted `CashEvent` rows, so trade proceeds are not counted
   twice against reconstructed holdings.
 - `FND`, `DIVIDEND`, and `TRANSFER_IN` are direct cash movements.
-- `MONEY_MARKET_*` rows are kept because this app stores them as cash events, not valued
-  positions. If those rows prove to be pure sweep bookkeeping for a given account export, the
-  resulting mismatch remains visible as `reconcileDelta` against broker NLV instead of being
-  hidden.
+- `MONEY_MARKET_*` and `REDEMPTION` rows are internal cash-equivalent sweep bookkeeping for
+  the reconstructed value curve. They are excluded from `cashValue` because trade cash flows
+  already capture buying-power changes; including sweeps would double-count internal movement
+  between cash and money-market funds.
 
-This matches the locked story decision that `CashEvent` is the cash source of truth while
-`DailyAccountSnapshot.totalCash` and broker NLV are reconciliation checks.
+This keeps reconstructed cash from double-counting deployed capital while preserving
+`DailyAccountSnapshot.totalCash` and broker NLV as reconciliation checks.

--- a/src/lib/analysis/backfill-value-snapshots.test.ts
+++ b/src/lib/analysis/backfill-value-snapshots.test.ts
@@ -1,15 +1,12 @@
 import { Prisma } from "@prisma/client";
 import { describe, expect, it } from "vitest";
-import { cumulativeLedgerAmountForCashEvent } from "./backfill-value-snapshots";
+import { cumulativeLedgerAmountForCashEvent, reconstructedTradeCashDelta } from "./backfill-value-snapshots";
 
 describe("cumulativeLedgerAmountForCashEvent", () => {
-  it("includes every persisted cash-event row type in the reconstructed cash ledger", () => {
+  it("includes external cash-event row types in the reconstructed cash ledger", () => {
     const rows = [
       ["DIVIDEND", "6.55", 6.55],
       ["FND", "24761.54", 24761.54],
-      ["MONEY_MARKET_BUY", "-80476.91", -80476.91],
-      ["MONEY_MARKET_DIVIDEND", "0", 0],
-      ["MONEY_MARKET_REDEEM", "27626.68", 27626.68],
       ["TRANSFER_IN", "52973.60", 52973.6],
     ] as const;
 
@@ -23,7 +20,29 @@ describe("cumulativeLedgerAmountForCashEvent", () => {
       0,
     );
 
-    expect(total).toBeCloseTo(24891.46, 2);
+    expect(total).toBeCloseTo(77741.69, 2);
+  });
+
+  it("excludes internal money-market cash-equivalent rows from reconstructed cash", () => {
+    const rows = [
+      ["MONEY_MARKET_BUY", "-80476.91"],
+      ["MONEY_MARKET_REDEEM", "27626.68"],
+      ["MONEY_MARKET_EXCHANGE_IN", "-4326.77"],
+      ["MONEY_MARKET_EXCHANGE_OUT", "4326.77"],
+      ["REDEMPTION", "100.00"],
+    ] as const;
+
+    const total = rows.reduce(
+      (sum, [rowType, amount]) =>
+        sum +
+        cumulativeLedgerAmountForCashEvent({
+          rowType,
+          amount: new Prisma.Decimal(amount),
+        }),
+      0,
+    );
+
+    expect(total).toBe(0);
   });
 
   it("does not filter unknown persisted row types at the cumulative ledger boundary", () => {
@@ -33,5 +52,58 @@ describe("cumulativeLedgerAmountForCashEvent", () => {
         amount: new Prisma.Decimal("42.10"),
       }),
     ).toBe(42.1);
+  });
+});
+
+describe("reconstructedTradeCashDelta", () => {
+  it("subtracts equity buys and adds equity sells using quantity times price", () => {
+    expect(
+      reconstructedTradeCashDelta({
+        assetClass: "EQUITY",
+        side: "BUY",
+        quantity: new Prisma.Decimal("10"),
+        price: new Prisma.Decimal("576.26"),
+      }),
+    ).toBeCloseTo(-5762.6, 2);
+
+    expect(
+      reconstructedTradeCashDelta({
+        assetClass: "EQUITY",
+        side: "SELL",
+        quantity: new Prisma.Decimal("5"),
+        price: new Prisma.Decimal("553.10"),
+      }),
+    ).toBeCloseTo(2765.5, 2);
+  });
+
+  it("uses the option multiplier for option trade cash flow", () => {
+    expect(
+      reconstructedTradeCashDelta({
+        assetClass: "OPTION",
+        side: "SELL",
+        quantity: new Prisma.Decimal("2"),
+        price: new Prisma.Decimal("1.84"),
+      }),
+    ).toBeCloseTo(368, 2);
+  });
+
+  it("ignores rows without a trade side or price", () => {
+    expect(
+      reconstructedTradeCashDelta({
+        assetClass: "EQUITY",
+        side: null,
+        quantity: new Prisma.Decimal("10"),
+        price: new Prisma.Decimal("100"),
+      }),
+    ).toBe(0);
+
+    expect(
+      reconstructedTradeCashDelta({
+        assetClass: "EQUITY",
+        side: "BUY",
+        quantity: new Prisma.Decimal("10"),
+        price: null,
+      }),
+    ).toBe(0);
   });
 });

--- a/src/lib/analysis/backfill-value-snapshots.ts
+++ b/src/lib/analysis/backfill-value-snapshots.ts
@@ -52,6 +52,14 @@ type ManualAdjustmentRow = Prisma.ManualAdjustmentGetPayload<{
 
 const FALLBACK_MARK_LOOKBACK_DAYS = 10;
 const UPSERT_BATCH_SIZE = 50;
+const INTERNAL_CASH_EQUIVALENT_ROW_TYPES = new Set([
+  "MONEY_MARKET",
+  "MONEY_MARKET_BUY",
+  "MONEY_MARKET_REDEEM",
+  "MONEY_MARKET_EXCHANGE_OUT",
+  "MONEY_MARKET_EXCHANGE_IN",
+  "REDEMPTION",
+]);
 
 function startOfUtcDay(date: Date): Date {
   return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
@@ -74,9 +82,39 @@ function isOnOrBeforeDate(date: Date, snapshotDate: Date): boolean {
 }
 
 export function cumulativeLedgerAmountForCashEvent(event: { amount: Prisma.Decimal | number; rowType: string }): number {
-  // CashEvent is the ledger boundary: every persisted row type contributes.
-  // TRD cash-balance rows are trade references and should not be persisted here.
+  // Money-market sweep rows move cash into/out of cash-equivalent funds. Trade
+  // cash deltas already capture buying power changes, so including sweeps here
+  // would double-count internal bookkeeping.
+  if (INTERNAL_CASH_EQUIVALENT_ROW_TYPES.has(event.rowType)) {
+    return 0;
+  }
+
   return Number(event.amount);
+}
+
+export function reconstructedTradeCashDelta(execution: {
+  assetClass: string;
+  side: string | null;
+  quantity: Prisma.Decimal | string | number;
+  price: Prisma.Decimal | string | number | null;
+}): number {
+  if (execution.side !== "BUY" && execution.side !== "SELL") {
+    return 0;
+  }
+
+  if (execution.price === null) {
+    return 0;
+  }
+
+  const quantity = Math.abs(Number(execution.quantity));
+  const price = Number(execution.price);
+  if (!Number.isFinite(quantity) || !Number.isFinite(price)) {
+    return 0;
+  }
+
+  const multiplier = execution.assetClass === "OPTION" ? 100 : 1;
+  const grossCashFlow = quantity * price * multiplier;
+  return execution.side === "BUY" ? grossCashFlow * -1 : grossCashFlow;
 }
 
 function toExecutionRecord(row: ExecutionRow): ExecutionRecord {
@@ -355,12 +393,21 @@ export async function backfillValueSnapshots(input: BackfillValueSnapshotsInput 
     const accountAdjustments = adjustments.filter((adjustment) => adjustment.accountId === account.id);
     const accountCashEvents = cashEventRows.filter((event) => event.accountId === account.id);
     const accountFirstTradeDate = firstTradeDateByAccount.get(account.id) ?? null;
+    let executionCashIndex = 0;
     let cashEventIndex = 0;
     let cashValue = Number(account.startingCapital ?? 0);
     let accountSnapshotsUpserted = 0;
 
     for (const tradingDay of tradingDays) {
       const snapshotDate = startOfUtcDay(tradingDay.markDate);
+
+      while (executionCashIndex < accountExecutions.length && isOnOrBeforeDate(new Date(accountExecutions[executionCashIndex]?.tradeDate ?? 0), snapshotDate)) {
+        const execution = accountExecutions[executionCashIndex];
+        if (execution) {
+          cashValue += reconstructedTradeCashDelta(execution);
+        }
+        executionCashIndex += 1;
+      }
 
       while (cashEventIndex < accountCashEvents.length && isOnOrBeforeDate(accountCashEvents[cashEventIndex]?.eventDate ?? new Date(0), snapshotDate)) {
         const cashEvent = accountCashEvents[cashEventIndex];


### PR DESCRIPTION
Closes #284\n\nThis fixes account value snapshots that kept cash at starting capital while adding equity market value on top. Cash reconstruction now includes derived trade cash flows and excludes internal money-market sweep rows from cash events.