### PR TITLE
feat: portfolio_snapshot export endpoint for KapMan KB §A2 ingest

### DIFF
--- a/src/app/api/export/portfolio-snapshot/route.test.ts
+++ b/src/app/api/export/portfolio-snapshot/route.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PortfolioSnapshot } from "@/types/api";
+
+const mocks = vi.hoisted(() => ({
+  account: { findMany: vi.fn() },
+  execution: { findMany: vi.fn() },
+  matchedLot: { findMany: vi.fn() },
+  manualAdjustment: { findMany: vi.fn() },
+  getEquityQuotes: vi.fn(),
+  getOptionQuotesBatch: vi.fn(),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    account: mocks.account,
+    execution: mocks.execution,
+    matchedLot: mocks.matchedLot,
+    manualAdjustment: mocks.manualAdjustment,
+  },
+}));
+
+vi.mock("@/lib/mcp/market-data", () => ({
+  getEquityQuotes: mocks.getEquityQuotes,
+  getOptionQuotesBatch: mocks.getOptionQuotesBatch,
+}));
+
+async function callGet(): Promise<PortfolioSnapshot> {
+  const { GET } = await import("./route");
+  const response = await GET(new Request("http://localhost/api/export/portfolio-snapshot"));
+  const payload = (await response.json()) as { data: PortfolioSnapshot };
+  return payload.data;
+}
+
+describe("GET /api/export/portfolio-snapshot", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mocks.account.findMany.mockResolvedValue([]);
+    mocks.execution.findMany.mockResolvedValue([]);
+    mocks.matchedLot.findMany.mockResolvedValue([]);
+    mocks.manualAdjustment.findMany.mockResolvedValue([]);
+    mocks.getEquityQuotes.mockResolvedValue(null);
+    mocks.getOptionQuotesBatch.mockResolvedValue(new Map());
+  });
+
+  it("returns a valid empty snapshot when there is no data", async () => {
+    const data = await callGet();
+    expect(data.kind).toBe("portfolio_snapshot");
+    expect(data.source).toBe("kapman-tradelog");
+    expect(data.tradelog_schema_version).toBe("1.0");
+    expect(data.open_excursions_available).toBe(false);
+    expect(data.open_positions).toEqual([]);
+    expect(data.closed_lots).toEqual([]);
+  });
+
+  it("emits an open option leg with a computed mark and unrealized P&L, open-leg excursions null", async () => {
+    mocks.account.findMany.mockResolvedValue([{ id: "acc1", accountId: "D-123" }]);
+    mocks.execution.findMany.mockResolvedValue([
+      {
+        id: "open-aapl",
+        accountId: "acc1",
+        broker: "SCHWAB_THINKORSWIM",
+        symbol: "AAPL",
+        tradeDate: new Date("2026-05-20T00:00:00.000Z"),
+        eventTimestamp: new Date("2026-05-20T14:30:00.000Z"),
+        eventType: "TRADE",
+        assetClass: "OPTION",
+        side: "BUY",
+        quantity: { toString: () => "2" },
+        price: { toString: () => "6.20" },
+        openingClosingEffect: "TO_OPEN",
+        instrumentKey: "AAPL_K",
+        underlyingSymbol: "AAPL",
+        optionType: "CALL",
+        strike: { toString: () => "190" },
+        expirationDate: new Date("2026-08-15T00:00:00.000Z"),
+        spreadGroupId: "SG1",
+        importId: "imp-1",
+      },
+    ]);
+    mocks.getOptionQuotesBatch.mockResolvedValue(new Map([["AAPL_K", 7.85]]));
+
+    const data = await callGet();
+
+    expect(mocks.getOptionQuotesBatch).toHaveBeenCalledTimes(1);
+    expect(data.open_positions).toHaveLength(1);
+    const leg = data.open_positions[0];
+    expect(leg.instrument_key).toBe("AAPL_K");
+    expect(leg.account_id).toBe("D-123");
+    expect(leg.structure).toBe("long_call");
+    expect(leg.direction).toBe("LONG");
+    expect(leg.mark).toBe(7.85);
+    expect(leg.unrealized_pnl).toBeCloseTo(330, 6); // 7.85*2*100 - 1240
+    expect(leg.entry_price).toBeCloseTo(6.2, 6);
+    expect(leg.entry_date).toBe("2026-05-20T00:00:00.000Z");
+    expect(leg.spread_group_id).toBe("SG1");
+    expect(leg.mae_pct).toBeNull();
+    expect(leg.mfe_pct).toBeNull();
+  });
+
+  it("emits a closed lot with effectiveClosePrice and excursions", async () => {
+    mocks.account.findMany.mockResolvedValue([{ id: "acc1", accountId: "D-123" }]);
+    mocks.matchedLot.findMany.mockResolvedValue([
+      {
+        id: "ml1",
+        accountId: "acc1",
+        quantity: { toString: () => "1" },
+        realizedPnl: { toString: () => "412" },
+        holdingDays: 22,
+        outcome: "WIN",
+        openExecutionId: "open-msft",
+        closeExecutionId: "close-msft",
+        openExecution: { symbol: "MSFT", tradeDate: new Date("2026-05-27T00:00:00.000Z"), importId: "imp-2" },
+        closeExecution: {
+          tradeDate: new Date("2026-06-18T00:00:00.000Z"),
+          price: null,
+          eventType: "ASSIGNMENT",
+          strike: { toString: () => "190" },
+        },
+        excursion: { maePct: { toString: () => "-0.18" }, mfePct: { toString: () => "0.41" } },
+      },
+    ]);
+
+    const data = await callGet();
+
+    expect(data.open_positions).toEqual([]);
+    expect(data.closed_lots).toHaveLength(1);
+    const lot = data.closed_lots[0];
+    expect(lot.symbol).toBe("MSFT");
+    expect(lot.account_id).toBe("D-123");
+    expect(lot.realized_pnl).toBe(412);
+    expect(lot.exit_date).toBe("2026-06-18T00:00:00.000Z");
+    expect(lot.exit_price).toBe(190); // assignment, price null -> strike
+    expect(lot.mae_pct).toBeCloseTo(-0.18, 6);
+    expect(lot.mfe_pct).toBeCloseTo(0.41, 6);
+  });
+});

