### PR TITLE
refine: portfolio_snapshot export = open positions only (+ underlying_symbol)

### DIFF
--- a/src/app/api/export/portfolio-snapshot/route.test.ts
+++ b/src/app/api/export/portfolio-snapshot/route.test.ts
@@ -50,7 +50,7 @@ describe("GET /api/export/portfolio-snapshot", () => {
     expect(data.tradelog_schema_version).toBe("1.0");
     expect(data.open_excursions_available).toBe(false);
     expect(data.open_positions).toEqual([]);
-    expect(data.closed_lots).toEqual([]);
+    expect(data).not.toHaveProperty("closed_lots");
   });
 
   it("emits an open option leg with a computed mark and unrealized P&L, open-leg excursions null", async () => {
@@ -86,6 +86,7 @@ describe("GET /api/export/portfolio-snapshot", () => {
     expect(data.open_positions).toHaveLength(1);
     const leg = data.open_positions[0];
     expect(leg.instrument_key).toBe("AAPL_K");
+    expect(leg.underlying_symbol).toBe("AAPL");
     expect(leg.account_id).toBe("D-123");
     expect(leg.structure).toBe("long_call");
     expect(leg.direction).toBe("LONG");
@@ -98,40 +99,49 @@ describe("GET /api/export/portfolio-snapshot", () => {
     expect(leg.mfe_pct).toBeNull();
   });
 
-  it("emits a closed lot with effectiveClosePrice and excursions", async () => {
+  it("nets fully-closed quantity out of open positions and emits no closed_lots", async () => {
     mocks.account.findMany.mockResolvedValue([{ id: "acc1", accountId: "D-123" }]);
+    // One opening equity execution fully matched by a closed lot -> no open position remains.
+    mocks.execution.findMany.mockResolvedValue([
+      {
+        id: "open-msft",
+        accountId: "acc1",
+        broker: "SCHWAB_THINKORSWIM",
+        symbol: "MSFT",
+        tradeDate: new Date("2026-05-27T00:00:00.000Z"),
+        eventTimestamp: new Date("2026-05-27T14:30:00.000Z"),
+        eventType: "TRADE",
+        assetClass: "EQUITY",
+        side: "BUY",
+        quantity: { toString: () => "10" },
+        price: { toString: () => "100" },
+        openingClosingEffect: "TO_OPEN",
+        instrumentKey: "MSFT",
+        underlyingSymbol: "MSFT",
+        optionType: null,
+        strike: null,
+        expirationDate: null,
+        spreadGroupId: null,
+        importId: "imp-2",
+      },
+    ]);
     mocks.matchedLot.findMany.mockResolvedValue([
       {
         id: "ml1",
         accountId: "acc1",
-        quantity: { toString: () => "1" },
+        quantity: { toString: () => "10" },
         realizedPnl: { toString: () => "412" },
         holdingDays: 22,
         outcome: "WIN",
         openExecutionId: "open-msft",
         closeExecutionId: "close-msft",
         openExecution: { symbol: "MSFT", tradeDate: new Date("2026-05-27T00:00:00.000Z"), importId: "imp-2" },
-        closeExecution: {
-          tradeDate: new Date("2026-06-18T00:00:00.000Z"),
-          price: null,
-          eventType: "ASSIGNMENT",
-          strike: { toString: () => "190" },
-        },
-        excursion: { maePct: { toString: () => "-0.18" }, mfePct: { toString: () => "0.41" } },
       },
     ]);
 
     const data = await callGet();
 
-    expect(data.open_positions).toEqual([]);
-    expect(data.closed_lots).toHaveLength(1);
-    const lot = data.closed_lots[0];
-    expect(lot.symbol).toBe("MSFT");
-    expect(lot.account_id).toBe("D-123");
-    expect(lot.realized_pnl).toBe(412);
-    expect(lot.exit_date).toBe("2026-06-18T00:00:00.000Z");
-    expect(lot.exit_price).toBe(190); // assignment, price null -> strike
-    expect(lot.mae_pct).toBeCloseTo(-0.18, 6);
-    expect(lot.mfe_pct).toBeCloseTo(0.41, 6);
+    expect(data.open_positions).toEqual([]); // fully matched -> not open
+    expect(data).not.toHaveProperty("closed_lots");
   });
 });

--- a/src/app/api/export/portfolio-snapshot/route.ts
+++ b/src/app/api/export/portfolio-snapshot/route.ts
@@ -1,4 +1,3 @@
-import { Prisma } from "@prisma/client";
 import { detailResponse } from "@/lib/api/responses";
 import { parseAccountIds } from "@/lib/api/account-scope";
 import { parsePayloadByType } from "@/lib/adjustments/types";
@@ -6,17 +5,13 @@ import { prisma } from "@/lib/db/prisma";
 import { getEquityQuotes, getOptionQuotesBatch } from "@/lib/mcp/market-data";
 import { computeOpenPositions } from "@/lib/positions/compute-open-positions";
 import { normalizePositionSnapshotAccountIds, resolvePositionSnapshotAccountIds } from "@/lib/positions/position-snapshot";
-import { buildPortfolioSnapshot, type ClosedLotInput, type PricedOpenPosition } from "@/lib/export/build-portfolio-snapshot";
+import { buildPortfolioSnapshot, type PricedOpenPosition } from "@/lib/export/build-portfolio-snapshot";
 import type {
   EquityQuoteRecord,
   ExecutionRecord,
   ManualAdjustmentRecord,
   MatchedLotRecord,
 } from "@/types/api";
-
-function decimalToNumber(value: Prisma.Decimal | null | undefined): number | null {
-  return value === null || value === undefined ? null : Number(value);
-}
 
 export async function GET(request: Request) {
   const url = new URL(request.url);
@@ -54,12 +49,11 @@ export async function GET(request: Request) {
         importId: true,
       },
     }),
+    // Loaded only so computeOpenPositions can net closed quantity out of the open legs; not serialized.
     prisma.matchedLot.findMany({
       where: accountScope,
       include: {
         openExecution: { select: { symbol: true, tradeDate: true, importId: true } },
-        closeExecution: { select: { tradeDate: true, price: true, eventType: true, strike: true } },
-        excursion: { select: { maePct: true, mfePct: true } },
       },
     }),
     prisma.manualAdjustment.findMany({
@@ -96,7 +90,7 @@ export async function GET(request: Request) {
     accountId: row.accountId,
     symbol: row.openExecution.symbol,
     openTradeDate: row.openExecution.tradeDate.toISOString(),
-    closeTradeDate: row.closeExecution?.tradeDate.toISOString() ?? null,
+    closeTradeDate: null,
     openImportId: row.openExecution.importId,
     closeImportId: null,
     quantity: row.quantity.toString(),
@@ -166,22 +160,6 @@ export async function GET(request: Request) {
     return { ...position, mark };
   });
 
-  const closedLots: ClosedLotInput[] = matchedLotRows
-    .filter((row) => row.closeExecution !== null)
-    .map((row) => ({
-      accountId: row.accountId,
-      symbol: row.openExecution.symbol,
-      realizedPnl: Number(row.realizedPnl),
-      exitDate: row.closeExecution?.tradeDate.toISOString() ?? null,
-      closePrice: decimalToNumber(row.closeExecution?.price ?? null),
-      closeEventType: row.closeExecution?.eventType ?? null,
-      closeStrike: decimalToNumber(row.closeExecution?.strike ?? null),
-      outcome: row.outcome,
-      holdingDays: row.holdingDays,
-      maePct: decimalToNumber(row.excursion?.maePct ?? null),
-      mfePct: decimalToNumber(row.excursion?.mfePct ?? null),
-    }));
-
   const accountExternalIdByInternal = new Map(accountRows.map((row) => [row.id, row.accountId]));
   // Empty array signals "all accounts" (no ?accountIds= filter); otherwise the resolved scope.
   const accountExternalIds =
@@ -194,7 +172,6 @@ export async function GET(request: Request) {
     accountExternalIdByInternal,
     pricedOpenPositions,
     executions,
-    closedLots,
   });
 
   return detailResponse(snapshot);

--- a/src/lib/export/build-portfolio-snapshot.test.ts
+++ b/src/lib/export/build-portfolio-snapshot.test.ts
@@ -4,8 +4,6 @@ import {
   buildEntryInfoByGroupKey,
   buildPortfolioSnapshot,
   deriveStructure,
-  effectiveClosePrice,
-  type ClosedLotInput,
   type PricedOpenPosition,
 } from "./build-portfolio-snapshot";
 
@@ -67,23 +65,6 @@ describe("deriveStructure", () => {
   });
 });
 
-describe("effectiveClosePrice", () => {
-  it("returns the raw close price when present, including a synthetic-expiration 0", () => {
-    expect(effectiveClosePrice(9.1, "TRADE", null)).toBe(9.1);
-    expect(effectiveClosePrice(0, "EXPIRATION_INFERRED", 190)).toBe(0);
-  });
-
-  it("uses the strike for assignment/exercise when price is null", () => {
-    expect(effectiveClosePrice(null, "ASSIGNMENT", 190)).toBe(190);
-    expect(effectiveClosePrice(null, "EXERCISE", 95)).toBe(95);
-  });
-
-  it("returns null when price is null and not an assignment/exercise with a strike", () => {
-    expect(effectiveClosePrice(null, "TRADE", 190)).toBeNull();
-    expect(effectiveClosePrice(null, "ASSIGNMENT", null)).toBeNull();
-  });
-});
-
 describe("buildEntryInfoByGroupKey", () => {
   it("keeps the earliest opening execution and carries its spread group", () => {
     const info = buildEntryInfoByGroupKey([
@@ -112,7 +93,6 @@ describe("buildPortfolioSnapshot", () => {
       accountExternalIdByInternal: accountMap,
       pricedOpenPositions: [optionLeg({})],
       executions: [execution({ spreadGroupId: "SG1" })],
-      closedLots: [],
     });
 
     expect(snapshot.kind).toBe("portfolio_snapshot");
@@ -120,9 +100,11 @@ describe("buildPortfolioSnapshot", () => {
     expect(snapshot.tradelog_schema_version).toBe("1.0");
     expect(snapshot.open_excursions_available).toBe(false);
     expect(snapshot.account_ids).toEqual(["D-123"]);
+    expect(snapshot).not.toHaveProperty("closed_lots");
 
     const leg = snapshot.open_positions[0];
     expect(leg.account_id).toBe("D-123");
+    expect(leg.underlying_symbol).toBe("AAPL");
     expect(leg.structure).toBe("long_call");
     expect(leg.direction).toBe("LONG");
     expect(leg.entry_price).toBeCloseTo(6.2, 6); // 1240 / (2 * 100)
@@ -142,40 +124,8 @@ describe("buildPortfolioSnapshot", () => {
       accountExternalIdByInternal: accountMap,
       pricedOpenPositions: [optionLeg({ mark: null })],
       executions: [],
-      closedLots: [],
     });
     expect(snapshot.open_positions[0].unrealized_pnl).toBeNull();
     expect(snapshot.open_positions[0].entry_date).toBeNull(); // no executions to join
-  });
-
-  it("maps closed lots with effectiveClosePrice and passthrough excursions", () => {
-    const closed: ClosedLotInput = {
-      accountId: "acc1",
-      symbol: "MSFT",
-      realizedPnl: 412,
-      exitDate: "2026-06-18T00:00:00.000Z",
-      closePrice: null,
-      closeEventType: "ASSIGNMENT",
-      closeStrike: 190,
-      outcome: "WIN",
-      holdingDays: 22,
-      maePct: -0.18,
-      mfePct: 0.41,
-    };
-    const snapshot = buildPortfolioSnapshot({
-      exportedAt: "t",
-      asOf: "t",
-      accountExternalIds: [],
-      accountExternalIdByInternal: accountMap,
-      pricedOpenPositions: [],
-      executions: [],
-      closedLots: [closed],
-    });
-    const lot = snapshot.closed_lots[0];
-    expect(lot.account_id).toBe("D-123");
-    expect(lot.exit_price).toBe(190); // assignment -> strike
-    expect(lot.realized_pnl).toBe(412);
-    expect(lot.mae_pct).toBe(-0.18);
-    expect(lot.mfe_pct).toBe(0.41);
   });
 });

--- a/src/lib/export/build-portfolio-snapshot.ts
+++ b/src/lib/export/build-portfolio-snapshot.ts
@@ -3,7 +3,6 @@ import type {
   ExecutionRecord,
   OpenPosition,
   PortfolioSnapshot,
-  PortfolioSnapshotClosedLot,
   PortfolioSnapshotOpenLeg,
 } from "@/types/api";
 
@@ -11,21 +10,6 @@ export const TRADELOG_SCHEMA_VERSION = "1.0" as const;
 
 /** OpenPosition with the per-leg mark resolved at compute time. */
 export type PricedOpenPosition = OpenPosition & { mark: number | null };
-
-/** Pre-shaped closed-lot input assembled by the route from MatchedLot + its relations. */
-export interface ClosedLotInput {
-  accountId: string; // internal account id
-  symbol: string;
-  realizedPnl: number;
-  exitDate: string | null;
-  closePrice: number | null;
-  closeEventType: string | null;
-  closeStrike: number | null;
-  outcome: string;
-  holdingDays: number;
-  maePct: number | null;
-  mfePct: number | null;
-}
 
 export interface BuildPortfolioSnapshotInput {
   exportedAt: string;
@@ -37,7 +21,6 @@ export interface BuildPortfolioSnapshotInput {
   pricedOpenPositions: PricedOpenPosition[];
   /** All executions in scope; the builder filters opening executions itself for the entry-join. */
   executions: ExecutionRecord[];
-  closedLots: ClosedLotInput[];
 }
 
 function contractMultiplier(assetClass: OpenPosition["assetClass"]): number {
@@ -63,25 +46,6 @@ export function deriveStructure(position: Pick<OpenPosition, "assetClass" | "opt
   }
 
   return "uncategorized";
-}
-
-/**
- * Mirrors effectiveClosePrice in src/lib/ledger/fifo-matcher.ts (the price the
- * realized-P&L math actually used): raw close price when present (0 for a
- * synthetic expiration), else the strike for assignment/exercise, else null.
- */
-export function effectiveClosePrice(
-  closePrice: number | null,
-  closeEventType: string | null,
-  closeStrike: number | null,
-): number | null {
-  if (closePrice !== null) {
-    return closePrice;
-  }
-  if ((closeEventType === "ASSIGNMENT" || closeEventType === "EXERCISE") && closeStrike !== null) {
-    return closeStrike;
-  }
-  return null;
 }
 
 interface EntryInfo {
@@ -148,6 +112,7 @@ export function buildPortfolioSnapshot(input: BuildPortfolioSnapshotInput): Port
 
     return {
       symbol: position.symbol,
+      underlying_symbol: position.underlyingSymbol,
       instrument_key: position.instrumentKey,
       account_id: input.accountExternalIdByInternal.get(position.accountId) ?? position.accountId,
       asset_class: position.assetClass,
@@ -169,18 +134,6 @@ export function buildPortfolioSnapshot(input: BuildPortfolioSnapshotInput): Port
     };
   });
 
-  const closed_lots: PortfolioSnapshotClosedLot[] = input.closedLots.map((lot) => ({
-    symbol: lot.symbol,
-    account_id: input.accountExternalIdByInternal.get(lot.accountId) ?? lot.accountId,
-    realized_pnl: lot.realizedPnl,
-    exit_date: lot.exitDate,
-    exit_price: effectiveClosePrice(lot.closePrice, lot.closeEventType, lot.closeStrike),
-    outcome: lot.outcome,
-    holding_days: lot.holdingDays,
-    mae_pct: lot.maePct,
-    mfe_pct: lot.mfePct,
-  }));
-
   return {
     kind: "portfolio_snapshot",
     source: "kapman-tradelog",
@@ -190,6 +143,5 @@ export function buildPortfolioSnapshot(input: BuildPortfolioSnapshotInput): Port
     as_of: input.asOf,
     open_excursions_available: false,
     open_positions,
-    closed_lots,
   };
 }

--- a/types/api.ts
+++ b/types/api.ts
@@ -827,7 +827,8 @@ export type PeriodReturnApiResponse = ApiDetailResponse<PeriodReturnResponse> | 
 // written by the KB at Pass 2, not by tradelog.
 
 export interface PortfolioSnapshotOpenLeg {
-  symbol: string;
+  symbol: string; // broker-raw execution symbol (may be an OCC-style option symbol)
+  underlying_symbol: string; // clean underlying ticker for display (raw symbol is broker-formatted)
   instrument_key: string;
   account_id: string; // external account id (human-facing label)
   asset_class: "OPTION" | "EQUITY";
@@ -849,18 +850,6 @@ export interface PortfolioSnapshotOpenLeg {
   excursion_as_of: null;
 }
 
-export interface PortfolioSnapshotClosedLot {
-  symbol: string;
-  account_id: string; // external account id
-  realized_pnl: number;
-  exit_date: string | null; // ISO
-  exit_price: number | null; // effectiveClosePrice (raw close price; strike for assignment/exercise; 0 for synthetic expiration)
-  outcome: string; // WIN|LOSS|FLAT
-  holding_days: number;
-  mae_pct: number | null; // fraction of cost basis (e.g. -0.18); from MatchedLot.excursion
-  mfe_pct: number | null;
-}
-
 export interface PortfolioSnapshot {
   kind: "portfolio_snapshot";
   source: "kapman-tradelog";
@@ -870,5 +859,4 @@ export interface PortfolioSnapshot {
   as_of: string; // ISO; instant open positions were computed/priced
   open_excursions_available: false; // open-leg MAE/MFE deferred (see PortfolioSnapshotOpenLeg)
   open_positions: PortfolioSnapshotOpenLeg[];
-  closed_lots: PortfolioSnapshotClosedLot[];
 }


### PR DESCRIPTION
Closes #300

Scopes the /positions 'Copy snapshot JSON' button to its purpose: **open positions only**.

- **Remove `closed_lots`** from the payload + route (lifetime closed-trade history is §A3 feedback territory, not a portfolio snapshot; it made the payload huge). `matchedLot` still loaded internally so `computeOpenPositions` nets out closed quantity.
- **Add `underlying_symbol`** per open position (raw `symbol` is broker-formatted/inconsistent across accounts; `instrument_key` disambiguates, `underlying_symbol` is the clean label).
- Drop unused closed-lot serializer (ClosedLotInput, effectiveClosePrice) + tests.

Validation: typecheck 0 · lint 0 · 327 tests · build ok.