### PR TITLE
fix: refresh derived analysis after ledger rebuilds

### DIFF
--- a/src/app/api/adjustments/route.ts
+++ b/src/app/api/adjustments/route.ts
@@ -2,6 +2,7 @@ import { Prisma } from "@prisma/client";
 import { buildAccountScopeWhere, parseAccountIds } from "@/lib/api/account-scope";
 import { detailResponse, errorResponse, listResponse, parsePagination } from "@/lib/api/responses";
 import { rebuildAccountSetups } from "@/lib/analytics/rebuild-account-setups";
+import { refreshDerivedAnalysisForAccounts } from "@/lib/analysis/refresh-derived-analysis";
 import { prisma } from "@/lib/db/prisma";
 import { rebuildAccountLedger } from "@/lib/ledger/rebuild-account-ledger";
 import { manualAdjustmentCreateSchema, parsePayloadByType } from "@/lib/adjustments/types";
@@ -166,6 +167,10 @@ export async function POST(request: Request) {
     await rebuildAccountLedger(tx, input.accountId, new Date());
     await rebuildAccountSetups(tx, input.accountId);
     return row;
+  });
+
+  await refreshDerivedAnalysisForAccounts({ accountIds: [input.accountId] }).catch((error) => {
+    console.warn("[adjustments] derived analysis refresh failed", error);
   });
 
   return detailResponse(mapRowToRecord(created));

--- a/src/app/api/imports/[id]/commit/route.ts
+++ b/src/app/api/imports/[id]/commit/route.ts
@@ -7,6 +7,7 @@ import { replaceImportCashEvents } from "@/lib/imports/replace-import-cash-event
 import { replaceImportExecutions } from "@/lib/imports/replace-import-executions";
 import { hydrateFidelityCashSnapshots } from "@/lib/imports/hydrate-fidelity-cash-snapshots";
 import { replaceImportSnapshots } from "@/lib/imports/replace-import-snapshots";
+import { refreshDerivedAnalysisForAccounts } from "@/lib/analysis/refresh-derived-analysis";
 import { deriveInstrumentKeyFromNormalizedExecution } from "@/lib/ledger/instrument-key";
 import { rebuildAccountLedger } from "@/lib/ledger/rebuild-account-ledger";
 import type { CommitImportResponse } from "@/types/api";
@@ -99,6 +100,13 @@ function buildCashEventDedupKey(input: {
     normalizedSymbol,
     normalizeNumberKey(input.amount),
   ].join("|");
+}
+
+function derivedRefreshFailureWarning(error: unknown) {
+  return {
+    code: "DERIVED_ANALYSIS_REFRESH_FAILED",
+    message: error instanceof Error ? error.message : "Derived analysis refresh failed after import commit.",
+  };
 }
 
 export async function POST(request: Request, context: { params: { id: string } }) {
@@ -435,13 +443,29 @@ export async function POST(request: Request, context: { params: { id: string } }
     ]);
   }
 
