### PR TITLE
Add option historical marks ingestion

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,7 @@ S3_BUCKET=flatfiles
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 POLYGON_S3_EQUITY_PREFIX=us_stocks_sip/day_aggs_v1
+POLYGON_S3_OPTIONS_PREFIX=us_options_opra/day_aggs_v1
+# Optional fallback for option historical marks when OPRA S3 objects are not
+# available on the current Massive/Polygon plan.
+POLYGON_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,13 @@ AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 POLYGON_S3_EQUITY_PREFIX=us_stocks_sip/day_aggs_v1
 POLYGON_S3_OPTIONS_PREFIX=us_options_opra/day_aggs_v1
+# Option historical mark ingestion clamps requests to the plan's available
+# history. Default is a two-year rolling window, starting the day after the
+# boundary to avoid out-of-contract calls.
+POLYGON_HISTORICAL_LOOKBACK_YEARS=2
+# Optional exact override if the plan entitlement changes or Massive provides a
+# fixed account-specific start date. Format: YYYY-MM-DD.
+POLYGON_HISTORICAL_MARKS_START_DATE=
 # Optional fallback for option historical marks when OPRA S3 objects are not
 # available on the current Massive/Polygon plan.
 POLYGON_API_KEY=

--- a/docs/account-value-curve/07-opra-findings.md
+++ b/docs/account-value-curve/07-opra-findings.md
@@ -26,3 +26,7 @@ S3 object download returned HTTP 403 with the locally configured plan, so the OP
 - No full OPRA universe storage is performed. Both paths are filtered to explicit or discovered held option contracts.
 - REST fallback smoke succeeded for one recent held contract over `2026-05-28` to `2026-05-29`, upserting 2 local marks.
 - REST fallback for older `2024` option aggregate data returned a plan authorization error, so local historical coverage still depends on the configured Polygon plan.
+- After confirming the plan includes a two-year historical window, retries inside that window succeeded:
+  - REST fallback for `INTC|CALL|34|2024-07-19` over `2024-06-10` to `2024-06-14` upserted 5 marks.
+  - S3 download for `us_options_opra/day_aggs_v1/2024/06/2024-06-10.csv.gz` succeeded and returned the expected OPRA aggregate header.
+- Option mark ingestion now clamps requested/default start dates to the configured Polygon historical access floor. Defaults use a two-year rolling window and start one day after the boundary; override with `POLYGON_HISTORICAL_MARKS_START_DATE=YYYY-MM-DD` if Massive provides an account-specific fixed date.

--- a/docs/account-value-curve/07-opra-findings.md
+++ b/docs/account-value-curve/07-opra-findings.md
@@ -1,0 +1,28 @@
+# Story 07 OPRA Findings
+
+## Spike Date
+
+2026-05-31
+
+## Prefix
+
+- Confirmed listable Massive/Polygon flat-file prefix: `us_options_opra/day_aggs_v1`.
+- Verified key layout by listing January 2024: `us_options_opra/day_aggs_v1/YYYY/MM/YYYY-MM-DD.csv.gz`.
+- January 2024 listing returned 21 trading-day files, starting with `2024-01-02.csv.gz`.
+
+## Columns
+
+S3 object download returned HTTP 403 with the locally configured plan, so the OPRA file header could not be directly read from S3 during the spike. The parser supports the same daily aggregate column families used by Massive/Polygon flat files:
+
+- Contract identifier: `ticker` or `symbol`, expected as OCC ticker, for example `O:SPY260116C00500000`.
+- OHLC: `open/high/low/close` or short-form `o/h/l/c`.
+- Volume: `volume` or short-form `v`.
+
+## Coverage and Fallback
+
+- S3 listing is available, but `GetObject` for `us_options_opra/day_aggs_v1/2024/01/2024-01-02.csv.gz` returned HTTP 403 in local testing. This indicates the current credentials can enumerate OPRA keys but cannot read OPRA day files on the current plan.
+- The implementation keeps the S3 path as the primary ingestion source and adds a bounded REST fallback via `--source rest` using Polygon aggregates for only the held contracts.
+- REST fallback persists marks with `source = POLYGON_REST`; S3 ingestion persists marks with `source = MASSIVE_S3`.
+- No full OPRA universe storage is performed. Both paths are filtered to explicit or discovered held option contracts.
+- REST fallback smoke succeeded for one recent held contract over `2026-05-28` to `2026-05-29`, upserting 2 local marks.
+- REST fallback for older `2024` option aggregate data returned a plan authorization error, so local historical coverage still depends on the configured Polygon plan.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "vitest run",
     "rebuild:pnl": "tsx scripts/rebuild-pnl.ts",
     "ingest:equity-marks": "tsx scripts/ingest-equity-marks.ts",
+    "ingest:option-marks": "tsx scripts/ingest-option-marks.ts",
     "backfill:value-snapshots": "tsx scripts/backfill-value-snapshots.ts",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate deploy",

