### PR TITLE
fix: positions expiry off-by-one + round export money fields

### DIFF
--- a/src/app/positions/page.tsx
+++ b/src/app/positions/page.tsx
@@ -36,6 +36,10 @@ function getDte(expirationDate: string | null): number | null {
   const expiration = new Date(expirationDate);
   return Math.ceil((expiration.getTime() - Date.now()) / (24 * 60 * 60 * 1000));
 }
+// expirationDate is a UTC-midnight date-only value; format in UTC so it doesn't shift a day back in local time.
+function formatExpiry(value: string): string {
+  return new Date(value).toLocaleDateString("en-US", { timeZone: "UTC" });
+}
 function formatQuoteTimestamp(value: Date | null): string {
   if (!value) return "—";
   return value.toLocaleString("en-US", { dateStyle: "medium", timeStyle: "medium" });
@@ -47,7 +51,7 @@ const PositionRow = memo(function PositionRow({ row, markLoading }: { row: OpenP
       <div className="px-2 py-2 font-semibold">{row.underlyingSymbol}</div>
       <div className="px-2 py-2">{row.assetClass === "OPTION" ? <Badge variant={row.optionType === "PUT" ? "put" : "call"}>{row.optionType ?? "OPTION"}</Badge> : <Badge variant="stub">EQUITY</Badge>}</div>
       <div className="px-2 py-2 text-right font-mono">{row.strike ?? "—"}</div>
-      <div className="px-2 py-2">{row.expirationDate ? new Date(row.expirationDate).toLocaleDateString() : "—"}</div>
+      <div className="px-2 py-2">{row.expirationDate ? formatExpiry(row.expirationDate) : "—"}</div>
       <div className={["px-2 py-2 text-right", row.dte === null ? "text-text-2" : row.dte < 7 ? "text-red-300" : row.dte < 30 ? "text-amber-300" : "text-text"].join(" ")}>{row.dte ?? "—"}</div>
       <div className={row.netQty >= 0 ? "px-2 py-2 text-right text-green-300" : "px-2 py-2 text-right text-red-300"}>{row.netQty}</div>
       <div className="px-2 py-2 text-right font-mono">{formatCurrency(row.costBasis)}</div>
@@ -86,7 +90,7 @@ export default function Page() {
     { id: "symbol", label: "Symbol", filterMode: "discrete", getFilterValues: (row) => row.underlyingSymbol, sortMode: "string", getSortValue: (row) => row.underlyingSymbol },
     { id: "assetClass", label: "Type", filterMode: "discrete", getFilterValues: (row) => (row.assetClass === "OPTION" ? row.optionType ?? "OPTION" : "EQUITY"), sortMode: "string", getSortValue: (row) => (row.assetClass === "OPTION" ? row.optionType ?? "OPTION" : "EQUITY") },
     { id: "strike", label: "Strike", align: "right", filterMode: "discrete", getFilterValues: (row) => row.strike ?? "—", sortMode: "number", getSortValue: (row) => (row.strike === null ? null : Number(row.strike)) },
-    { id: "expirationDate", label: "Expiry", filterMode: "discrete", getFilterValues: (row) => row.expirationDate ?? "—", getFilterOptionLabel: (value) => (value === "—" ? value : new Date(value).toLocaleDateString()), sortMode: "date", getSortValue: (row) => row.expirationDate, defaultSortDirection: "asc" },
+    { id: "expirationDate", label: "Expiry", filterMode: "discrete", getFilterValues: (row) => row.expirationDate ?? "—", getFilterOptionLabel: (value) => (value === "—" ? value : formatExpiry(value)), sortMode: "date", getSortValue: (row) => row.expirationDate, defaultSortDirection: "asc" },
     { id: "dte", label: "DTE", align: "right", filterMode: "discrete", getFilterValues: (row) => (row.dte === null ? "—" : String(row.dte)), sortMode: "number", getSortValue: (row) => row.dte },
     { id: "netQty", label: "Qty", align: "right", filterMode: "discrete", getFilterValues: (row) => String(row.netQty), sortMode: "number", getSortValue: (row) => row.netQty },
     { id: "costBasis", label: "Cost Basis", align: "right", filterMode: "discrete", getFilterValues: (row) => String(row.costBasis), sortMode: "number", getSortValue: (row) => row.costBasis },

--- a/src/lib/export/build-portfolio-snapshot.test.ts
+++ b/src/lib/export/build-portfolio-snapshot.test.ts
@@ -128,4 +128,19 @@ describe("buildPortfolioSnapshot", () => {
     expect(snapshot.open_positions[0].unrealized_pnl).toBeNull();
     expect(snapshot.open_positions[0].entry_date).toBeNull(); // no executions to join
   });
+
+  it("rounds money fields to clear floating-point noise", () => {
+    const snapshot = buildPortfolioSnapshot({
+      exportedAt: "t",
+      asOf: "t",
+      accountExternalIds: [],
+      accountExternalIdByInternal: accountMap,
+      pricedOpenPositions: [optionLeg({ netQty: 2, costBasis: 3979.9999999999995, mark: 19.55 })],
+      executions: [],
+    });
+    const leg = snapshot.open_positions[0];
+    expect(leg.cost_basis).toBe(3980); // was 3979.9999999999995
+    expect(leg.entry_price).toBe(19.9); // 3980 / (2 * 100)
+    expect(leg.unrealized_pnl).toBe(-70); // was -69.99999999999955
+  });
 });

--- a/src/lib/export/build-portfolio-snapshot.ts
+++ b/src/lib/export/build-portfolio-snapshot.ts
@@ -27,6 +27,16 @@ function contractMultiplier(assetClass: OpenPosition["assetClass"]): number {
   return assetClass === "OPTION" ? 100 : 1;
 }
 
+/** Round computed money values to cents, clearing floating-point artifacts. */
+function round2(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+/** Round a blended-average price; 4 dp preserves the average without FP noise. */
+function round4(value: number): number {
+  return Math.round(value * 10000) / 10000;
+}
+
 /**
  * Single-leg structure label using the canonical SetupTag vocabulary
  * (src/lib/analytics/setup-inference.ts). Spreads are NOT collapsed here — each
@@ -106,9 +116,9 @@ export function buildPortfolioSnapshot(input: BuildPortfolioSnapshotInput): Port
     const entryInfo = entryInfoByGroupKey.get(groupKey) ?? { entryDate: null, spreadGroupId: null };
 
     const entryPrice =
-      position.netQty !== 0 ? position.costBasis / (position.netQty * multiplier) : null;
+      position.netQty !== 0 ? round4(position.costBasis / (position.netQty * multiplier)) : null;
     const unrealizedPnl =
-      position.mark === null ? null : position.mark * position.netQty * multiplier - position.costBasis;
+      position.mark === null ? null : round2(position.mark * position.netQty * multiplier - position.costBasis);
 
     return {
       symbol: position.symbol,
@@ -123,7 +133,7 @@ export function buildPortfolioSnapshot(input: BuildPortfolioSnapshotInput): Port
       strike: position.strike,
       expiration: position.expirationDate,
       net_qty: position.netQty,
-      cost_basis: position.costBasis,
+      cost_basis: round2(position.costBasis),
       entry_date: entryInfo.entryDate,
       entry_price: entryPrice,
       mark: position.mark,


### PR DESCRIPTION
Closes #302

- **Expiry off-by-one (display)**: positions page rendered UTC-midnight `expirationDate` with `toLocaleDateString()`, shifting a day earlier in ET (`2026-09-18` → 9/17/2026). Added `formatExpiry()` (`timeZone:'UTC'`) for the row cell + Expiry filter label. The export already emitted the correct date; this aligns the screen to it.
- **Export rounding**: `build-portfolio-snapshot` now rounds cost_basis + unrealized_pnl to 2 dp, entry_price to 4 dp; `mark` left raw. Clears FP noise (e.g. 7490.000000000001).

typecheck 0 · lint 0 · 328 tests · build ok.