+  const responseWarnings = [...transactionResult.combinedWarnings];
+  try {
+    await refreshDerivedAnalysisForAccounts({ accountIds: [existingImport.accountId] });
+  } catch (error) {
+    const warning = derivedRefreshFailureWarning(error);
+    responseWarnings.push(warning);
+    await prisma.import.update({
+      where: { id: transactionResult.updatedImport.id },
+      data: {
+        warnings: responseWarnings as unknown as Prisma.InputJsonValue,
+      },
+    }).catch((updateError) => {
+      console.warn("[imports] failed to persist derived analysis refresh warning", updateError);
+    });
+  }
+
   const payload: CommitImportResponse = {
     importId: transactionResult.updatedImport.id,
     parsedRows: transactionResult.updatedImport.parsedRows,
     inserted: transactionResult.inserted,
     skippedDuplicates: transactionResult.skippedDuplicates,
     failed: transactionResult.updatedImport.failedRows,
-    warnings: transactionResult.combinedWarnings.map((warning) => `${warning.code}: ${warning.message}`),
+    warnings: responseWarnings.map((warning) => `${warning.code}: ${warning.message}`),
   };
 
   void fetch(new URL("/api/positions/snapshot/compute", request.url), {

--- a/src/components/widgets/ExcursionWidget.tsx
+++ b/src/components/widgets/ExcursionWidget.tsx
@@ -240,7 +240,7 @@ export function ExcursionWidget() {
 
       {!isLoading && !error && rows.length === 0 ? (
         <div className="rounded border border-border bg-surface-2 px-3 py-3 text-xs text-text-2">
-          <p>No lot excursions yet. Run the lot-excursion backfill after historical marks are loaded.</p>
+          <p>No lot excursions match the selected accounts and date range. If imports or adjustments were just committed, refresh derived analysis.</p>
         </div>
       ) : null}
 

--- a/src/lib/analysis/refresh-derived-analysis.test.ts
+++ b/src/lib/analysis/refresh-derived-analysis.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const refreshMocks = vi.hoisted(() => ({
+  backfillValueSnapshots: vi.fn(),
+  backfillLotExcursions: vi.fn(),
+}));
+
+vi.mock("@/lib/analysis/backfill-value-snapshots", () => ({
+  backfillValueSnapshots: refreshMocks.backfillValueSnapshots,
+}));
+
+vi.mock("@/lib/analysis/backfill-lot-excursions", () => ({
+  backfillLotExcursions: refreshMocks.backfillLotExcursions,
+}));
+
+describe("refreshDerivedAnalysisForAccounts", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    refreshMocks.backfillValueSnapshots.mockResolvedValue({ snapshotsUpserted: 3 });
+    refreshMocks.backfillLotExcursions.mockResolvedValue({ excursionsUpserted: 2 });
+  });
+
+  it("refreshes value snapshots before lot excursions for normalized accounts", async () => {
+    const logger = { log: vi.fn(), warn: vi.fn() };
+    const { refreshDerivedAnalysisForAccounts } = await import("./refresh-derived-analysis");
+
+    const summary = await refreshDerivedAnalysisForAccounts({
+      accountIds: [" acct-b ", "acct-a", "acct-b", ""],
+      logger,
+    });
+
+    expect(refreshMocks.backfillValueSnapshots).toHaveBeenCalledWith({
+      accountIds: ["acct-a", "acct-b"],
+      logger,
+    });
+    expect(refreshMocks.backfillLotExcursions).toHaveBeenCalledWith({
+      accountIds: ["acct-a", "acct-b"],
+      logger,
+    });
+    expect(refreshMocks.backfillValueSnapshots.mock.invocationCallOrder[0]).toBeLessThan(
+      refreshMocks.backfillLotExcursions.mock.invocationCallOrder[0],
+    );
+    expect(summary).toEqual({
+      valueSnapshots: { snapshotsUpserted: 3 },
+      lotExcursions: { excursionsUpserted: 2 },
+    });
+  });
+
+  it("rejects empty account scope", async () => {
+    const { refreshDerivedAnalysisForAccounts } = await import("./refresh-derived-analysis");
+
+    await expect(refreshDerivedAnalysisForAccounts({ accountIds: [" "] })).rejects.toThrow(
+      "Cannot refresh derived analysis without at least one account id.",
+    );
+    expect(refreshMocks.backfillValueSnapshots).not.toHaveBeenCalled();
+    expect(refreshMocks.backfillLotExcursions).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/analysis/refresh-derived-analysis.ts
+++ b/src/lib/analysis/refresh-derived-analysis.ts
@@ -1,0 +1,48 @@
+import { backfillLotExcursions, type BackfillLotExcursionsSummary } from "@/lib/analysis/backfill-lot-excursions";
+import { backfillValueSnapshots, type BackfillValueSnapshotsSummary } from "@/lib/analysis/backfill-value-snapshots";
+
+interface LoggerLike {
+  log(message: string): void;
+  warn(message: string): void;
+}
+
+export interface RefreshDerivedAnalysisInput {
+  accountIds: string[];
+  logger?: LoggerLike;
+}
+
+export interface RefreshDerivedAnalysisSummary {
+  valueSnapshots: BackfillValueSnapshotsSummary;
+  lotExcursions: BackfillLotExcursionsSummary;
+}
+
+function normalizeAccountIds(accountIds: string[]): string[] {
+  return Array.from(
+    new Set(
+      accountIds
+        .map((accountId) => accountId.trim())
+        .filter((accountId) => accountId.length > 0),
+    ),
+  ).sort((left, right) => left.localeCompare(right));
+}
+
+export async function refreshDerivedAnalysisForAccounts(input: RefreshDerivedAnalysisInput): Promise<RefreshDerivedAnalysisSummary> {
+  const accountIds = normalizeAccountIds(input.accountIds);
+  const logger = input.logger ?? console;
+
+  if (accountIds.length === 0) {
+    throw new Error("Cannot refresh derived analysis without at least one account id.");
+  }
+
+  logger.log(`[refresh:derived-analysis] refreshing accounts=${accountIds.join(",")}`);
+  const valueSnapshots = await backfillValueSnapshots({ accountIds, logger });
+  const lotExcursions = await backfillLotExcursions({ accountIds, logger });
+  logger.log(
+    `[refresh:derived-analysis] complete snapshots=${valueSnapshots.snapshotsUpserted} excursions=${lotExcursions.excursionsUpserted}`,
+  );
+
+  return {
+    valueSnapshots,
+    lotExcursions,
+  };
+}


### PR DESCRIPTION
Closes #296

## Summary
- Add a shared derived-analysis refresh helper that recomputes account value snapshots before lot excursions.
- Run the helper after import commits and adjustment commits, outside the ledger rebuild transaction.
- Surface import refresh failures as import warnings and clarify the MFE/MAE empty state copy.

## Validation
- npm run typecheck
- npm run lint
- npm test -- --passWithNoTests