--- a/src/app/api/export/portfolio-snapshot/route.ts
+++ b/src/app/api/export/portfolio-snapshot/route.ts
@@ -1,0 +1,201 @@
+import { Prisma } from "@prisma/client";
+import { detailResponse } from "@/lib/api/responses";
+import { parseAccountIds } from "@/lib/api/account-scope";
+import { parsePayloadByType } from "@/lib/adjustments/types";
+import { prisma } from "@/lib/db/prisma";
+import { getEquityQuotes, getOptionQuotesBatch } from "@/lib/mcp/market-data";
+import { computeOpenPositions } from "@/lib/positions/compute-open-positions";
+import { normalizePositionSnapshotAccountIds, resolvePositionSnapshotAccountIds } from "@/lib/positions/position-snapshot";
+import { buildPortfolioSnapshot, type ClosedLotInput, type PricedOpenPosition } from "@/lib/export/build-portfolio-snapshot";
+import type {
+  EquityQuoteRecord,
+  ExecutionRecord,
+  ManualAdjustmentRecord,
+  MatchedLotRecord,
+} from "@/types/api";
+
+function decimalToNumber(value: Prisma.Decimal | null | undefined): number | null {
+  return value === null || value === undefined ? null : Number(value);
+}
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const requestedAccountIds = normalizePositionSnapshotAccountIds(parseAccountIds(url.searchParams.get("accountIds")));
+  const accountIds = await resolvePositionSnapshotAccountIds(requestedAccountIds);
+  const accountScope = accountIds.length > 0 ? ({ accountId: { in: accountIds } } as const) : undefined;
+  const now = new Date().toISOString();
+
+  const [accountRows, executionRows, matchedLotRows, adjustmentRows] = await Promise.all([
+    prisma.account.findMany({
+      where: accountIds.length > 0 ? { id: { in: accountIds } } : undefined,
+      select: { id: true, accountId: true },
+    }),
+    prisma.execution.findMany({
+      where: accountScope,
+      select: {
+        id: true,
+        accountId: true,
+        broker: true,
+        symbol: true,
+        tradeDate: true,
+        eventTimestamp: true,
+        eventType: true,
+        assetClass: true,
+        side: true,
+        quantity: true,
+        price: true,
+        openingClosingEffect: true,
+        instrumentKey: true,
+        underlyingSymbol: true,
+        optionType: true,
+        strike: true,
+        expirationDate: true,
+        spreadGroupId: true,
+        importId: true,
+      },
+    }),
+    prisma.matchedLot.findMany({
+      where: accountScope,
+      include: {
+        openExecution: { select: { symbol: true, tradeDate: true, importId: true } },
+        closeExecution: { select: { tradeDate: true, price: true, eventType: true, strike: true } },
+        excursion: { select: { maePct: true, mfePct: true } },
+      },
+    }),
+    prisma.manualAdjustment.findMany({
+      where: { AND: [{ status: "ACTIVE" }, ...(accountScope ? [accountScope] : [])] },
+      include: { account: { select: { accountId: true } } },
+    }),
+  ]);
+
+  const executions: ExecutionRecord[] = executionRows.map((row) => ({
+    id: row.id,
+    accountId: row.accountId,
+    broker: row.broker,
+    symbol: row.symbol,
+    tradeDate: row.tradeDate.toISOString(),
+    eventTimestamp: row.eventTimestamp.toISOString(),
+    eventType: row.eventType,
+    assetClass: row.assetClass,
+    side: row.side,
+    quantity: row.quantity.toString(),
+    price: row.price?.toString() ?? null,
+    openingClosingEffect: row.openingClosingEffect ?? null,
+    instrumentKey: row.instrumentKey,
+    underlyingSymbol: row.underlyingSymbol,
+    optionType: row.optionType,
+    strike: row.strike?.toString() ?? null,
+    expirationDate: row.expirationDate?.toISOString() ?? null,
+    spreadGroupId: row.spreadGroupId,
+    importId: row.importId,
+  }));
+
+  // computeOpenPositions only reads quantity + openExecutionId from matched lots.
+  const matchedLotsForCompute: MatchedLotRecord[] = matchedLotRows.map((row) => ({
+    id: row.id,
+    accountId: row.accountId,
+    symbol: row.openExecution.symbol,
+    openTradeDate: row.openExecution.tradeDate.toISOString(),
+    closeTradeDate: row.closeExecution?.tradeDate.toISOString() ?? null,
+    openImportId: row.openExecution.importId,
+    closeImportId: null,
+    quantity: row.quantity.toString(),
+    realizedPnl: row.realizedPnl.toString(),
+    holdingDays: row.holdingDays,
+    outcome: row.outcome,
+    openExecutionId: row.openExecutionId,
+    closeExecutionId: row.closeExecutionId,
+  }));
+
+  const manualAdjustments: ManualAdjustmentRecord[] = [];
+  for (const row of adjustmentRows) {
+    try {
+      manualAdjustments.push({
+        id: row.id,
+        createdAt: row.createdAt.toISOString(),
+        createdBy: row.createdBy,
+        accountId: row.accountId,
+        accountExternalId: row.account.accountId,
+        symbol: row.symbol,
+        effectiveDate: row.effectiveDate.toISOString(),
+        adjustmentType: row.adjustmentType,
+        payload: parsePayloadByType(row.adjustmentType, row.payloadJson),
+        reason: row.reason,
+        evidenceRef: row.evidenceRef,
+        status: row.status,
+        reversedByAdjustmentId: row.reversedByAdjustmentId,
+      });
+    } catch {
+      // Ignore malformed adjustment payloads in the export.
+    }
+  }
+
+  const openPositions = computeOpenPositions(executions, matchedLotsForCompute, manualAdjustments);
+
+  const equityPositions = openPositions.filter((position) => position.assetClass === "EQUITY");
+  const optionPositions = openPositions.filter(
+    (position) => position.assetClass === "OPTION" && position.optionType && position.expirationDate && position.strike,
+  );
+
+  const equityQuotePromise: Promise<Record<string, EquityQuoteRecord> | null> =
+    equityPositions.length > 0
+      ? getEquityQuotes(Array.from(new Set(equityPositions.map((position) => position.symbol))))
+      : Promise.resolve(null);
+
+  const [equityQuotes, optionQuotes] = await Promise.all([
+    equityQuotePromise,
+    optionPositions.length > 0
+      ? getOptionQuotesBatch(
+          optionPositions.map((position) => ({
+            underlyingSymbol: position.underlyingSymbol,
+            strike: Number(position.strike),
+            expirationDate: position.expirationDate?.slice(0, 10) ?? "",
+            optionType: position.optionType ?? "",
+          })),
+        )
+      : Promise.resolve(new Map<string, number | null>()),
+  ]);
+
+  const pricedOpenPositions: PricedOpenPosition[] = openPositions.map((position) => {
+    let mark: number | null = null;
+    if (position.assetClass === "EQUITY") {
+      mark = equityQuotes?.[position.symbol]?.mark ?? null;
+    } else if (position.assetClass === "OPTION") {
+      mark = optionQuotes.get(position.instrumentKey) ?? null;
+    }
+    return { ...position, mark };
+  });
+
+  const closedLots: ClosedLotInput[] = matchedLotRows
+    .filter((row) => row.closeExecution !== null)
+    .map((row) => ({
+      accountId: row.accountId,
+      symbol: row.openExecution.symbol,
+      realizedPnl: Number(row.realizedPnl),
+      exitDate: row.closeExecution?.tradeDate.toISOString() ?? null,
+      closePrice: decimalToNumber(row.closeExecution?.price ?? null),
+      closeEventType: row.closeExecution?.eventType ?? null,
+      closeStrike: decimalToNumber(row.closeExecution?.strike ?? null),
+      outcome: row.outcome,
+      holdingDays: row.holdingDays,
+      maePct: decimalToNumber(row.excursion?.maePct ?? null),
+      mfePct: decimalToNumber(row.excursion?.mfePct ?? null),
+    }));
+
+  const accountExternalIdByInternal = new Map(accountRows.map((row) => [row.id, row.accountId]));
+  // Empty array signals "all accounts" (no ?accountIds= filter); otherwise the resolved scope.
+  const accountExternalIds =
+    requestedAccountIds.length > 0 ? accountRows.map((row) => row.accountId) : [];
+
+  const snapshot = buildPortfolioSnapshot({
+    exportedAt: now,
+    asOf: now,
+    accountExternalIds,
+    accountExternalIdByInternal,
+    pricedOpenPositions,
+    executions,
+    closedLots,
+  });
+
+  return detailResponse(snapshot);
+}