--- a/scripts/ingest-option-marks.ts
+++ b/scripts/ingest-option-marks.ts
@@ -1,0 +1,105 @@
+import { ingestOptionMarks, type OptionMarksIngestSource } from "../src/lib/marketdata/ingest-option-marks";
+
+interface ParsedArgs {
+  startDate?: Date;
+  endDate?: Date;
+  contracts?: string[];
+  source?: OptionMarksIngestSource;
+}
+
+function parseDateOnly(value: string, flagName: string): Date {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    throw new Error(`Invalid ${flagName} date format: ${value}. Expected YYYY-MM-DD.`);
+  }
+
+  const parsed = new Date(`${value}T00:00:00.000Z`);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`Invalid ${flagName} date value: ${value}.`);
+  }
+
+  return parsed;
+}
+
+function parseContracts(value: string): string[] {
+  return value
+    .split(",")
+    .map((contract) => contract.trim())
+    .filter((contract) => contract.length > 0);
+}
+
+function parseSource(value: string): OptionMarksIngestSource {
+  if (value === "s3" || value === "rest") {
+    return value;
+  }
+
+  throw new Error(`Invalid --source value: ${value}. Expected s3 or rest.`);
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const parsed: ParsedArgs = {};
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+
+    if (token === "--start") {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error("Missing value for --start");
+      }
+      parsed.startDate = parseDateOnly(value, "--start");
+      index += 1;
+      continue;
+    }
+
+    if (token === "--end") {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error("Missing value for --end");
+      }
+      parsed.endDate = parseDateOnly(value, "--end");
+      index += 1;
+      continue;
+    }
+
+    if (token === "--contracts") {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error("Missing value for --contracts");
+      }
+      parsed.contracts = parseContracts(value);
+      index += 1;
+      continue;
+    }
+
+    if (token === "--source") {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error("Missing value for --source");
+      }
+      parsed.source = parseSource(value);
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${token}`);
+  }
+
+  return parsed;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const summary = await ingestOptionMarks({
+    startDate: args.startDate,
+    endDate: args.endDate,
+    contracts: args.contracts,
+    source: args.source,
+  });
+
+  console.log("[ingest:option-marks] summary", summary);
+}
+
+main().catch((error) => {
+  console.error("[ingest:option-marks] failed", error);
+  process.exit(1);
+});

--- a/src/lib/analysis/backfill-value-snapshots.test.ts
+++ b/src/lib/analysis/backfill-value-snapshots.test.ts
@@ -1,6 +1,32 @@
 import { Prisma } from "@prisma/client";
 import { describe, expect, it } from "vitest";
-import { cumulativeLedgerAmountForCashEvent, reconstructedTradeCashDelta } from "./backfill-value-snapshots";
+import { buildFirstActivityDateByAccount, cumulativeLedgerAmountForCashEvent, reconstructedTradeCashDelta } from "./backfill-value-snapshots";
+
+function dateOnly(value: Date | undefined): string | null {
+  return value ? value.toISOString().slice(0, 10) : null;
+}
+
+describe("buildFirstActivityDateByAccount", () => {
+  it("starts funded idle accounts from broker snapshots before their first trade", () => {
+    const result = buildFirstActivityDateByAccount({
+      tradeDates: [{ accountId: "schwab-idle", date: new Date("2025-12-05T15:00:00.000Z") }],
+      cashEventDates: [],
+      brokerSnapshotDates: [{ accountId: "schwab-idle", date: new Date("2025-09-02T00:00:00.000Z") }],
+    });
+
+    expect(dateOnly(result.get("schwab-idle"))).toBe("2025-09-02");
+  });
+
+  it("uses the earliest available execution, cash event, or broker snapshot date per account", () => {
+    const result = buildFirstActivityDateByAccount({
+      tradeDates: [{ accountId: "account-1", date: new Date("2025-03-10T00:00:00.000Z") }],
+      cashEventDates: [{ accountId: "account-1", date: new Date("2025-02-01T00:00:00.000Z") }],
+      brokerSnapshotDates: [{ accountId: "account-1", date: new Date("2025-04-01T00:00:00.000Z") }],
+    });
+
+    expect(dateOnly(result.get("account-1"))).toBe("2025-02-01");
+  });
+});
 
 describe("cumulativeLedgerAmountForCashEvent", () => {
   it("includes external cash-event row types in the reconstructed cash ledger", () => {
@@ -103,6 +129,21 @@ describe("reconstructedTradeCashDelta", () => {
         side: "BUY",
         quantity: new Prisma.Decimal("10"),
         price: null,
+      }),
+    ).toBe(0);
+  });
+
+  it("does not reduce cash for transferred-in ACAT receive executions", () => {
+    expect(
+      reconstructedTradeCashDelta({
+        assetClass: "EQUITY",
+        side: "BUY",
+        quantity: new Prisma.Decimal("100"),
+        price: new Prisma.Decimal("89.81"),
+        rawRowJson: {
+          action: "EXECUTION BUY OPEN EQUITY (ACAT_RECEIVE)",
+          rawAction: "TRANSFER OF ASSETS ACAT RECEIVE SELECT SECTOR SPDR TRUST STATE STREET (XLE)",
+        },
       }),
     ).toBe(0);
   });

--- a/src/lib/analysis/backfill-value-snapshots.ts
+++ b/src/lib/analysis/backfill-value-snapshots.ts
@@ -50,6 +50,11 @@ type ManualAdjustmentRow = Prisma.ManualAdjustmentGetPayload<{
   };
 }>;
 
+export interface AccountActivityDateRow {
+  accountId: string;
+  date: Date | null;
+}
+
 const FALLBACK_MARK_LOOKBACK_DAYS = 10;
 const UPSERT_BATCH_SIZE = 50;
 const INTERNAL_CASH_EQUIVALENT_ROW_TYPES = new Set([
@@ -81,6 +86,36 @@ function isOnOrBeforeDate(date: Date, snapshotDate: Date): boolean {
   return date.getTime() <= toEndOfDayUtcIso(dateKey(snapshotDate)).getTime();
 }
 
+function setEarliestAccountActivityDate(result: Map<string, Date>, row: AccountActivityDateRow): void {
+  if (!row.date) {
+    return;
+  }
+
+  const date = startOfUtcDay(row.date);
+  const existing = result.get(row.accountId);
+  if (!existing || date.getTime() < existing.getTime()) {
+    result.set(row.accountId, date);
+  }
+}
+
+export function buildFirstActivityDateByAccount(input: {
+  tradeDates: AccountActivityDateRow[];
+  cashEventDates: AccountActivityDateRow[];
+  brokerSnapshotDates: AccountActivityDateRow[];
+}): Map<string, Date> {
+  const result = new Map<string, Date>();
+  for (const row of input.tradeDates) {
+    setEarliestAccountActivityDate(result, row);
+  }
+  for (const row of input.cashEventDates) {
+    setEarliestAccountActivityDate(result, row);
+  }
+  for (const row of input.brokerSnapshotDates) {
+    setEarliestAccountActivityDate(result, row);
+  }
+  return result;
+}
+
 export function cumulativeLedgerAmountForCashEvent(event: { amount: Prisma.Decimal | number; rowType: string }): number {
   // Money-market sweep rows move cash into/out of cash-equivalent funds. Trade
   // cash deltas already capture buying power changes, so including sweeps here
@@ -97,7 +132,12 @@ export function reconstructedTradeCashDelta(execution: {
   side: string | null;
   quantity: Prisma.Decimal | string | number;
   price: Prisma.Decimal | string | number | null;
+  rawRowJson?: Prisma.JsonValue | null;
 }): number {
+  if (isCashNeutralTransferReceive(execution.rawRowJson)) {
+    return 0;
+  }
+
   if (execution.side !== "BUY" && execution.side !== "SELL") {
     return 0;
   }
@@ -115,6 +155,24 @@ export function reconstructedTradeCashDelta(execution: {
   const multiplier = execution.assetClass === "OPTION" ? 100 : 1;
   const grossCashFlow = quantity * price * multiplier;
   return execution.side === "BUY" ? grossCashFlow * -1 : grossCashFlow;
+}
+
+function isRecord(value: Prisma.JsonValue | null | undefined): value is Prisma.JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function jsonStringField(value: Prisma.JsonValue | undefined): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function isCashNeutralTransferReceive(rawRowJson: Prisma.JsonValue | null | undefined): boolean {
+  if (!isRecord(rawRowJson)) {
+    return false;
+  }
+
+  const action = jsonStringField(rawRowJson.action)?.toUpperCase() ?? "";
+  const rawAction = jsonStringField(rawRowJson.rawAction)?.toUpperCase() ?? "";
+  return action.includes("ACAT_RECEIVE") || rawAction.includes("ACAT RECEIVE");
 }
 
 function toExecutionRecord(row: ExecutionRow): ExecutionRecord {
@@ -258,12 +316,28 @@ export async function backfillValueSnapshots(input: BackfillValueSnapshotsInput 
     throw new Error(`Invalid date range: start ${dateKey(startDate)} is after end ${dateKey(endDate)}.`);
   }
 
-  const firstTradeRows = await prismaClient.execution.groupBy({
-    by: ["accountId"],
-    where: { accountId: { in: scopedAccountIds } },
-    _min: { tradeDate: true },
+  const [firstTradeRows, firstCashEventRows, firstBrokerSnapshotRows] = await Promise.all([
+    prismaClient.execution.groupBy({
+      by: ["accountId"],
+      where: { accountId: { in: scopedAccountIds } },
+      _min: { tradeDate: true },
+    }),
+    prismaClient.cashEvent.groupBy({
+      by: ["accountId"],
+      where: { accountId: { in: scopedAccountIds } },
+      _min: { eventDate: true },
+    }),
+    prismaClient.dailyAccountSnapshot.groupBy({
+      by: ["accountId"],
+      where: { accountId: { in: scopedAccountIds } },
+      _min: { snapshotDate: true },
+    }),
+  ]);
+  const firstActivityDateByAccount = buildFirstActivityDateByAccount({
+    tradeDates: firstTradeRows.map((row) => ({ accountId: row.accountId, date: row._min.tradeDate })),
+    cashEventDates: firstCashEventRows.map((row) => ({ accountId: row.accountId, date: row._min.eventDate })),
+    brokerSnapshotDates: firstBrokerSnapshotRows.map((row) => ({ accountId: row.accountId, date: row._min.snapshotDate })),
   });
-  const firstTradeDateByAccount = new Map(firstTradeRows.map((row) => [row.accountId, row._min.tradeDate ? startOfUtcDay(row._min.tradeDate) : null]));
 
   const tradingDays = await prismaClient.historicalMark.findMany({
     where: {
@@ -388,11 +462,12 @@ export async function backfillValueSnapshots(input: BackfillValueSnapshotsInput 
   const upserts: Array<Prisma.PrismaPromise<unknown>> = [];
 
   for (const account of accounts) {
+    const accountExecutionRows = executionRows.filter((execution) => execution.accountId === account.id);
     const accountExecutions = executions.filter((execution) => execution.accountId === account.id);
     const accountMatchedLots = matchedLots.filter((lot) => lot.accountId === account.id);
     const accountAdjustments = adjustments.filter((adjustment) => adjustment.accountId === account.id);
     const accountCashEvents = cashEventRows.filter((event) => event.accountId === account.id);
-    const accountFirstTradeDate = firstTradeDateByAccount.get(account.id) ?? null;
+    const accountFirstActivityDate = firstActivityDateByAccount.get(account.id) ?? null;
     let executionCashIndex = 0;
     let cashEventIndex = 0;
     let cashValue = Number(account.startingCapital ?? 0);
@@ -401,8 +476,8 @@ export async function backfillValueSnapshots(input: BackfillValueSnapshotsInput 
     for (const tradingDay of tradingDays) {
       const snapshotDate = startOfUtcDay(tradingDay.markDate);
 
-      while (executionCashIndex < accountExecutions.length && isOnOrBeforeDate(new Date(accountExecutions[executionCashIndex]?.tradeDate ?? 0), snapshotDate)) {
-        const execution = accountExecutions[executionCashIndex];
+      while (executionCashIndex < accountExecutionRows.length && isOnOrBeforeDate(accountExecutionRows[executionCashIndex]?.tradeDate ?? new Date(0), snapshotDate)) {
+        const execution = accountExecutionRows[executionCashIndex];
         if (execution) {
           cashValue += reconstructedTradeCashDelta(execution);
         }
@@ -417,7 +492,7 @@ export async function backfillValueSnapshots(input: BackfillValueSnapshotsInput 
         cashEventIndex += 1;
       }
 
-      if (accountFirstTradeDate === null || snapshotDate.getTime() < accountFirstTradeDate.getTime()) {
+      if (accountFirstActivityDate === null || snapshotDate.getTime() < accountFirstActivityDate.getTime()) {
         continue;
       }
 

--- a/src/lib/marketdata/ingest-option-marks.test.ts
+++ b/src/lib/marketdata/ingest-option-marks.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { resolvePolygonHistoricalAccessStartDate } from "./ingest-option-marks";
+
+function dateOnly(value: Date): string {
+  return value.toISOString().slice(0, 10);
+}
+
+describe("resolvePolygonHistoricalAccessStartDate", () => {
+  it("defaults to the first day after the two-year rolling boundary", () => {
+    const result = resolvePolygonHistoricalAccessStartDate(new Date("2026-05-31T12:00:00.000Z"), {});
+
+    expect(dateOnly(result)).toBe("2024-06-01");
+  });
+
+  it("uses an explicit configured access start date when provided", () => {
+    const result = resolvePolygonHistoricalAccessStartDate(new Date("2026-05-31T12:00:00.000Z"), {
+      POLYGON_HISTORICAL_MARKS_START_DATE: "2025-01-15",
+    });
+
+    expect(dateOnly(result)).toBe("2025-01-15");
+  });
+
+  it("supports a configurable lookback window", () => {
+    const result = resolvePolygonHistoricalAccessStartDate(new Date("2026-05-31T12:00:00.000Z"), {
+      POLYGON_HISTORICAL_LOOKBACK_YEARS: "1",
+    });
+
+    expect(dateOnly(result)).toBe("2025-06-01");
+  });
+
+  it("rejects malformed configuration", () => {
+    expect(() =>
+      resolvePolygonHistoricalAccessStartDate(new Date("2026-05-31T12:00:00.000Z"), {
+        POLYGON_HISTORICAL_MARKS_START_DATE: "05/31/2024",
+      }),
+    ).toThrow(/POLYGON_HISTORICAL_MARKS_START_DATE/);
+
+    expect(() =>
+      resolvePolygonHistoricalAccessStartDate(new Date("2026-05-31T12:00:00.000Z"), {
+        POLYGON_HISTORICAL_LOOKBACK_YEARS: "0",
+      }),
+    ).toThrow(/POLYGON_HISTORICAL_LOOKBACK_YEARS/);
+  });
+});

--- a/src/lib/marketdata/ingest-option-marks.ts
+++ b/src/lib/marketdata/ingest-option-marks.ts
@@ -16,6 +16,7 @@ interface LoggerLike {
 }
 
 export type OptionMarksIngestSource = "s3" | "rest";
+export const DEFAULT_POLYGON_HISTORICAL_LOOKBACK_YEARS = 2;
 
 export interface IngestOptionMarksInput {
   startDate?: Date;
@@ -33,6 +34,7 @@ export interface IngestOptionMarksSummary {
   source: OptionMarksIngestSource;
   startDate: string;
   endDate: string;
+  historicalAccessStartDate: string;
   contractsRequested: number;
   datesProcessed: number;
   datesSkippedMissing: number;
@@ -43,6 +45,8 @@ export interface IngestOptionMarksSummary {
 }
 
 interface IngestDefaults {
+  requestedStartDate: Date;
+  historicalAccessStartDate: Date;
   startDate: Date;
   endDate: Date;
   contracts: string[];
@@ -75,6 +79,55 @@ function utcDateLabel(date: Date): string {
 function getUtcYesterday(now: Date): Date {
   const todayUtc = startOfUtcDay(now);
   return new Date(todayUtc.getTime() - 24 * 60 * 60 * 1000);
+}
+
+function addUtcDays(date: Date, days: number): Date {
+  return new Date(startOfUtcDay(date).getTime() + days * 24 * 60 * 60 * 1000);
+}
+
+function subtractUtcYears(date: Date, years: number): Date {
+  return new Date(Date.UTC(date.getUTCFullYear() - years, date.getUTCMonth(), date.getUTCDate()));
+}
+
+function parseDateOnlyUtc(value: string, envName: string): Date {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    throw new Error(`Invalid ${envName} date format: ${value}. Expected YYYY-MM-DD.`);
+  }
+
+  const parsed = new Date(`${value}T00:00:00.000Z`);
+  if (!Number.isFinite(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== value) {
+    throw new Error(`Invalid ${envName} date value: ${value}.`);
+  }
+
+  return parsed;
+}
+
+function parsePositiveInteger(value: string, envName: string): number {
+  if (!/^\d+$/.test(value.trim())) {
+    throw new Error(`Invalid ${envName} value: ${value}. Expected a positive integer.`);
+  }
+
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`Invalid ${envName} value: ${value}. Expected a positive integer.`);
+  }
+
+  return parsed;
+}
+
+export function resolvePolygonHistoricalAccessStartDate(now: Date = new Date(), env: Record<string, string | undefined> = process.env): Date {
+  const explicitStartDate = env.POLYGON_HISTORICAL_MARKS_START_DATE?.trim();
+  if (explicitStartDate) {
+    return parseDateOnlyUtc(explicitStartDate, "POLYGON_HISTORICAL_MARKS_START_DATE");
+  }
+
+  const lookbackYearsRaw = env.POLYGON_HISTORICAL_LOOKBACK_YEARS?.trim();
+  const lookbackYears = lookbackYearsRaw
+    ? parsePositiveInteger(lookbackYearsRaw, "POLYGON_HISTORICAL_LOOKBACK_YEARS")
+    : DEFAULT_POLYGON_HISTORICAL_LOOKBACK_YEARS;
+
+  // Start one day after the rolling boundary to avoid out-of-contract boundary calls.
+  return addUtcDays(subtractUtcYears(startOfUtcDay(now), lookbackYears), 1);
 }
 
 function isWeekend(date: Date): boolean {
@@ -187,10 +240,14 @@ export async function resolveIngestOptionMarksDefaults(input: {
   const contracts = input.contracts ? normalizeContracts(input.contracts) : await loadDistinctOptionContracts(prismaClient);
   const fallbackEndDate = getUtcYesterday(now);
   const earliestTradeDate = await loadEarliestOptionTradeDate(prismaClient);
-  const startDate = startOfUtcDay(input.startDate ?? earliestTradeDate ?? fallbackEndDate);
+  const requestedStartDate = startOfUtcDay(input.startDate ?? earliestTradeDate ?? fallbackEndDate);
+  const historicalAccessStartDate = resolvePolygonHistoricalAccessStartDate(now);
+  const startDate = requestedStartDate.getTime() < historicalAccessStartDate.getTime() ? historicalAccessStartDate : requestedStartDate;
   const endDate = startOfUtcDay(input.endDate ?? fallbackEndDate);
 
   return {
+    requestedStartDate,
+    historicalAccessStartDate,
     startDate,
     endDate,
     contracts,
@@ -235,7 +292,7 @@ async function ingestOptionMarksFromS3(params: {
   s3Client?: S3LikeClient;
   logger: LoggerLike;
   defaults: IngestDefaults;
-}): Promise<Omit<IngestOptionMarksSummary, "source" | "startDate" | "endDate" | "contractsRequested">> {
+}): Promise<Omit<IngestOptionMarksSummary, "source" | "startDate" | "endDate" | "historicalAccessStartDate" | "contractsRequested">> {
   const s3Config = defaultS3FlatfilesConfig();
   const s3Client = params.s3Client ?? createS3FlatfilesClient(s3Config);
   const availableDates = await listAvailableDatesInRange(s3Client, {
@@ -378,7 +435,7 @@ async function ingestOptionMarksFromRest(params: {
   logger: LoggerLike;
   defaults: IngestDefaults;
   polygonApiKey?: string;
-}): Promise<Omit<IngestOptionMarksSummary, "source" | "startDate" | "endDate" | "contractsRequested">> {
+}): Promise<Omit<IngestOptionMarksSummary, "source" | "startDate" | "endDate" | "historicalAccessStartDate" | "contractsRequested">> {
   const apiKey = params.polygonApiKey ?? process.env.POLYGON_API_KEY;
   if (!apiKey || apiKey.trim().length === 0) {
     throw new Error("Missing POLYGON_API_KEY for option mark REST fallback.");
@@ -440,7 +497,15 @@ export async function ingestOptionMarks(input: IngestOptionMarksInput = {}): Pro
   });
 
   if (defaults.startDate.getTime() > defaults.endDate.getTime()) {
-    throw new Error(`Invalid date range: start ${utcDateLabel(defaults.startDate)} is after end ${utcDateLabel(defaults.endDate)}.`);
+    throw new Error(
+      `Invalid date range after historical-access clamp: start ${utcDateLabel(defaults.startDate)} is after end ${utcDateLabel(defaults.endDate)}. Earliest configured access date is ${utcDateLabel(defaults.historicalAccessStartDate)}.`,
+    );
+  }
+
+  if (defaults.requestedStartDate.getTime() < defaults.historicalAccessStartDate.getTime()) {
+    logger.warn(
+      `[ingest:option-marks] requested start ${utcDateLabel(defaults.requestedStartDate)} is before Polygon historical access start ${utcDateLabel(defaults.historicalAccessStartDate)}; clamping to ${utcDateLabel(defaults.startDate)}.`,
+    );
   }
 
   if (defaults.contracts.length === 0) {
@@ -449,6 +514,7 @@ export async function ingestOptionMarks(input: IngestOptionMarksInput = {}): Pro
       source,
       startDate: utcDateLabel(defaults.startDate),
       endDate: utcDateLabel(defaults.endDate),
+      historicalAccessStartDate: utcDateLabel(defaults.historicalAccessStartDate),
       contractsRequested: 0,
       datesProcessed: 0,
       datesSkippedMissing: 0,
@@ -477,6 +543,7 @@ export async function ingestOptionMarks(input: IngestOptionMarksInput = {}): Pro
     source,
     startDate: utcDateLabel(defaults.startDate),
     endDate: utcDateLabel(defaults.endDate),
+    historicalAccessStartDate: utcDateLabel(defaults.historicalAccessStartDate),
     contractsRequested: defaults.contracts.length,
     ...ingested,
   };

--- a/src/lib/marketdata/ingest-option-marks.ts
+++ b/src/lib/marketdata/ingest-option-marks.ts
@@ -1,0 +1,489 @@
+import { MarkAssetClass, MarkSource, type Prisma, type PrismaClient } from "@prisma/client";
+import { prisma } from "@/lib/db/prisma";
+import { canonicalToOcc, occToCanonical, parseCanonicalOptionInstrumentKey } from "@/lib/marketdata/occ-ticker";
+import { parseOptionDayAggsCsv, type OptionDayAggRow } from "@/lib/marketdata/option-day-aggs-parser";
+import {
+  createS3FlatfilesClient,
+  defaultS3FlatfilesConfig,
+  downloadDayAggsCsvForDate,
+  listAvailableDatesInRange,
+  type S3LikeClient,
+} from "@/lib/marketdata/s3-flatfiles";
+
+interface LoggerLike {
+  log(message: string): void;
+  warn(message: string): void;
+}
+
+export type OptionMarksIngestSource = "s3" | "rest";
+
+export interface IngestOptionMarksInput {
+  startDate?: Date;
+  endDate?: Date;
+  contracts?: string[];
+  source?: OptionMarksIngestSource;
+  now?: Date;
+  prismaClient?: PrismaClient;
+  s3Client?: S3LikeClient;
+  logger?: LoggerLike;
+  polygonApiKey?: string;
+}
+
+export interface IngestOptionMarksSummary {
+  source: OptionMarksIngestSource;
+  startDate: string;
+  endDate: string;
+  contractsRequested: number;
+  datesProcessed: number;
+  datesSkippedMissing: number;
+  rowsUpserted: number;
+  contractsMissing: string[];
+  invalidRowCount: number;
+  duplicateContractCount: number;
+}
+
+interface IngestDefaults {
+  startDate: Date;
+  endDate: Date;
+  contracts: string[];
+}
+
+interface PolygonAggregateResult {
+  o?: number;
+  h?: number;
+  l?: number;
+  c?: number;
+  v?: number;
+  t?: number;
+}
+
+interface PolygonAggregateResponse {
+  status?: string;
+  results?: PolygonAggregateResult[];
+  error?: string;
+  message?: string;
+}
+
+function startOfUtcDay(date: Date): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+}
+
+function utcDateLabel(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function getUtcYesterday(now: Date): Date {
+  const todayUtc = startOfUtcDay(now);
+  return new Date(todayUtc.getTime() - 24 * 60 * 60 * 1000);
+}
+
+function isWeekend(date: Date): boolean {
+  const day = date.getUTCDay();
+  return day === 0 || day === 6;
+}
+
+function listUtcDateRangeInclusive(startDate: Date, endDate: Date): Date[] {
+  const dates: Date[] = [];
+  for (let cursor = startOfUtcDay(startDate); cursor.getTime() <= endDate.getTime(); cursor = new Date(cursor.getTime() + 24 * 60 * 60 * 1000)) {
+    dates.push(cursor);
+  }
+  return dates;
+}
+
+function normalizeContracts(contracts: string[]): string[] {
+  return Array.from(
+    new Set(
+      contracts
+        .map((contract) => parseCanonicalOptionInstrumentKey(contract).instrumentKey)
+        .filter((contract) => contract.length > 0),
+    ),
+  ).sort((left, right) => left.localeCompare(right));
+}
+
+function tryBuildCanonicalContractFromExecution(execution: {
+  instrumentKey: string | null;
+  symbol: string;
+  underlyingSymbol: string | null;
+  optionType: string | null;
+  strike: Prisma.Decimal | null;
+  expirationDate: Date | null;
+}): string | null {
+  if (execution.instrumentKey) {
+    try {
+      return parseCanonicalOptionInstrumentKey(execution.instrumentKey).instrumentKey;
+    } catch {
+      // Fall back to execution fields below; some legacy rows may have non-canonical keys.
+    }
+  }
+
+  if (!execution.optionType || !execution.strike || !execution.expirationDate) {
+    return null;
+  }
+
+  const optionType = execution.optionType.toUpperCase();
+  if (optionType !== "CALL" && optionType !== "PUT") {
+    return null;
+  }
+
+  const underlying = execution.underlyingSymbol ?? execution.symbol;
+  const expirationDate = utcDateLabel(execution.expirationDate);
+  const fallbackKey = `${underlying}|${optionType}|${execution.strike.toString()}|${expirationDate}`;
+
+  try {
+    return parseCanonicalOptionInstrumentKey(fallbackKey).instrumentKey;
+  } catch {
+    return null;
+  }
+}
+
+async function loadDistinctOptionContracts(prismaClient: PrismaClient): Promise<string[]> {
+  const rows = await prismaClient.execution.findMany({
+    where: {
+      assetClass: "OPTION",
+    },
+    select: {
+      instrumentKey: true,
+      symbol: true,
+      underlyingSymbol: true,
+      optionType: true,
+      strike: true,
+      expirationDate: true,
+    },
+  });
+
+  const contracts = rows
+    .map((row) => tryBuildCanonicalContractFromExecution(row))
+    .filter((contract): contract is string => contract !== null);
+
+  return normalizeContracts(contracts);
+}
+
+async function loadEarliestOptionTradeDate(prismaClient: PrismaClient): Promise<Date | null> {
+  const row = await prismaClient.execution.findFirst({
+    where: {
+      assetClass: "OPTION",
+    },
+    orderBy: {
+      tradeDate: "asc",
+    },
+    select: {
+      tradeDate: true,
+    },
+  });
+
+  return row ? startOfUtcDay(row.tradeDate) : null;
+}
+
+export async function resolveIngestOptionMarksDefaults(input: {
+  now?: Date;
+  prismaClient?: PrismaClient;
+  contracts?: string[];
+  startDate?: Date;
+  endDate?: Date;
+} = {}): Promise<IngestDefaults> {
+  const prismaClient = input.prismaClient ?? prisma;
+  const now = input.now ?? new Date();
+
+  const contracts = input.contracts ? normalizeContracts(input.contracts) : await loadDistinctOptionContracts(prismaClient);
+  const fallbackEndDate = getUtcYesterday(now);
+  const earliestTradeDate = await loadEarliestOptionTradeDate(prismaClient);
+  const startDate = startOfUtcDay(input.startDate ?? earliestTradeDate ?? fallbackEndDate);
+  const endDate = startOfUtcDay(input.endDate ?? fallbackEndDate);
+
+  return {
+    startDate,
+    endDate,
+    contracts,
+  };
+}
+
+async function upsertOptionMark(prismaClient: PrismaClient, params: { row: OptionDayAggRow; markDate: Date; source: MarkSource }): Promise<void> {
+  await prismaClient.historicalMark.upsert({
+    where: {
+      instrumentKey_markDate: {
+        instrumentKey: params.row.instrumentKey,
+        markDate: params.markDate,
+      },
+    },
+    update: {
+      assetClass: MarkAssetClass.OPTION,
+      symbol: params.row.underlying,
+      open: params.row.open.toFixed(6),
+      high: params.row.high.toFixed(6),
+      low: params.row.low.toFixed(6),
+      close: params.row.close.toFixed(6),
+      volume: params.row.volume === null ? null : params.row.volume.toFixed(6),
+      source: params.source,
+    },
+    create: {
+      instrumentKey: params.row.instrumentKey,
+      assetClass: MarkAssetClass.OPTION,
+      symbol: params.row.underlying,
+      markDate: params.markDate,
+      open: params.row.open.toFixed(6),
+      high: params.row.high.toFixed(6),
+      low: params.row.low.toFixed(6),
+      close: params.row.close.toFixed(6),
+      volume: params.row.volume === null ? null : params.row.volume.toFixed(6),
+      source: params.source,
+    },
+  });
+}
+
+async function ingestOptionMarksFromS3(params: {
+  prismaClient: PrismaClient;
+  s3Client?: S3LikeClient;
+  logger: LoggerLike;
+  defaults: IngestDefaults;
+}): Promise<Omit<IngestOptionMarksSummary, "source" | "startDate" | "endDate" | "contractsRequested">> {
+  const s3Config = defaultS3FlatfilesConfig();
+  const s3Client = params.s3Client ?? createS3FlatfilesClient(s3Config);
+  const availableDates = await listAvailableDatesInRange(s3Client, {
+    bucket: s3Config.bucket,
+    prefix: s3Config.optionsPrefix,
+    startDate: params.defaults.startDate,
+    endDate: params.defaults.endDate,
+  });
+  const availableDateSet = new Set(availableDates.map((date) => utcDateLabel(date)));
+
+  let datesProcessed = 0;
+  let datesSkippedMissing = 0;
+  let rowsUpserted = 0;
+  let invalidRowCount = 0;
+  let duplicateContractCount = 0;
+  const contractsMissing = new Set<string>();
+
+  for (const markDate of listUtcDateRangeInclusive(params.defaults.startDate, params.defaults.endDate)) {
+    const markDateLabel = utcDateLabel(markDate);
+    if (!availableDateSet.has(markDateLabel)) {
+      if (isWeekend(markDate)) {
+        continue;
+      }
+
+      datesSkippedMissing += 1;
+      params.logger.warn(`[ingest:option-marks] missing key for ${markDateLabel}; skipping.`);
+      continue;
+    }
+
+    const csvText = await downloadDayAggsCsvForDate(s3Client, {
+      bucket: s3Config.bucket,
+      prefix: s3Config.optionsPrefix,
+      markDate,
+    });
+
+    if (csvText === null) {
+      datesSkippedMissing += 1;
+      params.logger.warn(`[ingest:option-marks] key disappeared for ${markDateLabel}; skipping.`);
+      continue;
+    }
+
+    const parsed = parseOptionDayAggsCsv(csvText, params.defaults.contracts);
+    invalidRowCount += parsed.invalidRowCount;
+    duplicateContractCount += parsed.duplicateContractCount;
+
+    for (const missingContract of parsed.missingContracts) {
+      contractsMissing.add(missingContract);
+    }
+
+    for (const row of parsed.rows) {
+      await upsertOptionMark(params.prismaClient, {
+        row,
+        markDate: startOfUtcDay(markDate),
+        source: MarkSource.MASSIVE_S3,
+      });
+      rowsUpserted += 1;
+    }
+
+    datesProcessed += 1;
+    params.logger.log(
+      `[ingest:option-marks] source=s3 date=${markDateLabel} rows=${parsed.rows.length} invalidRows=${parsed.invalidRowCount} duplicates=${parsed.duplicateContractCount}`,
+    );
+  }
+
+  return {
+    datesProcessed,
+    datesSkippedMissing,
+    rowsUpserted,
+    contractsMissing: Array.from(contractsMissing).sort((left, right) => left.localeCompare(right)),
+    invalidRowCount,
+    duplicateContractCount,
+  };
+}
+
+function parsePolygonAggregateRows(contract: string, rows: PolygonAggregateResult[]): Array<{ row: OptionDayAggRow; markDate: Date }> {
+  const parsedContract = occToCanonical(canonicalToOcc(contract));
+  const parsedRows: Array<{ row: OptionDayAggRow; markDate: Date }> = [];
+
+  for (const result of rows) {
+    if (typeof result.t !== "number") {
+      continue;
+    }
+
+    const open = typeof result.o === "number" && Number.isFinite(result.o) ? result.o : null;
+    const high = typeof result.h === "number" && Number.isFinite(result.h) ? result.h : null;
+    const low = typeof result.l === "number" && Number.isFinite(result.l) ? result.l : null;
+    const close = typeof result.c === "number" && Number.isFinite(result.c) ? result.c : null;
+
+    if (open === null || high === null || low === null || close === null) {
+      continue;
+    }
+
+    parsedRows.push({
+      markDate: startOfUtcDay(new Date(result.t)),
+      row: {
+        instrumentKey: parsedContract.instrumentKey,
+        occTicker: parsedContract.occTicker,
+        underlying: parsedContract.underlying,
+        open,
+        high,
+        low,
+        close,
+        volume: typeof result.v === "number" && Number.isFinite(result.v) ? result.v : null,
+      },
+    });
+  }
+
+  return parsedRows;
+}
+
+async function fetchPolygonOptionAggregates(params: {
+  contract: string;
+  startDate: Date;
+  endDate: Date;
+  apiKey: string;
+}): Promise<PolygonAggregateResult[]> {
+  const occTicker = canonicalToOcc(params.contract);
+  const url = new URL(`https://api.polygon.io/v2/aggs/ticker/${encodeURIComponent(occTicker)}/range/1/day/${utcDateLabel(params.startDate)}/${utcDateLabel(params.endDate)}`);
+  url.searchParams.set("adjusted", "true");
+  url.searchParams.set("sort", "asc");
+  url.searchParams.set("limit", "50000");
+  url.searchParams.set("apiKey", params.apiKey);
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Polygon REST aggregate request failed for ${params.contract}: HTTP ${response.status} ${body.slice(0, 300)}`);
+  }
+
+  const payload = (await response.json()) as PolygonAggregateResponse;
+  if (payload.status === "ERROR") {
+    throw new Error(`Polygon REST aggregate request failed for ${params.contract}: ${payload.error ?? payload.message ?? "unknown error"}`);
+  }
+
+  return payload.results ?? [];
+}
+
+async function ingestOptionMarksFromRest(params: {
+  prismaClient: PrismaClient;
+  logger: LoggerLike;
+  defaults: IngestDefaults;
+  polygonApiKey?: string;
+}): Promise<Omit<IngestOptionMarksSummary, "source" | "startDate" | "endDate" | "contractsRequested">> {
+  const apiKey = params.polygonApiKey ?? process.env.POLYGON_API_KEY;
+  if (!apiKey || apiKey.trim().length === 0) {
+    throw new Error("Missing POLYGON_API_KEY for option mark REST fallback.");
+  }
+
+  let rowsUpserted = 0;
+  const datesProcessed = new Set<string>();
+  const contractsMissing = new Set<string>();
+
+  for (const contract of params.defaults.contracts) {
+    const aggregateRows = await fetchPolygonOptionAggregates({
+      contract,
+      startDate: params.defaults.startDate,
+      endDate: params.defaults.endDate,
+      apiKey,
+    });
+    const parsedRows = parsePolygonAggregateRows(contract, aggregateRows);
+
+    if (parsedRows.length === 0) {
+      contractsMissing.add(contract);
+      params.logger.warn(`[ingest:option-marks] source=rest contract=${contract} returned no day aggregates.`);
+      continue;
+    }
+
+    for (const parsed of parsedRows) {
+      await upsertOptionMark(params.prismaClient, {
+        row: parsed.row,
+        markDate: parsed.markDate,
+        source: MarkSource.POLYGON_REST,
+      });
+      rowsUpserted += 1;
+      datesProcessed.add(utcDateLabel(parsed.markDate));
+    }
+
+    params.logger.log(`[ingest:option-marks] source=rest contract=${contract} rows=${parsedRows.length}`);
+  }
+
+  return {
+    datesProcessed: datesProcessed.size,
+    datesSkippedMissing: 0,
+    rowsUpserted,
+    contractsMissing: Array.from(contractsMissing).sort((left, right) => left.localeCompare(right)),
+    invalidRowCount: 0,
+    duplicateContractCount: 0,
+  };
+}
+
+export async function ingestOptionMarks(input: IngestOptionMarksInput = {}): Promise<IngestOptionMarksSummary> {
+  const prismaClient = input.prismaClient ?? prisma;
+  const logger = input.logger ?? console;
+  const source = input.source ?? "s3";
+
+  const defaults = await resolveIngestOptionMarksDefaults({
+    now: input.now,
+    prismaClient,
+    contracts: input.contracts,
+    startDate: input.startDate,
+    endDate: input.endDate,
+  });
+
+  if (defaults.startDate.getTime() > defaults.endDate.getTime()) {
+    throw new Error(`Invalid date range: start ${utcDateLabel(defaults.startDate)} is after end ${utcDateLabel(defaults.endDate)}.`);
+  }
+
+  if (defaults.contracts.length === 0) {
+    logger.log("[ingest:option-marks] no option contracts found; nothing to ingest.");
+    return {
+      source,
+      startDate: utcDateLabel(defaults.startDate),
+      endDate: utcDateLabel(defaults.endDate),
+      contractsRequested: 0,
+      datesProcessed: 0,
+      datesSkippedMissing: 0,
+      rowsUpserted: 0,
+      contractsMissing: [],
+      invalidRowCount: 0,
+      duplicateContractCount: 0,
+    };
+  }
+
+  const ingested = source === "rest"
+    ? await ingestOptionMarksFromRest({
+        prismaClient,
+        logger,
+        defaults,
+        polygonApiKey: input.polygonApiKey,
+      })
+    : await ingestOptionMarksFromS3({
+        prismaClient,
+        s3Client: input.s3Client,
+        logger,
+        defaults,
+      });
+
+  const summary: IngestOptionMarksSummary = {
+    source,
+    startDate: utcDateLabel(defaults.startDate),
+    endDate: utcDateLabel(defaults.endDate),
+    contractsRequested: defaults.contracts.length,
+    ...ingested,
+  };
+
+  logger.log(
+    `[ingest:option-marks] complete source=${summary.source} datesProcessed=${summary.datesProcessed} rowsUpserted=${summary.rowsUpserted} contractsMissing=${summary.contractsMissing.length}`,
+  );
+
+  return summary;
+}

--- a/src/lib/marketdata/occ-ticker.test.ts
+++ b/src/lib/marketdata/occ-ticker.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { canonicalToOcc, normalizeCanonicalStrike, occToCanonical, parseCanonicalOptionInstrumentKey } from "./occ-ticker";
+
+describe("OCC ticker conversion", () => {
+  it("converts a standard OCC ticker to the canonical option instrument key", () => {
+    expect(occToCanonical("O:SPY260116C00500000")).toEqual({
+      occTicker: "O:SPY260116C00500000",
+      instrumentKey: "SPY|CALL|500|2026-01-16",
+      underlying: "SPY",
+      optionType: "CALL",
+      strike: "500",
+      expirationDate: "2026-01-16",
+    });
+  });
+
+  it("converts a canonical option instrument key to OCC format", () => {
+    expect(canonicalToOcc("SPY|CALL|500|2026-01-16")).toBe("O:SPY260116C00500000");
+    expect(canonicalToOcc("QQQ|PUT|450|2026-02-20")).toBe("O:QQQ260220P00450000");
+  });
+
+  it("normalizes fractional strikes without losing join-compatible precision", () => {
+    expect(normalizeCanonicalStrike("007.5000")).toBe("7.5");
+    expect(canonicalToOcc("XYZ|CALL|7.5|2026-03-20")).toBe("O:XYZ260320C00007500");
+    expect(occToCanonical("O:XYZ260320C00007500").instrumentKey).toBe("XYZ|CALL|7.5|2026-03-20");
+  });
+
+  it("round-trips a real holding-style instrument key", () => {
+    const holdingKey = "TSLA|PUT|262.5|2026-06-18";
+    const occ = canonicalToOcc(holdingKey);
+    const parsed = occToCanonical(occ);
+
+    expect(parsed.instrumentKey).toBe(holdingKey);
+    expect(canonicalToOcc(parsed.instrumentKey)).toBe(occ);
+  });
+
+  it("supports underlyings that are not three letters", () => {
+    expect(canonicalToOcc("BRK.B|CALL|350|2026-01-16")).toBe("O:BRK.B260116C00350000");
+    expect(occToCanonical("O:SPXW260116P05000000").instrumentKey).toBe("SPXW|PUT|5000|2026-01-16");
+  });
+
+  it("rejects malformed canonical keys and unsupported strike precision", () => {
+    expect(() => parseCanonicalOptionInstrumentKey("SPY|CALL|500")).toThrow(/Invalid canonical/);
+    expect(() => canonicalToOcc("SPY|CALL|7.1234|2026-01-16")).toThrow(/precision/);
+    expect(() => occToCanonical("SPY260116C00500000")).toThrow(/Invalid OCC/);
+  });
+});

--- a/src/lib/marketdata/occ-ticker.ts
+++ b/src/lib/marketdata/occ-ticker.ts
@@ -1,0 +1,174 @@
+export type CanonicalOptionType = "CALL" | "PUT";
+
+export interface CanonicalOptionInstrument {
+  instrumentKey: string;
+  underlying: string;
+  optionType: CanonicalOptionType;
+  strike: string;
+  expirationDate: string;
+}
+
+export interface OccTickerParseResult extends CanonicalOptionInstrument {
+  occTicker: string;
+}
+
+const OCC_TICKER_PATTERN = /^O:(.+)(\d{6})([CP])(\d{8})$/i;
+const CANONICAL_DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+const DECIMAL_STRIKE_PATTERN = /^(\d+)(?:\.(\d+))?$/;
+
+function assertValidDateOnly(value: string): void {
+  const match = value.match(CANONICAL_DATE_PATTERN);
+  if (!match) {
+    throw new Error(`Invalid option expiration date: ${value}. Expected YYYY-MM-DD.`);
+  }
+
+  const [, year, month, day] = match;
+  const parsed = new Date(`${value}T00:00:00.000Z`);
+  if (
+    !Number.isFinite(parsed.getTime()) ||
+    parsed.getUTCFullYear() !== Number(year) ||
+    parsed.getUTCMonth() + 1 !== Number(month) ||
+    parsed.getUTCDate() !== Number(day)
+  ) {
+    throw new Error(`Invalid option expiration date: ${value}.`);
+  }
+}
+
+function normalizeUnderlying(value: string): string {
+  const underlying = value.trim().toUpperCase();
+  if (underlying.length === 0) {
+    throw new Error("Option underlying symbol is required.");
+  }
+  if (underlying.includes("|")) {
+    throw new Error(`Invalid option underlying symbol: ${value}.`);
+  }
+  return underlying;
+}
+
+export function normalizeCanonicalStrike(value: string | number): string {
+  const raw = typeof value === "number" ? value.toString() : value.trim();
+  if (raw.length === 0) {
+    throw new Error("Option strike is required.");
+  }
+  if (typeof value === "number" && !Number.isFinite(value)) {
+    throw new Error(`Invalid option strike: ${String(value)}.`);
+  }
+
+  const match = raw.match(DECIMAL_STRIKE_PATTERN);
+  if (!match) {
+    throw new Error(`Invalid option strike: ${raw}.`);
+  }
+
+  const wholePart = match[1].replace(/^0+(?=\d)/, "");
+  const fractionalRaw = match[2] ?? "";
+  const fractionalTrimmed = fractionalRaw.replace(/0+$/, "");
+
+  if (fractionalTrimmed.length > 3) {
+    throw new Error(`Invalid option strike precision: ${raw}. OCC tickers support up to 3 decimals.`);
+  }
+
+  return fractionalTrimmed.length === 0 ? wholePart : `${wholePart}.${fractionalTrimmed}`;
+}
+
+function strikeToOccDigits(strike: string): string {
+  const normalized = normalizeCanonicalStrike(strike);
+  const [wholePart, fractionalPart = ""] = normalized.split(".");
+  const strikeInteger = Number(wholePart) * 1000 + Number(fractionalPart.padEnd(3, "0"));
+
+  if (!Number.isSafeInteger(strikeInteger) || strikeInteger < 0) {
+    throw new Error(`Invalid option strike: ${strike}.`);
+  }
+
+  const digits = String(strikeInteger).padStart(8, "0");
+  if (digits.length > 8) {
+    throw new Error(`Option strike is too large for OCC format: ${strike}.`);
+  }
+
+  return digits;
+}
+
+function strikeFromOccDigits(value: string): string {
+  if (!/^\d{8}$/.test(value)) {
+    throw new Error(`Invalid OCC strike digits: ${value}.`);
+  }
+
+  const strikeInteger = Number(value);
+  const wholePart = Math.floor(strikeInteger / 1000);
+  const fractionalPart = strikeInteger % 1000;
+
+  if (fractionalPart === 0) {
+    return String(wholePart);
+  }
+
+  return `${wholePart}.${String(fractionalPart).padStart(3, "0").replace(/0+$/, "")}`;
+}
+
+function expirationFromOccDate(value: string): string {
+  const yearTwoDigits = Number(value.slice(0, 2));
+  const fullYear = yearTwoDigits >= 70 ? 1900 + yearTwoDigits : 2000 + yearTwoDigits;
+  const month = value.slice(2, 4);
+  const day = value.slice(4, 6);
+  const expirationDate = `${fullYear}-${month}-${day}`;
+  assertValidDateOnly(expirationDate);
+  return expirationDate;
+}
+
+export function parseCanonicalOptionInstrumentKey(instrumentKey: string): CanonicalOptionInstrument {
+  const parts = instrumentKey.split("|");
+  if (parts.length !== 4) {
+    throw new Error(`Invalid canonical option instrument key: ${instrumentKey}.`);
+  }
+
+  const underlying = normalizeUnderlying(parts[0]);
+  const optionTypeRaw = parts[1].trim().toUpperCase();
+  if (optionTypeRaw !== "CALL" && optionTypeRaw !== "PUT") {
+    throw new Error(`Invalid option type in instrument key: ${parts[1]}.`);
+  }
+
+  const strike = normalizeCanonicalStrike(parts[2]);
+  const expirationDate = parts[3].trim();
+  assertValidDateOnly(expirationDate);
+
+  return {
+    instrumentKey: `${underlying}|${optionTypeRaw}|${strike}|${expirationDate}`,
+    underlying,
+    optionType: optionTypeRaw,
+    strike,
+    expirationDate,
+  };
+}
+
+export function canonicalToOcc(instrumentKey: string): string {
+  const parsed = parseCanonicalOptionInstrumentKey(instrumentKey);
+  const [, yearSuffix, month, day] = parsed.expirationDate.match(CANONICAL_DATE_PATTERN) ?? [];
+  if (!yearSuffix || !month || !day) {
+    throw new Error(`Invalid option expiration date: ${parsed.expirationDate}.`);
+  }
+
+  const yearTwoDigits = yearSuffix.slice(-2);
+  const optionTypeCode = parsed.optionType === "CALL" ? "C" : "P";
+  return `O:${parsed.underlying}${yearTwoDigits}${month}${day}${optionTypeCode}${strikeToOccDigits(parsed.strike)}`;
+}
+
+export function occToCanonical(occ: string): OccTickerParseResult {
+  const normalized = occ.trim().toUpperCase().replace(/\s+/g, "");
+  const match = normalized.match(OCC_TICKER_PATTERN);
+  if (!match) {
+    throw new Error(`Invalid OCC option ticker: ${occ}.`);
+  }
+
+  const underlying = normalizeUnderlying(match[1]);
+  const expirationDate = expirationFromOccDate(match[2]);
+  const optionType: CanonicalOptionType = match[3] === "C" ? "CALL" : "PUT";
+  const strike = strikeFromOccDigits(match[4]);
+  const instrumentKey = `${underlying}|${optionType}|${strike}|${expirationDate}`;
+
+  return {
+    occTicker: canonicalToOcc(instrumentKey),
+    instrumentKey,
+    underlying,
+    optionType,
+    strike,
+    expirationDate,
+  };
+}

--- a/src/lib/marketdata/option-day-aggs-parser.test.ts
+++ b/src/lib/marketdata/option-day-aggs-parser.test.ts
@@ -1,0 +1,64 @@
+import { gunzipSync, gzipSync } from "node:zlib";
+import { describe, expect, it } from "vitest";
+import { parseOptionDayAggsCsv } from "./option-day-aggs-parser";
+
+function unzipCsvFromFixture(csvText: string): string {
+  const zipped = gzipSync(Buffer.from(csvText, "utf8"));
+  return gunzipSync(zipped).toString("utf8");
+}
+
+describe("parseOptionDayAggsCsv", () => {
+  it("maps OCC tickers to canonical keys, filters contracts, and deduplicates", () => {
+    const csv = unzipCsvFromFixture([
+      "ticker,o,h,l,c,v,window_start",
+      "O:SPY260116C00500000,4.1,4.8,3.9,4.5,1200,1768521600000000000",
+      "O:QQQ260220P00450000,2.1,2.4,1.8,2.2,800,1771545600000000000",
+      "O:SPY260116C00500000,4.2,4.9,4.0,4.6,1250,1768521600000000000",
+      "O:BAD,1,1,1,1,100,1768521600000000000",
+      "O:TSLA260618P00262500,3.1,3.4,,3.2,700,1781740800000000000",
+    ].join("\n"));
+
+    const result = parseOptionDayAggsCsv(csv, ["SPY|CALL|500|2026-01-16", "TSLA|PUT|262.5|2026-06-18"]);
+
+    expect(result.rows).toEqual([
+      {
+        instrumentKey: "SPY|CALL|500|2026-01-16",
+        occTicker: "O:SPY260116C00500000",
+        underlying: "SPY",
+        open: 4.2,
+        high: 4.9,
+        low: 4,
+        close: 4.6,
+        volume: 1250,
+      },
+    ]);
+    expect(result.invalidRowCount).toBe(2);
+    expect(result.duplicateContractCount).toBe(1);
+    expect(result.missingContracts).toEqual(["TSLA|PUT|262.5|2026-06-18"]);
+  });
+
+  it("supports long-form columns and treats invalid volume as null", () => {
+    const csv = unzipCsvFromFixture([
+      "symbol,open,high,low,close,volume",
+      "O:IWM260320C00077500,1.1,1.5,1,1.3,not-a-number",
+    ].join("\n"));
+
+    const result = parseOptionDayAggsCsv(csv, ["IWM|CALL|077.5000|2026-03-20"]);
+
+    expect(result.rows).toEqual([
+      {
+        instrumentKey: "IWM|CALL|77.5|2026-03-20",
+        occTicker: "O:IWM260320C00077500",
+        underlying: "IWM",
+        open: 1.1,
+        high: 1.5,
+        low: 1,
+        close: 1.3,
+        volume: null,
+      },
+    ]);
+    expect(result.invalidRowCount).toBe(0);
+    expect(result.duplicateContractCount).toBe(0);
+    expect(result.missingContracts).toEqual([]);
+  });
+});

--- a/src/lib/marketdata/option-day-aggs-parser.ts
+++ b/src/lib/marketdata/option-day-aggs-parser.ts
@@ -1,0 +1,201 @@
+import { occToCanonical, parseCanonicalOptionInstrumentKey } from "./occ-ticker";
+
+export interface OptionDayAggRow {
+  instrumentKey: string;
+  occTicker: string;
+  underlying: string;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number | null;
+}
+
+export interface ParseOptionDayAggsResult {
+  rows: OptionDayAggRow[];
+  invalidRowCount: number;
+  duplicateContractCount: number;
+  missingContracts: string[];
+}
+
+interface HeaderIndex {
+  ticker: number;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+function parseCsvLine(line: string): string[] {
+  const cells: string[] = [];
+  let current = "";
+  let inQuotes = false;
+
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index];
+
+    if (char === '"') {
+      const next = line[index + 1];
+      if (inQuotes && next === '"') {
+        current += '"';
+        index += 1;
+        continue;
+      }
+      inQuotes = !inQuotes;
+      continue;
+    }
+
+    if (char === "," && !inQuotes) {
+      cells.push(current);
+      current = "";
+      continue;
+    }
+
+    current += char;
+  }
+
+  cells.push(current);
+  return cells;
+}
+
+function normalizeHeader(header: string): string {
+  return header.trim().toLowerCase();
+}
+
+function findHeaderIndex(headers: string[], candidates: string[]): number {
+  for (const candidate of candidates) {
+    const index = headers.indexOf(candidate);
+    if (index >= 0) {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
+function parseHeader(line: string): HeaderIndex {
+  const headers = parseCsvLine(line).map(normalizeHeader);
+
+  return {
+    ticker: findHeaderIndex(headers, ["ticker", "symbol"]),
+    open: findHeaderIndex(headers, ["open", "o"]),
+    high: findHeaderIndex(headers, ["high", "h"]),
+    low: findHeaderIndex(headers, ["low", "l"]),
+    close: findHeaderIndex(headers, ["close", "c"]),
+    volume: findHeaderIndex(headers, ["volume", "v"]),
+  };
+}
+
+function parseNumber(value: string | undefined): number | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalized = value.trim();
+  if (normalized.length === 0) {
+    return null;
+  }
+
+  const number = Number(normalized);
+  return Number.isFinite(number) ? number : null;
+}
+
+function hasRequiredIndexes(index: HeaderIndex): boolean {
+  return index.ticker >= 0 && index.open >= 0 && index.high >= 0 && index.low >= 0 && index.close >= 0;
+}
+
+function normalizeContractSet(contracts: Iterable<string>): Set<string> {
+  return new Set(
+    Array.from(contracts)
+      .map((contract) => parseCanonicalOptionInstrumentKey(contract).instrumentKey)
+      .filter((contract) => contract.length > 0),
+  );
+}
+
+export function parseOptionDayAggsCsv(csvText: string, includeContracts: Iterable<string>): ParseOptionDayAggsResult {
+  const includeContractSet = normalizeContractSet(includeContracts);
+  const lines = csvText
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  if (lines.length === 0) {
+    return {
+      rows: [],
+      invalidRowCount: 0,
+      duplicateContractCount: 0,
+      missingContracts: Array.from(includeContractSet).sort((left, right) => left.localeCompare(right)),
+    };
+  }
+
+  const headerIndex = parseHeader(lines[0]);
+  if (!hasRequiredIndexes(headerIndex)) {
+    return {
+      rows: [],
+      invalidRowCount: Math.max(0, lines.length - 1),
+      duplicateContractCount: 0,
+      missingContracts: Array.from(includeContractSet).sort((left, right) => left.localeCompare(right)),
+    };
+  }
+
+  const rowsByInstrumentKey = new Map<string, OptionDayAggRow>();
+  let invalidRowCount = 0;
+  let duplicateContractCount = 0;
+
+  for (let index = 1; index < lines.length; index += 1) {
+    const cells = parseCsvLine(lines[index]);
+    const occTickerRaw = cells[headerIndex.ticker] ?? "";
+
+    let parsedTicker: ReturnType<typeof occToCanonical>;
+    try {
+      parsedTicker = occToCanonical(occTickerRaw);
+    } catch {
+      invalidRowCount += 1;
+      continue;
+    }
+
+    if (includeContractSet.size > 0 && !includeContractSet.has(parsedTicker.instrumentKey)) {
+      continue;
+    }
+
+    const open = parseNumber(cells[headerIndex.open]);
+    const high = parseNumber(cells[headerIndex.high]);
+    const low = parseNumber(cells[headerIndex.low]);
+    const close = parseNumber(cells[headerIndex.close]);
+
+    if (open === null || high === null || low === null || close === null) {
+      invalidRowCount += 1;
+      continue;
+    }
+
+    const volume = headerIndex.volume >= 0 ? parseNumber(cells[headerIndex.volume]) : null;
+    if (rowsByInstrumentKey.has(parsedTicker.instrumentKey)) {
+      duplicateContractCount += 1;
+    }
+
+    rowsByInstrumentKey.set(parsedTicker.instrumentKey, {
+      instrumentKey: parsedTicker.instrumentKey,
+      occTicker: parsedTicker.occTicker,
+      underlying: parsedTicker.underlying,
+      open,
+      high,
+      low,
+      close,
+      volume,
+    });
+  }
+
+  const rows = Array.from(rowsByInstrumentKey.values()).sort((left, right) => left.instrumentKey.localeCompare(right.instrumentKey));
+  const parsedContracts = new Set(rows.map((row) => row.instrumentKey));
+  const missingContracts = Array.from(includeContractSet)
+    .filter((contract) => !parsedContracts.has(contract))
+    .sort((left, right) => left.localeCompare(right));
+
+  return {
+    rows,
+    invalidRowCount,
+    duplicateContractCount,
+    missingContracts,
+  };
+}

--- a/src/lib/marketdata/s3-flatfiles.ts
+++ b/src/lib/marketdata/s3-flatfiles.ts
@@ -4,6 +4,7 @@ import { Readable } from "node:stream";
 
 const DEFAULT_REGION = "us-east-1";
 export const DEFAULT_EQUITY_S3_PREFIX = "us_stocks_sip/day_aggs_v1";
+export const DEFAULT_OPTIONS_S3_PREFIX = "us_options_opra/day_aggs_v1";
 
 export interface S3FlatfilesConfig {
   endpointUrl: string;
@@ -11,6 +12,7 @@ export interface S3FlatfilesConfig {
   accessKeyId: string;
   secretAccessKey: string;
   equityPrefix: string;
+  optionsPrefix: string;
 }
 
 export interface S3LikeClient {
@@ -34,6 +36,7 @@ export function defaultS3FlatfilesConfig(env: NodeJS.ProcessEnv = process.env): 
     accessKeyId: env.AWS_ACCESS_KEY_ID as string,
     secretAccessKey: env.AWS_SECRET_ACCESS_KEY as string,
     equityPrefix: env.POLYGON_S3_EQUITY_PREFIX?.trim() || DEFAULT_EQUITY_S3_PREFIX,
+    optionsPrefix: env.POLYGON_S3_OPTIONS_PREFIX?.trim() || DEFAULT_OPTIONS_S3_PREFIX,
   };
 }
 


### PR DESCRIPTION
Closes #286

## Summary
- Adds OCC <-> canonical option instrument conversion with tests.
- Adds OPRA day aggregate parsing filtered to held contracts.
- Adds option historical mark ingestion via Massive S3 plus a Polygon REST fallback source for local plan limitations.
- Documents OPRA spike findings and local fallback behavior.

## Validation
- npm run typecheck
- npm run lint
- npm test -- --passWithNoTests
- npm run ingest:option-marks -- --source rest --contracts <recent-held-contract> --start 2026-05-28 --end 2026-05-29
- npm run backfill:value-snapshots -- --start 2026-05-28 --end 2026-05-29

Draft intentionally: local testing requested before any production deployment.