--- a/src/app/positions/page.tsx
+++ b/src/app/positions/page.tsx
@@ -65,6 +65,7 @@ export default function Page() {
   const { selectedAccounts, getAccountDisplayText } = useAccountFilterContext();
   const snapshot = openPositionsStore.getSnapshot(selectedAccounts);
   const [openColumnId, setOpenColumnId] = useState<string | null>(null);
+  const [snapshotCopyStatus, setSnapshotCopyStatus] = useState<"idle" | "copied" | "failed">("idle");
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
   const filteredPositions = useMemo(() => positions.filter((position) => isAccountInScope(selectedAccounts, position.accountId)), [positions, selectedAccounts]);
@@ -108,6 +109,22 @@ export default function Page() {
 
   async function handleRefreshQuotes() { await openPositionsStore.refresh(selectedAccounts); }
 
+  async function handleCopySnapshot() {
+    try {
+      const params = new URLSearchParams();
+      if (selectedAccounts.length > 0) params.set("accountIds", selectedAccounts.join(","));
+      const query = params.toString();
+      const response = await fetch(`/api/export/portfolio-snapshot${query ? `?${query}` : ""}`);
+      if (!response.ok) throw new Error(`Export failed: ${response.status}`);
+      const body = (await response.json()) as { data: unknown };
+      await navigator.clipboard.writeText(JSON.stringify(body.data, null, 2));
+      setSnapshotCopyStatus("copied");
+    } catch {
+      setSnapshotCopyStatus("failed");
+    }
+    setTimeout(() => setSnapshotCopyStatus("idle"), 2000);
+  }
+
   function applyColumnState(columnId: string, values: string[], direction: SortDirection | null) {
     table.setColumnFilter(columnId, values);
     if (direction) table.setSort({ columnId, direction });
@@ -122,7 +139,10 @@ export default function Page() {
           <span className="rounded-full bg-surface-2 px-2 py-0.5 text-[11px] text-text-2">{table.sortedRows.length} positions</span>
           <span className="text-xs text-text-2">Last quoted: {formatQuoteTimestamp(lastQuoted)}</span>
         </div>
-        <button type="button" onClick={() => void handleRefreshQuotes()} disabled={snapshot.isLoading} className="rounded border border-border bg-surface-2 px-2 py-1 text-xs text-text disabled:opacity-50">{snapshot.isLoading ? "Refreshing..." : "Refresh Quotes"}</button>
+        <div className="flex items-center gap-2">
+          <button type="button" onClick={() => void handleCopySnapshot()} className="rounded border border-border bg-surface-2 px-2 py-1 text-xs text-text disabled:opacity-50" title="Copy a portfolio_snapshot JSON for the KapMan KB §A2 ingest">{snapshotCopyStatus === "copied" ? "Copied!" : snapshotCopyStatus === "failed" ? "Copy failed" : "Copy snapshot JSON"}</button>
+          <button type="button" onClick={() => void handleRefreshQuotes()} disabled={snapshot.isLoading} className="rounded border border-border bg-surface-2 px-2 py-1 text-xs text-text disabled:opacity-50">{snapshot.isLoading ? "Refreshing..." : "Refresh Quotes"}</button>
+        </div>
       </header>
 
       {loading ? <LoadingSkeleton lines={6} /> : null}

--- a/src/lib/export/build-portfolio-snapshot.test.ts
+++ b/src/lib/export/build-portfolio-snapshot.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "vitest";
+import type { ExecutionRecord, OpenPosition } from "@/types/api";
+import {
+  buildEntryInfoByGroupKey,
+  buildPortfolioSnapshot,
+  deriveStructure,
+  effectiveClosePrice,
+  type ClosedLotInput,
+  type PricedOpenPosition,
+} from "./build-portfolio-snapshot";
+
+function execution(overrides: Partial<ExecutionRecord>): ExecutionRecord {
+  return {
+    id: "exec-1",
+    accountId: "acc1",
+    broker: "SCHWAB_THINKORSWIM",
+    symbol: "AAPL",
+    tradeDate: "2026-05-20T00:00:00.000Z",
+    eventTimestamp: "2026-05-20T14:30:00.000Z",
+    eventType: "TRADE",
+    assetClass: "OPTION",
+    side: "BUY",
+    quantity: "2",
+    price: "6.20",
+    openingClosingEffect: "TO_OPEN",
+    instrumentKey: "AAPL_K",
+    underlyingSymbol: "AAPL",
+    optionType: "CALL",
+    strike: "190",
+    expirationDate: "2026-08-15T00:00:00.000Z",
+    spreadGroupId: null,
+    importId: "imp-1",
+    ...overrides,
+  };
+}
+
+function optionLeg(overrides: Partial<PricedOpenPosition>): PricedOpenPosition {
+  const base: OpenPosition = {
+    symbol: "AAPL",
+    underlyingSymbol: "AAPL",
+    assetClass: "OPTION",
+    optionType: "CALL",
+    strike: "190",
+    expirationDate: "2026-08-15T00:00:00.000Z",
+    instrumentKey: "AAPL_K",
+    netQty: 2,
+    costBasis: 1240,
+    accountId: "acc1",
+  };
+  return { ...base, mark: 7.85, ...overrides };
+}
+
+describe("deriveStructure", () => {
+  it("labels equity as stock", () => {
+    expect(deriveStructure({ assetClass: "EQUITY", optionType: null, netQty: 100 })).toBe("stock");
+  });
+
+  it("labels option legs by type and sign", () => {
+    expect(deriveStructure({ assetClass: "OPTION", optionType: "CALL", netQty: 2 })).toBe("long_call");
+    expect(deriveStructure({ assetClass: "OPTION", optionType: "CALL", netQty: -2 })).toBe("short_call");
+    expect(deriveStructure({ assetClass: "OPTION", optionType: "PUT", netQty: 3 })).toBe("long_put");
+    expect(deriveStructure({ assetClass: "OPTION", optionType: "PUT", netQty: -3 })).toBe("short_put");
+  });
+
+  it("falls back to uncategorized when option type is missing", () => {
+    expect(deriveStructure({ assetClass: "OPTION", optionType: null, netQty: 1 })).toBe("uncategorized");
+  });
+});
+
+describe("effectiveClosePrice", () => {
+  it("returns the raw close price when present, including a synthetic-expiration 0", () => {
+    expect(effectiveClosePrice(9.1, "TRADE", null)).toBe(9.1);
+    expect(effectiveClosePrice(0, "EXPIRATION_INFERRED", 190)).toBe(0);
+  });
+
+  it("uses the strike for assignment/exercise when price is null", () => {
+    expect(effectiveClosePrice(null, "ASSIGNMENT", 190)).toBe(190);
+    expect(effectiveClosePrice(null, "EXERCISE", 95)).toBe(95);
+  });
+
+  it("returns null when price is null and not an assignment/exercise with a strike", () => {
+    expect(effectiveClosePrice(null, "TRADE", 190)).toBeNull();
+    expect(effectiveClosePrice(null, "ASSIGNMENT", null)).toBeNull();
+  });
+});
+
+describe("buildEntryInfoByGroupKey", () => {
+  it("keeps the earliest opening execution and carries its spread group", () => {
+    const info = buildEntryInfoByGroupKey([
+      execution({ id: "a", tradeDate: "2026-05-22T00:00:00.000Z", spreadGroupId: "SG1" }),
+      execution({ id: "b", tradeDate: "2026-05-20T00:00:00.000Z", spreadGroupId: "SG1" }),
+    ]);
+    expect(info.get("acc1::AAPL_K")).toEqual({ entryDate: "2026-05-20T00:00:00.000Z", spreadGroupId: "SG1" });
+  });
+
+  it("ignores closing executions", () => {
+    const info = buildEntryInfoByGroupKey([
+      execution({ id: "close", openingClosingEffect: "TO_CLOSE", tradeDate: "2026-04-01T00:00:00.000Z" }),
+    ]);
+    expect(info.size).toBe(0);
+  });
+});
+
+describe("buildPortfolioSnapshot", () => {
+  const accountMap = new Map([["acc1", "D-123"]]);
+
+  it("computes per-leg entry_price, unrealized_pnl, structure, direction and joins entry info", () => {
+    const snapshot = buildPortfolioSnapshot({
+      exportedAt: "2026-06-26T18:00:00.000Z",
+      asOf: "2026-06-26T18:00:00.000Z",
+      accountExternalIds: ["D-123"],
+      accountExternalIdByInternal: accountMap,
+      pricedOpenPositions: [optionLeg({})],
+      executions: [execution({ spreadGroupId: "SG1" })],
+      closedLots: [],
+    });
+
+    expect(snapshot.kind).toBe("portfolio_snapshot");
+    expect(snapshot.source).toBe("kapman-tradelog");
+    expect(snapshot.tradelog_schema_version).toBe("1.0");
+    expect(snapshot.open_excursions_available).toBe(false);
+    expect(snapshot.account_ids).toEqual(["D-123"]);
+
+    const leg = snapshot.open_positions[0];
+    expect(leg.account_id).toBe("D-123");
+    expect(leg.structure).toBe("long_call");
+    expect(leg.direction).toBe("LONG");
+    expect(leg.entry_price).toBeCloseTo(6.2, 6); // 1240 / (2 * 100)
+    expect(leg.unrealized_pnl).toBeCloseTo(330, 6); // 7.85*2*100 - 1240
+    expect(leg.entry_date).toBe("2026-05-20T00:00:00.000Z");
+    expect(leg.spread_group_id).toBe("SG1");
+    expect(leg.mae_pct).toBeNull();
+    expect(leg.mfe_pct).toBeNull();
+    expect(leg.excursion_as_of).toBeNull();
+  });
+
+  it("emits null unrealized_pnl when the mark is unavailable", () => {
+    const snapshot = buildPortfolioSnapshot({
+      exportedAt: "t",
+      asOf: "t",
+      accountExternalIds: [],
+      accountExternalIdByInternal: accountMap,
+      pricedOpenPositions: [optionLeg({ mark: null })],
+      executions: [],
+      closedLots: [],
+    });
+    expect(snapshot.open_positions[0].unrealized_pnl).toBeNull();
+    expect(snapshot.open_positions[0].entry_date).toBeNull(); // no executions to join
+  });
+
+  it("maps closed lots with effectiveClosePrice and passthrough excursions", () => {
+    const closed: ClosedLotInput = {
+      accountId: "acc1",
+      symbol: "MSFT",
+      realizedPnl: 412,
+      exitDate: "2026-06-18T00:00:00.000Z",
+      closePrice: null,
+      closeEventType: "ASSIGNMENT",
+      closeStrike: 190,
+      outcome: "WIN",
+      holdingDays: 22,
+      maePct: -0.18,
+      mfePct: 0.41,
+    };
+    const snapshot = buildPortfolioSnapshot({
+      exportedAt: "t",
+      asOf: "t",
+      accountExternalIds: [],
+      accountExternalIdByInternal: accountMap,
+      pricedOpenPositions: [],
+      executions: [],
+      closedLots: [closed],
+    });
+    const lot = snapshot.closed_lots[0];
+    expect(lot.account_id).toBe("D-123");
+    expect(lot.exit_price).toBe(190); // assignment -> strike
+    expect(lot.realized_pnl).toBe(412);
+    expect(lot.mae_pct).toBe(-0.18);
+    expect(lot.mfe_pct).toBe(0.41);
+  });
+});

--- a/src/lib/export/build-portfolio-snapshot.ts
+++ b/src/lib/export/build-portfolio-snapshot.ts
@@ -1,0 +1,195 @@
+import { fallbackInstrumentKey } from "@/lib/positions/compute-open-positions";
+import type {
+  ExecutionRecord,
+  OpenPosition,
+  PortfolioSnapshot,
+  PortfolioSnapshotClosedLot,
+  PortfolioSnapshotOpenLeg,
+} from "@/types/api";
+
+export const TRADELOG_SCHEMA_VERSION = "1.0" as const;
+
+/** OpenPosition with the per-leg mark resolved at compute time. */
+export type PricedOpenPosition = OpenPosition & { mark: number | null };
+
+/** Pre-shaped closed-lot input assembled by the route from MatchedLot + its relations. */
+export interface ClosedLotInput {
+  accountId: string; // internal account id
+  symbol: string;
+  realizedPnl: number;
+  exitDate: string | null;
+  closePrice: number | null;
+  closeEventType: string | null;
+  closeStrike: number | null;
+  outcome: string;
+  holdingDays: number;
+  maePct: number | null;
+  mfePct: number | null;
+}
+
+export interface BuildPortfolioSnapshotInput {
+  exportedAt: string;
+  asOf: string;
+  /** Resolved external account ids in scope; empty array = all accounts. */
+  accountExternalIds: string[];
+  /** internal account id -> external account id (human-facing label). */
+  accountExternalIdByInternal: Map<string, string>;
+  pricedOpenPositions: PricedOpenPosition[];
+  /** All executions in scope; the builder filters opening executions itself for the entry-join. */
+  executions: ExecutionRecord[];
+  closedLots: ClosedLotInput[];
+}
+
+function contractMultiplier(assetClass: OpenPosition["assetClass"]): number {
+  return assetClass === "OPTION" ? 100 : 1;
+}
+
+/**
+ * Single-leg structure label using the canonical SetupTag vocabulary
+ * (src/lib/analytics/setup-inference.ts). Spreads are NOT collapsed here — each
+ * open leg is one row; consumers group legs by spread_group_id to name the spread.
+ */
+export function deriveStructure(position: Pick<OpenPosition, "assetClass" | "optionType" | "netQty">): string {
+  if (position.assetClass === "EQUITY") {
+    return "stock";
+  }
+
+  const isLong = position.netQty > 0;
+  if (position.optionType === "CALL") {
+    return isLong ? "long_call" : "short_call";
+  }
+  if (position.optionType === "PUT") {
+    return isLong ? "long_put" : "short_put";
+  }
+
+  return "uncategorized";
+}
+
+/**
+ * Mirrors effectiveClosePrice in src/lib/ledger/fifo-matcher.ts (the price the
+ * realized-P&L math actually used): raw close price when present (0 for a
+ * synthetic expiration), else the strike for assignment/exercise, else null.
+ */
+export function effectiveClosePrice(
+  closePrice: number | null,
+  closeEventType: string | null,
+  closeStrike: number | null,
+): number | null {
+  if (closePrice !== null) {
+    return closePrice;
+  }
+  if ((closeEventType === "ASSIGNMENT" || closeEventType === "EXERCISE") && closeStrike !== null) {
+    return closeStrike;
+  }
+  return null;
+}
+
+interface EntryInfo {
+  entryDate: string | null;
+  spreadGroupId: string | null;
+}
+
+function isOpeningExecution(execution: ExecutionRecord): boolean {
+  // Mirrors the opening-leg condition in compute-open-positions.ts.
+  const isPlainEquityBuy =
+    execution.assetClass === "EQUITY" &&
+    execution.side === "BUY" &&
+    execution.openingClosingEffect === "UNKNOWN" &&
+    execution.spreadGroupId === null;
+  return execution.openingClosingEffect === "TO_OPEN" || isPlainEquityBuy;
+}
+
+function groupKeyForExecution(execution: ExecutionRecord): string {
+  const key = execution.instrumentKey ?? fallbackInstrumentKey(execution);
+  return execution.accountId + "::" + key;
+}
+
+/** entryDate = earliest opening execution; spreadGroupId = the earliest opening leg's group (if any). */
+export function buildEntryInfoByGroupKey(executions: ExecutionRecord[]): Map<string, EntryInfo> {
+  const byGroup = new Map<string, EntryInfo>();
+
+  for (const execution of executions) {
+    if (!isOpeningExecution(execution)) {
+      continue;
+    }
+
+    const groupKey = groupKeyForExecution(execution);
+    const existing = byGroup.get(groupKey);
+
+    if (!existing) {
+      byGroup.set(groupKey, { entryDate: execution.tradeDate, spreadGroupId: execution.spreadGroupId });
+      continue;
+    }
+
+    if (existing.entryDate === null || execution.tradeDate < existing.entryDate) {
+      existing.entryDate = execution.tradeDate;
+      // Prefer the spreadGroupId of the earliest opening leg.
+      existing.spreadGroupId = execution.spreadGroupId ?? existing.spreadGroupId;
+    } else if (existing.spreadGroupId === null && execution.spreadGroupId !== null) {
+      existing.spreadGroupId = execution.spreadGroupId;
+    }
+  }
+
+  return byGroup;
+}
+
+export function buildPortfolioSnapshot(input: BuildPortfolioSnapshotInput): PortfolioSnapshot {
+  const entryInfoByGroupKey = buildEntryInfoByGroupKey(input.executions);
+
+  const open_positions: PortfolioSnapshotOpenLeg[] = input.pricedOpenPositions.map((position) => {
+    const multiplier = contractMultiplier(position.assetClass);
+    const groupKey = position.accountId + "::" + position.instrumentKey;
+    const entryInfo = entryInfoByGroupKey.get(groupKey) ?? { entryDate: null, spreadGroupId: null };
+
+    const entryPrice =
+      position.netQty !== 0 ? position.costBasis / (position.netQty * multiplier) : null;
+    const unrealizedPnl =
+      position.mark === null ? null : position.mark * position.netQty * multiplier - position.costBasis;
+
+    return {
+      symbol: position.symbol,
+      instrument_key: position.instrumentKey,
+      account_id: input.accountExternalIdByInternal.get(position.accountId) ?? position.accountId,
+      asset_class: position.assetClass,
+      option_type: position.optionType,
+      structure: deriveStructure(position),
+      direction: position.netQty > 0 ? "LONG" : "SHORT",
+      spread_group_id: entryInfo.spreadGroupId,
+      strike: position.strike,
+      expiration: position.expirationDate,
+      net_qty: position.netQty,
+      cost_basis: position.costBasis,
+      entry_date: entryInfo.entryDate,
+      entry_price: entryPrice,
+      mark: position.mark,
+      unrealized_pnl: unrealizedPnl,
+      mae_pct: null,
+      mfe_pct: null,
+      excursion_as_of: null,
+    };
+  });
+
+  const closed_lots: PortfolioSnapshotClosedLot[] = input.closedLots.map((lot) => ({
+    symbol: lot.symbol,
+    account_id: input.accountExternalIdByInternal.get(lot.accountId) ?? lot.accountId,
+    realized_pnl: lot.realizedPnl,
+    exit_date: lot.exitDate,
+    exit_price: effectiveClosePrice(lot.closePrice, lot.closeEventType, lot.closeStrike),
+    outcome: lot.outcome,
+    holding_days: lot.holdingDays,
+    mae_pct: lot.maePct,
+    mfe_pct: lot.mfePct,
+  }));
+
+  return {
+    kind: "portfolio_snapshot",
+    source: "kapman-tradelog",
+    exported_at: input.exportedAt,
+    tradelog_schema_version: TRADELOG_SCHEMA_VERSION,
+    account_ids: input.accountExternalIds,
+    as_of: input.asOf,
+    open_excursions_available: false,
+    open_positions,
+    closed_lots,
+  };
+}

--- a/src/lib/positions/compute-open-positions.ts
+++ b/src/lib/positions/compute-open-positions.ts
@@ -10,7 +10,7 @@ function signedQuantity(side: string | null, quantity: number): number {
   return side === "SELL" ? quantity * -1 : quantity;
 }
 
-function fallbackInstrumentKey(execution: ExecutionRecord): string {
+export function fallbackInstrumentKey(execution: ExecutionRecord): string {
   const expiration = execution.expirationDate ? execution.expirationDate.slice(0, 10) : "";
   return [
     execution.accountId,

--- a/types/api.ts
+++ b/types/api.ts
@@ -819,3 +819,56 @@ export interface PeriodReturnResponse {
 }
 
 export type PeriodReturnApiResponse = ApiDetailResponse<PeriodReturnResponse> | ApiErrorResponse;
+
+// --- Portfolio snapshot export (KapMan KB §A2 ingest contract) ---
+// Emitted by GET /api/export/portfolio-snapshot as a copy-pasteable handoff the
+// KapMan KB Portfolio mode consumes 1:1. Entry-time Wyckoff/DGPI/IV-HV context and
+// SIGNAL alert levels are intentionally NOT here — those are journal-owned (positions.md),
+// written by the KB at Pass 2, not by tradelog.
+
+export interface PortfolioSnapshotOpenLeg {
+  symbol: string;
+  instrument_key: string;
+  account_id: string; // external account id (human-facing label)
+  asset_class: "OPTION" | "EQUITY";
+  option_type: "CALL" | "PUT" | null;
+  structure: string; // single-leg label (stock|long_call|short_call|long_put|short_put|uncategorized); spreads grouped by spread_group_id
+  direction: "LONG" | "SHORT";
+  spread_group_id: string | null;
+  strike: string | null;
+  expiration: string | null; // ISO date
+  net_qty: number; // signed
+  cost_basis: number; // multiplier-inclusive
+  entry_date: string | null; // ISO; earliest opening execution among the leg's opens
+  entry_price: number | null; // weighted avg = cost_basis / (net_qty * multiplier)
+  mark: number | null;
+  unrealized_pnl: number | null; // mark*net_qty*mult - cost_basis; null when mark unavailable
+  // Open-leg excursions are not available in tradelog (LotExcursion is 1:1 with a closed MatchedLot).
+  mae_pct: null;
+  mfe_pct: null;
+  excursion_as_of: null;
+}
+
+export interface PortfolioSnapshotClosedLot {
+  symbol: string;
+  account_id: string; // external account id
+  realized_pnl: number;
+  exit_date: string | null; // ISO
+  exit_price: number | null; // effectiveClosePrice (raw close price; strike for assignment/exercise; 0 for synthetic expiration)
+  outcome: string; // WIN|LOSS|FLAT
+  holding_days: number;
+  mae_pct: number | null; // fraction of cost basis (e.g. -0.18); from MatchedLot.excursion
+  mfe_pct: number | null;
+}
+
+export interface PortfolioSnapshot {
+  kind: "portfolio_snapshot";
+  source: "kapman-tradelog";
+  exported_at: string; // ISO; lineage clock for the §A2 handoff
+  tradelog_schema_version: string;
+  account_ids: string[]; // resolved external account ids in scope; [] = all accounts
+  as_of: string; // ISO; instant open positions were computed/priced
+  open_excursions_available: false; // open-leg MAE/MFE deferred (see PortfolioSnapshotOpenLeg)
+  open_positions: PortfolioSnapshotOpenLeg[];
+  closed_lots: PortfolioSnapshotClosedLot[];
+}


### PR DESCRIPTION
Closes #298

Adds a read-only `GET /api/export/portfolio-snapshot` that emits a copy-pasteable JSON `portfolio_snapshot` payload the KapMan KB Portfolio-mode §A2 ingest consumes 1:1, plus a **Copy snapshot JSON** button on `/positions`.

## What & why
The KB §A2 contract needs a real, structured tradelog handoff (the dashboard previously had no export). This is the producer side; the KB ingest will mirror this payload.

## Decisions (with operator)
- **Open-leg MAE/MFE deferred** — `LotExcursion` is 1:1 with a closed `MatchedLot`; open legs have no excursion row. Open legs emit `mae_pct`/`mfe_pct`/`excursion_as_of` = null with `open_excursions_available: false`. Closed-lot MAE/MFE IS included.
- **Fresh-compute** open positions (mirrors the snapshot/compute pipeline → live quotes) so structure/entry/mark/unrealized P&L are fully populated.
- **exit_price = effectiveClosePrice** (raw price; strike for assignment/exercise; 0 for synthetic expiration) so it reconciles with `realized_pnl`.
- **Endpoint + UI button.**

## Notes
- No Prisma migration (read-only; every column already exists).
- New pure serializer (`build-portfolio-snapshot.ts`) holds all derivations; route stays thin. Exported `fallbackInstrumentKey` for the opening-execution re-join.
- Entry-time Wyckoff/DGPI/IV-HV context + SIGNAL alert levels are intentionally NOT exported — those are journal-owned (positions.md), written by the KB at Pass 2.

## Validation
- `npm run typecheck` 0 · `npm run lint` 0 (pre-existing font warning only) · `npm test` 345 pass (incl. 14 new) · `npm run build` ok, route registered.